### PR TITLE
fix 

### DIFF
--- a/script/c14001430.lua
+++ b/script/c14001430.lua
@@ -28,6 +28,11 @@ function c14001430.initial_effect(c)
 	e4:SetTarget(c14001430.reptg)
 	e4:SetValue(c14001430.repval)
 	c:RegisterEffect(e4)
+	--immune to necro valley
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetCode(EFFECT_NECRO_VALLEY_IM)
+	c:RegisterEffect(e5)
 end
 function c14001430.tdfilter(c)
 	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x71) and c:IsAbleToDeck()


### PR DESCRIPTION
マドルチェ・シャトー / Madolche Chateau

changed to reflect the following OCG ruling

If the opponent has "Necrovalley" in their Field Card Zone when you activate "Madolche Chateau" in your Field Card Zone, at the time the effect of "Madolche Chateau" resolves, since the effect of "Necrovalley" is no longer applied, the effect of "Madolche Chateau" is not negated and all "Madolche" monsters in your Graveyard are returned to the Deck.[1]

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12359&keyword=&tag=-1
