### PR TITLE
fix

### DIFF
--- a/ocgcore/processor.cpp
+++ b/ocgcore/processor.cpp
@@ -2552,21 +2552,13 @@ int32 field::process_battle_command(uint16 step) {
 				if(core.select_cards.size() == 0 && pcard->operation_param == 0)
 					continue;
 				core.attackable_cards.push_back(pcard);
-				if(pcard->is_affected_by_effect(EFFECT_FIRST_ATTACK)) {
-					if(first_attack.size()) {
-						first_attack.clear();
-						must_attack.clear();
-						core.attackable_cards.clear();
-						break;
-					} else {
-						core.attackable_cards.clear();
-						core.attackable_cards.push_back(pcard);
-						first_attack.push_back(pcard);
-					}
-				}
+				if(pcard->is_affected_by_effect(EFFECT_FIRST_ATTACK))
+					first_attack.push_back(pcard);
 				if(pcard->is_affected_by_effect(EFFECT_MUST_ATTACK))
 					must_attack.push_back(pcard);
 			}
+			if(first_attack.size())
+				core.attackable_cards = first_attack;
 		}
 		core.to_m2 = TRUE;
 		core.to_ep = TRUE;

--- a/script/c12469386.lua
+++ b/script/c12469386.lua
@@ -20,7 +20,8 @@ function c12469386.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c12469386.filter,1,nil,tp)
 end
 function c12469386.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end
 function c12469386.spop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c12940613.lua
+++ b/script/c12940613.lua
@@ -1,14 +1,13 @@
---リミッター解除
+--マドルチェ·マナー
 function c12940613.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_ATKCHANGE+CATEGORY_TODECK)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetHintTiming(TIMING_DAMAGE_STEP)
 	e1:SetCondition(c12940613.condition)
-	e1:SetCost(c12940613.cost)
 	e1:SetTarget(c12940613.target)
 	e1:SetOperation(c12940613.activate)
 	c:RegisterEffect(e1)
@@ -16,27 +15,30 @@ end
 function c12940613.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
-function c12940613.cfilter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x71) and c:IsAbleToDeckAsCost()
-end
-function c12940613.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c12940613.cfilter,tp,LOCATION_GRAVE,0,1,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-	local g=Duel.SelectMatchingCard(tp,c12940613.cfilter,tp,LOCATION_GRAVE,0,1,1,nil)
-	Duel.SendtoDeck(g,nil,2,REASON_COST)
-end
 function c12940613.filter(c)
 	return c:IsFaceup() and c:IsSetCard(0x71)
 end
-function c12940613.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c12940613.filter,tp,LOCATION_MZONE,0,1,nil) end
+function c12940613.tdfilter1(c)
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x71) and c:IsAbleToDeck()
 end
-function c12940613.tdfilter(c)
+function c12940613.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c12940613.tdfilter1(chkc) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c12940613.filter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingTarget(c12940613.tdfilter1,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
+	local g=Duel.SelectTarget(tp,c12940613.tdfilter1,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,1,0,0)
+end
+function c12940613.tdfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsAbleToDeck()
 end
 function c12940613.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)
+	end
 	local g=Duel.GetMatchingGroup(c12940613.filter,tp,LOCATION_MZONE,0,nil)
-	local tc=g:GetFirst()
+	tc=g:GetFirst()
 	if not tc then return end
 	while tc do
 		local e1=Effect.CreateEffect(e:GetHandler())
@@ -50,8 +52,9 @@ function c12940613.activate(e,tp,eg,ep,ev,re,r,rp)
 		tc:RegisterEffect(e2)
 		tc=g:GetNext()
 	end
-	local dg=Duel.GetMatchingGroup(c12940613.tdfilter,tp,LOCATION_GRAVE,0,nil)
+	local dg=Duel.GetMatchingGroup(c12940613.tdfilter2,tp,LOCATION_GRAVE,0,nil)
 	if dg:GetCount()~=0 and Duel.SelectYesNo(tp,aux.Stringid(12940613,0)) then
+		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 		Duel.SendtoDeck(dg:Select(tp,1,1,nil),nil,2,REASON_EFFECT)
 	end

--- a/script/c15894048.lua
+++ b/script/c15894048.lua
@@ -4,14 +4,25 @@ function c15894048.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_FIRST_ATTACK)
+	e1:SetCondition(c15894048.facon)
 	c:RegisterEffect(e1)
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_MUST_ATTACK)
+	e2:SetCondition(c15894048.facon)
 	c:RegisterEffect(e2)
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
 	e3:SetCode(EFFECT_ATTACK_ALL)
+	e3:SetCondition(c15894048.facon)
 	e3:SetValue(1)
 	c:RegisterEffect(e3)
+end
+function c15894048.filter(c)
+	return c:GetAttackAnnouncedCount()>0
+end
+function c15894048.facon(e)
+	local tp=e:GetHandlerPlayer()
+	return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0
+		and not Duel.IsExistingMatchingCard(c15894048.filter,tp,LOCATION_MZONE,0,1,e:GetHandler())
 end

--- a/script/c38369349.lua
+++ b/script/c38369349.lua
@@ -6,6 +6,7 @@ function c38369349.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(c38369349.splimit)
 	c:RegisterEffect(e1)
 	--special summon
 	local e2=Effect.CreateEffect(c)
@@ -57,6 +58,9 @@ function c38369349.initial_effect(c)
 	e8:SetCost(c38369349.atcost)
 	e8:SetOperation(c38369349.atop)
 	c:RegisterEffect(e8)
+end
+function c38369349.splimit(e,se,sp,st,spos,tgp)
+	return Duel.IsExistingMatchingCard(c38369349.cfilter,tgp,LOCATION_ONFIELD,0,1,nil)
 end
 function c38369349.cfilter(c)
 	return c:IsFaceup() and c:IsCode(15259703)

--- a/script/c39823987.lua
+++ b/script/c39823987.lua
@@ -88,6 +88,6 @@ end
 function c39823987.spop2(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
-		Duel.SpecialSummon(tc,0,tp,tp,true,false,POS_FACEUP)
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c41442341.lua
+++ b/script/c41442341.lua
@@ -14,7 +14,7 @@ function c41442341.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c41442341.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_ADVANCE)~=0
+	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_ADVANCE)==SUMMON_TYPE_ADVANCE
 end
 function c41442341.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,2000) end

--- a/script/c44125452.lua
+++ b/script/c44125452.lua
@@ -16,7 +16,7 @@ function c44125452.condition(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_DECK)
 end
 function c44125452.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end

--- a/script/c52158283.lua
+++ b/script/c52158283.lua
@@ -1,4 +1,4 @@
---ADチェンジャー
+--先史遺産コロッサル·ヘッド
 function c52158283.initial_effect(c)
 	--adchange
 	local e1=Effect.CreateEffect(c)
@@ -17,7 +17,7 @@ function c52158283.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
 end
 function c52158283.filter(c)
-	return c:IsPosition(POS_ATTACK) and c:IsLevelAbove(3)
+	return c:IsAttackPos() and c:IsLevelAbove(3)
 end
 function c52158283.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c52158283.filter(chkc) end
@@ -30,14 +30,13 @@ function c52158283.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
 		if tc:IsAttackPos() then
-			local opt=0
+			local pos=0
 			if tc:IsCanTurnSet() then 
-				opt=Duel.SelectOption(tp,aux.Stringid(52158283,1),aux.Stringid(52158283,2))
+				pos=Duel.SelectPosition(tp,tc,POS_DEFENCE)
 			else
-				opt=Duel.SelectOption(tp,aux.Stringid(52158283,1))
+				pos=Duel.SelectPosition(tp,tc,POS_FACEUP_DEFENCE)
 			end
-			if opt==0 then Duel.ChangePosition(tc,POS_FACEUP_DEFENCE)
-			else Duel.ChangePosition(tc,POS_FACEDOWN_DEFENCE) end
+			Duel.ChangePosition(tc,pos)
 		else
 			Duel.ChangePosition(tc,0,0,POS_FACEDOWN_DEFENCE,POS_FACEUP_DEFENCE)
 		end

--- a/script/c53183600.lua
+++ b/script/c53183600.lua
@@ -6,6 +6,7 @@ function c53183600.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(c53183600.splimit)
 	c:RegisterEffect(e1)
 	--special summon
 	local e2=Effect.CreateEffect(c)
@@ -57,6 +58,9 @@ function c53183600.initial_effect(c)
 	e8:SetCost(c53183600.atcost)
 	e8:SetOperation(c53183600.atop)
 	c:RegisterEffect(e8)
+end
+function c53183600.splimit(e,se,sp,st,spos,tgp)
+	return Duel.IsExistingMatchingCard(c53183600.cfilter,tgp,LOCATION_ONFIELD,0,1,nil)
 end
 function c53183600.cfilter(c)
 	return c:IsFaceup() and c:IsCode(15259703)

--- a/script/c65458948.lua
+++ b/script/c65458948.lua
@@ -6,6 +6,7 @@ function c65458948.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(c65458948.splimit)
 	c:RegisterEffect(e1)
 	--special summon
 	local e2=Effect.CreateEffect(c)
@@ -57,6 +58,9 @@ function c65458948.initial_effect(c)
 	e8:SetCost(c65458948.atcost)
 	e8:SetOperation(c65458948.atop)
 	c:RegisterEffect(e8)
+end
+function c65458948.splimit(e,se,sp,st,spos,tgp)
+	return Duel.IsExistingMatchingCard(c65458948.cfilter,tgp,LOCATION_ONFIELD,0,1,nil)
 end
 function c65458948.cfilter(c)
 	return c:IsFaceup() and c:IsCode(15259703)

--- a/script/c66818682.lua
+++ b/script/c66818682.lua
@@ -40,7 +40,7 @@ function c66818682.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
 function c66818682.spfilter(c,e,tp)
-	return c:IsCode(39823987) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:IsCode(39823987) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c66818682.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c66818682.spfilter(chkc,e,tp) end
@@ -53,6 +53,6 @@ end
 function c66818682.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
-		Duel.SpecialSummon(tc,0,tp,tp,true,false,POS_FACEUP)
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c67159705.lua
+++ b/script/c67159705.lua
@@ -26,6 +26,7 @@ function c67159705.initial_effect(c)
 	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
 	e3:SetCode(EFFECT_DESTROY_SUBSTITUTE)
 	e3:SetCondition(c67159705.uncon)
+	e3:SetValue(1)
 	c:RegisterEffect(e3)
 	--eqlimit
 	local e4=Effect.CreateEffect(c)
@@ -100,7 +101,7 @@ function c67159705.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		and Duel.IsExistingTarget(c67159705.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,c67159705.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 end
 function c67159705.desop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/script/c74298287.lua
+++ b/script/c74298287.lua
@@ -37,7 +37,7 @@ function c74298287.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterFlagEffect(tp,74298287,RESET_PHASE+PHASE_END,0,1)
 end
 function c74298287.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end

--- a/script/c75014062.lua
+++ b/script/c75014062.lua
@@ -21,7 +21,7 @@ end
 function c75014062.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and c75014062.filter(chkc) end
 	if chk==0 then return Duel.IsExistingTarget(c75014062.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(75014062,0))
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(75014062,1))
 	local g=Duel.SelectTarget(tp,c75014062.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_COUNTER,nil,1,0,0x3001)
 end

--- a/script/c75132317.lua
+++ b/script/c75132317.lua
@@ -36,7 +36,8 @@ function c75132317.filter(c)
 	return c:IsSetCard(0x7c) and c:IsType(TYPE_TRAP) and c:IsSSetable()
 end
 function c75132317.settg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not e:GetHandler():IsStatus(STATUS_CHAINING) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and e:GetHandler():IsFaceup()
+		and not e:GetHandler():IsStatus(STATUS_CHAINING) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
 		and Duel.IsExistingMatchingCard(c75132317.filter,tp,LOCATION_DECK,0,1,nil) end
 end
 function c75132317.setop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c87774234.lua
+++ b/script/c87774234.lua
@@ -16,7 +16,7 @@ function c87774234.condition(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_DECK)
 end
 function c87774234.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end

--- a/script/c89258906.lua
+++ b/script/c89258906.lua
@@ -27,7 +27,7 @@ function c89258906.condition(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_DECK)
 end
 function c89258906.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end

--- a/script/c90020065.lua
+++ b/script/c90020065.lua
@@ -39,7 +39,7 @@ function c90020065.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c90020065.desop(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(Card.IsDestructable,tp,LOCATION_MZONE,0,nil)
-	local dam=g:GetSum(Card.GetAttack)
+	local dam=g:GetSum(Card.GetAttack)/2
 	Duel.Destroy(g,REASON_EFFECT)
 	Duel.Damage(1-tp,dam,REASON_EFFECT)
 end

--- a/script/c90960358.lua
+++ b/script/c90960358.lua
@@ -6,6 +6,7 @@ function c90960358.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(c90960358.splimit)
 	c:RegisterEffect(e1)
 	--special summon
 	local e2=Effect.CreateEffect(c)
@@ -58,6 +59,9 @@ function c90960358.initial_effect(c)
 	e8:SetRange(LOCATION_MZONE)
 	e8:SetValue(c90960358.val)
 	c:RegisterEffect(e8)
+end
+function c90960358.splimit(e,se,sp,st,spos,tgp)
+	return Duel.IsExistingMatchingCard(c90960358.cfilter,tgp,LOCATION_ONFIELD,0,1,nil)
 end
 function c90960358.cfilter(c)
 	return c:IsFaceup() and c:IsCode(15259703)

--- a/script/c93599951.lua
+++ b/script/c93599951.lua
@@ -28,6 +28,6 @@ function c93599951.activate(e,tp,eg,ep,ev,re,r,rp)
 		if tc:IsDefencePos() then
 			Duel.ChangePosition(tc,POS_FACEUP_ATTACK)
 		end
-		Duel.ChangeAttacker(tc)
+		Duel.ReplaceAttacker(tc)
 	end
 end

--- a/script/c97403510.lua
+++ b/script/c97403510.lua
@@ -73,7 +73,7 @@ function c97403510.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsReason(REASON_DESTROY) and e:GetHandler():GetOverlayCount()>0
 end
 function c97403510.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A5%C8%A5%A5%A1%BC%A5%F3
Ｑ：特殊召喚モンスターに該当するトゥーンモンスターは墓地から特殊召喚できますか？
Ａ：《トゥーン・ブラック・マジシャン・ガール》などの特殊召喚モンスターは正規の手順で特殊召喚された後に墓地へ送られた場合、フィールド上に《トゥーン・ワールド》が存在すれば《死者蘇生》などで特殊召喚できます。(12/05/02)

http://yugioh-wiki.net/index.php?%A1%D4%B5%E6%B6%CB%B6%B2%BD%C3%A1%D5
Ｑ：自分フィールド上に《究極恐獣》が２体以上存在する場合、バトルフェイズ開始時にどのような処理が行われるのですか？
Ａ：まず１体目の《究極恐獣》で全体攻撃をします。２体目は「一番最初」という条件を満たせなくなっているため効果が適用されません。
　　よって２体目は一度の攻撃しか行えないことになります。

Ｑ：相手フィールドにモンスターが存在しない場合、このモンスターは相手に直接攻撃することができますか？
Ａ：はい、可能です。ただし、１番最初に攻撃する必要はありません。

http://yugioh-wiki.net/index.php?%A1%D4%A5%DE%A5%C9%A5%EB%A5%C1%A5%A7%A1%A6%A5%DE%A5%CA%A1%BC%A1%D5
Ｑ：自分の墓地の「マドルチェ」１体をデッキに戻す処理と攻撃力・守備力がアップする処理は同時に行う扱いですか？
Ａ：はい、同時に行う扱いです。(12/04/19)
