### PR TITLE
fix

### DIFF
--- a/script/c10000020.lua
+++ b/script/c10000020.lua
@@ -98,7 +98,7 @@ function c10000020.adval(e,c)
 	return Duel.GetFieldGroupCount(c:GetControler(),LOCATION_HAND,0)*1000
 end
 function c10000020.atkfilter(c,e,tp)
-	return c:GetSummonPlayer()==tp and c:IsPosition(POS_FACEUP_ATTACK) and (not e or c:IsRelateToEffect(e))
+	return c:IsControler(tp) and c:IsPosition(POS_FACEUP_ATTACK) and (not e or c:IsRelateToEffect(e))
 end
 function c10000020.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c10000020.atkfilter,1,nil,nil,1-tp)

--- a/script/c10000021.lua
+++ b/script/c10000021.lua
@@ -98,7 +98,7 @@ function c10000021.adval(e,c)
 	return Duel.GetFieldGroupCount(c:GetControler(),LOCATION_HAND,0)*1000
 end
 function c10000021.atkfilter(c,e,tp)
-	return c:GetSummonPlayer()==tp and c:IsPosition(POS_FACEUP_ATTACK) and (not e or c:IsRelateToEffect(e))
+	return c:IsControler(tp) and c:IsPosition(POS_FACEUP_ATTACK) and (not e or c:IsRelateToEffect(e))
 end
 function c10000021.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c10000021.atkfilter,1,nil,nil,1-tp)

--- a/script/c57019473.lua
+++ b/script/c57019473.lua
@@ -17,8 +17,7 @@ function c57019473.filter(c)
 end
 function c57019473.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c57019473.filter(chkc) end 
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingTarget(c57019473.filter,tp,LOCATION_GRAVE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c57019473.filter,tp,LOCATION_GRAVE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectTarget(tp,c57019473.filter,tp,LOCATION_GRAVE,0,1,1,nil)
 	Duel.SetOperationInfo(0,HINTMSG_REMOVE,g,1,0,0)

--- a/script/c61132951.lua
+++ b/script/c61132951.lua
@@ -4,7 +4,7 @@ function c61132951.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(61132951,0))
 	e1:SetCategory(CATEGORY_DESTROY)
-	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetCode(EVENT_BATTLE_CONFIRM)
 	e1:SetTarget(c61132951.destg)
 	e1:SetOperation(c61132951.desop)
@@ -12,7 +12,7 @@ function c61132951.initial_effect(c)
 end
 function c61132951.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local d=Duel.GetAttackTarget()
-	if chk ==0 then	return Duel.GetAttacker()==e:GetHandler()
+	if chk==0 then return Duel.GetAttacker()==e:GetHandler()
 		and d and d:IsDefencePos() and d:IsDestructable() end
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,d,1,0,0)
 end

--- a/script/c67959180.lua
+++ b/script/c67959180.lua
@@ -23,8 +23,7 @@ function c67959180.operation(e,tp,eg,ep,ev,re,r,rp)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
-		e1:SetProperty(EFFECT_FLAG_COPY_INHERIT)
-		e1:SetReset(RESET_EVENT+0x1ff0000)
+		e1:SetReset(RESET_EVENT+0x1ff0000+RESET_PHASE+PHASE_END)
 		if opt==coin then
 			e1:SetValue(c:GetBaseAttack()/2)
 		else

--- a/script/c68473226.lua
+++ b/script/c68473226.lua
@@ -17,15 +17,18 @@ function c68473226.initial_effect(c)
 	e2:SetOperation(c68473226.regop)
 	c:RegisterEffect(e2)
 end
+function c68473226.spfilter(c)
+	return c:IsLevelAbove(8) and c:IsAbleToGraveAsCost()
+end
 function c68473226.spcon(e,c)
 	if c==nil then return true end
-	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0 and
-		Duel.IsExistingMatchingCard(Card.IsLevelAbove,c:GetControler(),LOCATION_HAND,0,1,c,8)
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c68473226.spfilter,c:GetControler(),LOCATION_HAND,0,1,c)
 end
 function c68473226.spop(e,tp,eg,ep,ev,re,r,rp,c)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
-	local g=Duel.SelectMatchingCard(tp,Card.IsLevelAbove,tp,LOCATION_HAND,0,1,1,c,8)
-	Duel.SendtoGrave(g,REASON_DISCARD+REASON_COST)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c68473226.spfilter,tp,LOCATION_HAND,0,1,1,c)
+	Duel.SendtoGrave(g,REASON_COST)
 end
 function c68473226.regcon(e,tp,eg,ep,ev,re,r,rp)
 	local rc=e:GetHandler():GetReasonCard()

--- a/script/c86827882.lua
+++ b/script/c86827882.lua
@@ -19,10 +19,10 @@ function c86827882.filter(c)
 	return c:IsFaceup() and (c:IsSetCard(0x42) or c:IsSetCard(0x4b))
 end
 function c86827882.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c86827882.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c86827882.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c86827882.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c86827882.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	local g=Duel.SelectTarget(tp,c86827882.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c86827882.filter,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function c86827882.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/script/c88069166.lua
+++ b/script/c88069166.lua
@@ -31,9 +31,9 @@ function c88069166.filter(c)
 end
 function c88069166.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c88069166.filter(chkc) end
-	if chk==0 then return true end
+	if chk==0 then return Duel.IsExistingTarget(c88069166.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	local g=Duel.SelectTarget(tp,c88069166.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SelectTarget(tp,c88069166.filter,tp,LOCATION_MZONE,0,1,1,nil)
 	Duel.SetChainLimit(c88069166.chlimit)
 end
 function c88069166.chlimit(e,ep,tp)

--- a/script/c90200789.lua
+++ b/script/c90200789.lua
@@ -18,12 +18,12 @@ function c90200789.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c90200789.filter1(c,tp,slv)
-	local lv1=c:GetOriginalLevel()
+	local lv1=c:GetLevel()
 	return c:IsFaceup() and c:IsSetCard(0x2b) and lv1>0
 		 and Duel.IsExistingTarget(c90200789.filter2,tp,0,LOCATION_MZONE,1,nil,lv1,slv)
 end
 function c90200789.filter2(c,lv1,slv)
-	local lv2=c:GetOriginalLevel()
+	local lv2=c:GetLevel()
 	return c:IsFaceup() and lv2>0 and lv1+lv2>=slv
 end
 function c90200789.spfilter(c,e,tp,lv)
@@ -34,15 +34,15 @@ function c90200789.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local sg=Duel.GetMatchingGroup(c90200789.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
 	if chk==0 then
 		if sg:GetCount()==0 then return false end
-		local mlv=sg:GetMinGroup(Card.GetLevel):GetFirst():GetLevel()
+		local mg,mlv=sg:GetMinGroup(Card.GetLevel)
 		return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
 			and Duel.IsExistingTarget(c90200789.filter1,tp,LOCATION_MZONE,0,1,nil,tp,mlv)
 	end
-	local mlv=sg:GetMinGroup(Card.GetLevel):GetFirst():GetLevel()
+	local mg,mlv=sg:GetMinGroup(Card.GetLevel)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g1=Duel.SelectTarget(tp,c90200789.filter1,tp,LOCATION_MZONE,0,1,1,nil,tp,mlv)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g2=Duel.SelectTarget(tp,c90200789.filter2,tp,0,LOCATION_MZONE,1,1,nil,g1:GetFirst():GetOriginalLevel(),mlv)
+	local g2=Duel.SelectTarget(tp,c90200789.filter2,tp,0,LOCATION_MZONE,1,1,nil,g1:GetFirst():GetLevel(),mlv)
 	g1:Merge(g2)
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,g1,2,0,0)
 end


### PR DESCRIPTION
Slifer the Sky Dragon

Ｑ：相手が《ヴォルカニック・クイーン》を自分フィールド上に特殊召喚した時、自分フィールド上の《オシリスの天空竜》の効果は発動しますか？
Ａ：《オシリスの天空竜》の効果は発動しません。(12/01/20)

Ｑ：自分が《ヴォルカニック・クイーン》を相手フィールド上に特殊召喚した時、自分フィールド上の《オシリスの天空竜》の効果は発動しますか？
Ａ：《オシリスの天空竜》の効果は発動します。(12/02/13)

Ninjitsu Art of Super-Transformation

Ｑ：罠モンスターを選択して墓地へ送った場合、そのレベルを合計分に含める事はできますか？
Ａ：いいえ、墓地へ送った時点でモンスター扱いではなくなりますので、レベルの合計分に含める事はできません。(12/03/15)

Ｑ：自分のデッキには《青眼の白龍》(レベル８)がいます。
　　自分の《忍者マスター ＨＡＮＺＯ》(レベル４)と、相手の「《甲虫装機 ダンセル》を装備した《甲虫装機 ホーネット》」(本来のレベルは３だが、フィールドでは６)を対象に発動できますか？
Ａ：はい、発動できモンスターは墓地へ行きます。
　　ただしレベルの数値は墓地におけるレベル合計の７（＝４＋３）として勘定するので、《青眼の白龍》は特殊召喚できません。(12/05/02)
