### PR TITLE
fix Spatial Collapse

### DIFF
--- a/ocgcore/card.cpp
+++ b/ocgcore/card.cpp
@@ -1667,6 +1667,15 @@ int32 card::is_setable_mzone(uint8 playerid, uint8 ignore_count, effect* peffect
 int32 card::is_setable_szone(uint8 playerid) {
 	if(!(data.type & TYPE_FIELD) && pduel->game_field->get_useable_count(current.controler, LOCATION_SZONE, current.controler, LOCATION_REASON_TOFIELD) <= 0)
 		return FALSE;
+	if(data.type & TYPE_FIELD) {
+		int32 fcount = 0;
+		if(pduel->game_field->get_field_card(current.controler, LOCATION_SZONE, 5))
+			fcount++;
+		effect_set eset;
+		pduel->game_field->filter_player_effect(current.controler, EFFECT_MAX_SZONE, &eset);
+		if(eset.count && pduel->game_field->get_useable_count(current.controler, LOCATION_SZONE, current.controler, LOCATION_REASON_TOFIELD) <= -fcount)
+			return FALSE;
+	}
 	if(data.type & TYPE_MONSTER && !is_affected_by_effect(EFFECT_MONSTER_SSET))
 		return FALSE;
 	if(is_affected_by_effect(EFFECT_FORBIDDEN))

--- a/ocgcore/effect.cpp
+++ b/ocgcore/effect.cpp
@@ -137,6 +137,15 @@ int32 effect::is_activateable(uint8 playerid, tevent& e, int32 neglect_cond, int
 					return FALSE;
 				if(!(handler->data.type & TYPE_FIELD) && pduel->game_field->get_useable_count(handler->current.controler, LOCATION_SZONE, handler->current.controler, LOCATION_REASON_TOFIELD) <= 0)
 					return FALSE;
+				if(handler->data.type & TYPE_FIELD) {
+					int32 fcount = 0;
+					if(pduel->game_field->get_field_card(handler->current.controler, LOCATION_SZONE, 5))
+						fcount++;
+					effect_set eset;
+					pduel->game_field->filter_player_effect(handler->current.controler, EFFECT_MAX_SZONE, &eset);
+					if(eset.count && pduel->game_field->get_useable_count(handler->current.controler, LOCATION_SZONE, handler->current.controler, LOCATION_REASON_TOFIELD) <= -fcount)
+						return FALSE;
+				}
 			} else if(handler->current.location == LOCATION_SZONE) {
 				if(handler->is_position(POS_FACEUP))
 					return FALSE;

--- a/ocgcore/field.cpp
+++ b/ocgcore/field.cpp
@@ -13,7 +13,7 @@
 #include "interpreter.h"
 #include <iostream>
 
-int32 field::field_used_count[32] = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5};
+int32 field::field_used_count[64] = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6};
 
 bool chain::chain_operation_sort(chain c1, chain c2) {
 	return c1.triggering_effect->id < c2.triggering_effect->id;
@@ -431,13 +431,13 @@ int32 field::get_useable_count(uint8 playerid, uint8 location, uint8 uplayer, ui
 		if(uplayer < 2)
 			filter_player_effect(playerid, EFFECT_MAX_MZONE, &eset);
 	} else {
-		flag = (flag & 0x1f00) >> 8;
-		used_flag = (used_flag & 0x1f00) >> 8;
+		flag = (flag & 0x3f00) >> 8;
+		used_flag = (used_flag & 0x3f00) >> 8;
 		if(uplayer < 2)
 			filter_player_effect(playerid, EFFECT_MAX_SZONE, &eset);
 	}
 	if(list)
-		*list = flag;
+		*list = flag & 0x1f;
 	if(eset.count) {
 		int32 max = 5;
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
@@ -448,7 +448,7 @@ int32 field::get_useable_count(uint8 playerid, uint8 location, uint8 uplayer, ui
 		int32 limit = max - field_used_count[used_flag];
 		return block < limit ? block : limit;
 	} else {
-		return 5 - field_used_count[flag];
+		return 5 - field_used_count[flag & 0x1f];
 	}
 }
 void field::shuffle(uint8 playerid, uint8 location) {

--- a/ocgcore/field.h
+++ b/ocgcore/field.h
@@ -282,7 +282,7 @@ public:
 	return_value returns;
 	tevent nil_event;
 
-	static int32 field_used_count[32];
+	static int32 field_used_count[64];
 	field(duel* pduel);
 	~field();
 	void reload_field_info();

--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -1645,6 +1645,15 @@ int32 field::sset(uint16 step, uint8 setplayer, uint8 toplayer, card * target) {
 	case 0: {
 		if(!(target->data.type & TYPE_FIELD) && get_useable_count(toplayer, LOCATION_SZONE, setplayer, LOCATION_REASON_TOFIELD) <= 0)
 			return TRUE;
+		if(target->data.type & TYPE_FIELD) {
+			int32 fcount = 0;
+			if(get_field_card(toplayer, LOCATION_SZONE, 5))
+				fcount++;
+			effect_set eset;
+			pduel->game_field->filter_player_effect(toplayer, EFFECT_MAX_SZONE, &eset);
+			if(eset.count && get_useable_count(toplayer, LOCATION_SZONE, setplayer, LOCATION_REASON_TOFIELD) <= -fcount)
+				return FALSE;
+		}
 		if(target->data.type & TYPE_MONSTER && !target->is_affected_by_effect(EFFECT_MONSTER_SSET))
 			return TRUE;
 		if(target->current.location == LOCATION_SZONE)


### PR DESCRIPTION
fix glitch player can activate (set) spell or trap card under applying Spatial Collapse if he has 5 cards including field spell on the field
