### PR TITLE
fix for abyss dweller

### DIFF
--- a/script/c82593786.lua
+++ b/script/c82593786.lua
@@ -13,7 +13,7 @@ function c82593786.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c82593786.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetAttackTarget()~=nil
+	return Duel.GetAttacker()~=nil
 end
 function c82593786.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFlagEffect(tp,82593786)==0 and e:GetHandler():IsAbleToRemoveAsCost() end


### PR DESCRIPTION
fixed abyss dweller lingering for too long when activated at the Opponents End Phase
