### PR TITLE
Update c85909450.lua

### DIFF
--- a/script/c85909450.lua
+++ b/script/c85909450.lua
@@ -40,7 +40,7 @@ function c85909450.effcon(e)
 	return e:GetHandler():GetOverlayCount()>0
 end
 function c85909450.target(e,c)
-	return c:IsSetCard(0x64)
+	return c:IsSetCard(0x64) and c:IsType(TYPE_MONSTER)
 end
 function c85909450.tgvalue(e,re,rp)
 	return rp~=e:GetHandlerPlayer()


### PR DESCRIPTION
It doesn't  protect "ハーピィの狩場" .
