### PR TITLE
trigger

### DIFF
--- a/ocgcore/card.cpp
+++ b/ocgcore/card.cpp
@@ -682,9 +682,8 @@ void card::apply_field_effect() {
 	if (current.controler == PLAYER_NONE)
 		return;
 	for (auto it = field_effect.begin(); it != field_effect.end(); ++it) {
-		if (current.location & it->second->range) {
+		if ((current.location & it->second->range) || ((it->second->range & LOCATION_HAND) && (it->second->type & EFFECT_TYPE_TRIGGER_O)))
 			pduel->game_field->add_effect(it->second);
-		}
 	}
 	if(unique_code && (current.location & LOCATION_ONFIELD))
 		pduel->game_field->add_unique_card(this);
@@ -693,7 +692,7 @@ void card::cancel_field_effect() {
 	if (current.controler == PLAYER_NONE)
 		return;
 	for (auto it = field_effect.begin(); it != field_effect.end(); ++it) {
-		if (current.location & it->second->range)
+		if ((current.location & it->second->range) || ((it->second->range & LOCATION_HAND) && (it->second->type & EFFECT_TYPE_TRIGGER_O)))
 			pduel->game_field->remove_effect(it->second);
 	}
 	if(unique_code && current.location & LOCATION_ONFIELD)

--- a/ocgcore/effect.cpp
+++ b/ocgcore/effect.cpp
@@ -397,7 +397,10 @@ int32 effect::is_chainable(uint8 tp) {
 	if((type & EFFECT_TYPE_ACTIVATE) && (sp <= 1) && !(flag & EFFECT_FLAG_COF))
 		return FALSE;
 	if(pduel->game_field->core.current_chain.size()) {
-		if(sp < pduel->game_field->core.current_chain.rbegin()->triggering_effect->get_speed())
+		if((type & EFFECT_TYPE_TRIGGER_O) && (handler->current.location == LOCATION_HAND)) {
+			if(pduel->game_field->core.current_chain.rbegin()->triggering_effect->get_speed() > 2)
+				return FALSE;
+		} else if(sp < pduel->game_field->core.current_chain.rbegin()->triggering_effect->get_speed())
 			return FALSE;
 	}
 	if(pduel->game_field->core.chain_limit) {

--- a/ocgcore/field.h
+++ b/ocgcore/field.h
@@ -175,6 +175,7 @@ struct processor {
 	chain_list new_fchain_b;
 	chain_list new_ochain_b;
 	chain_list flip_chain_b;
+	chain_list new_ochain_h;
 	chain_list new_chains;
 	instant_f_list quick_f_chain;
 	card_set leave_confirmed;


### PR DESCRIPTION
手札誘発
http://yugioh-wiki.net/index.php?%BC%EA%BB%A5%CD%B6%C8%AF

同時に複数のカードが発動した場合
手札誘発は通常の誘発効果だけでチェーンを組み終わった後に発動できる。

誘発効果は発動条件を満たすと他の効果に先行してチェーンが組まれるが、手札誘発は通常の優先権に従う。

一連の処理中に手札に加えられた場合でも、最初から手札に存在していたかのように発動条件を満たす事もある。

Ｑ：《邪帝ガイウス》のアドバンス召喚成功時に、《邪帝ガイウス》の効果にチェーンして自分は《イリュージョン・スナッチ》の効果を発動しようとしています。同時に、相手は《奈落の落とし穴》を発動しようとしています。この場合、どちらに先にチェーンする権利がありますか？
 Ａ：チェーン１：《邪帝ガイウス》の後、優先権が相手に移るためチェーン２：《奈落の落とし穴》を発動出来ます。
 　　ここでスペルスピード２の《奈落の落とし穴》にチェーンを組む形でスペルスピード１のチェーン３：《イリュージョン・スナッチ》の効果を発動出来ます。(12/05/17)

Ｑ：《邪帝ガイウス》のアドバンス召喚成功時に、《邪帝ガイウス》の効果にチェーンして自分は《イリュージョン・スナッチ》の効果を発動しようとしています。同時に、相手は《天罰》を発動しようとしています。この場合、どちらに先にチェーンする権利がありますか？
 Ａ：チェーン１：《邪帝ガイウス》の後、優先権が相手に移るためチェーン２：《天罰》を発動します。
 　　スペルスピード３の《天罰》にチェーンを組む形でスペルスピード１の《イリュージョン・スナッチ》の効果はチェーン発動する事は出来ません。
 　　スペルスピードが２の《奈落の落とし穴》にチェーン発動できる理由はルールに反していますが、開発部署に確認を取っており、そういうものであるとしかお答えできません。(12/05/17)

「ジェネレーション・チェンジ」の効果によって、フィールド上の「炎王獣 バロン」が破壊された場合、
その「ジェネレーション・チェンジ」の効果によって手札に加わった「炎王獣 バロン」の効果を発動し、手札から特殊召喚する事はできます。 
(http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12660)
