### PR TITLE
include string.h in ocgcore/libdebug.cpp

### DIFF
--- a/ocgcore/libdebug.cpp
+++ b/ocgcore/libdebug.cpp
@@ -5,6 +5,7 @@
  *      Author: Argon
  */
 
+#include <string.h>
 #include "scriptlib.h"
 #include "duel.h"
 #include "field.h"


### PR DESCRIPTION
include string.h header, it will be not included automatically under Linux/gcc, and cause an error.
i didn't test if it works on Visual Studio, if it crash, add a "#ifndef win32"
