### PR TITLE
Starlight Road now negates activations instead of effects

### DIFF
--- a/script/c58120309.lua
+++ b/script/c58120309.lua
@@ -29,7 +29,7 @@ function c58120309.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function c58120309.activate(e,tp,eg,ep,ev,re,r,rp)
-	Duel.NegateEffect(ev)
+	Duel.NegateActivation(ev)
 	if re:GetHandler():IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 then
 		local sc=Duel.GetFirstMatchingCard(c58120309.sfilter,tp,LOCATION_EXTRA,0,nil,e,tp)
 		if sc and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and Duel.SelectYesNo(tp,aux.Stringid(58120309,0)) then


### PR DESCRIPTION
As per latest text (GLD5-EN052), Starlight Road should negate activations, not effects of cards.

"When a card or effect is activated that destroys 2 or more cards you control: Negate the activation, and if you do, destroy that card, then you can Special Summon 1 "Stardust Dragon" from your Extra Deck."

This makes a major difference in a case when Starlight Road is Chain Link 2 -- since CL1 has negated activation, the last thing that happens on the field is that Summon and you can Torrential Tribute/Bottomless Traphole that summoned Stardust.