### PR TITLE
fix: 29669359, 6614221, 69890967, 85121942, 88071625, 98645731

### DIFF
--- a/script/c29669359.lua
+++ b/script/c29669359.lua
@@ -35,13 +35,15 @@ function c29669359.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.IsExistingTarget(c29669359.filter,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,c29669359.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	local atk=g:GetFirst():GetTextAttack()
+	if atk<0 then atk=0 end
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,g:GetFirst():GetTextAttack())
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,atk)
 end
 function c29669359.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(1-tp) then
-		local atk=tc:GetBaseAttack()
+	if tc:IsRelateToEffect(e) and tc:IsControler(1-tp) then
+		local atk=tc:GetTextAttack()
 		if atk<0 then atk=0 end
 		if Duel.Destroy(tc,REASON_EFFECT)~=0 then
 			Duel.Damage(1-tp,atk,REASON_EFFECT)

--- a/script/c6614221.lua
+++ b/script/c6614221.lua
@@ -27,7 +27,7 @@ function c6614221.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=mg:GetFirst()
 	local atk=0
 	while tc do
-		local catk=tc:GetBaseAttack()
+		local catk=tc:GetTextAttack()
 		if catk<0 then catk=0 end
 		atk=atk+catk
 		tc=mg:GetNext()

--- a/script/c69890967.lua
+++ b/script/c69890967.lua
@@ -70,7 +70,9 @@ end
 function c69890967.atcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,nil,1,e:GetHandler()) end
 	local g=Duel.SelectReleaseGroup(tp,nil,1,1,e:GetHandler())
-	e:SetLabel(g:GetFirst():GetTextAttack())
+	local atk=g:GetFirst():GetTextAttack()
+	if atk<0 then atk=0 end
+	e:SetLabel(atk)
 	Duel.Release(g,REASON_COST)
 end
 function c69890967.atop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c85121942.lua
+++ b/script/c85121942.lua
@@ -37,7 +37,7 @@ function c85121942.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local c=e:GetHandler()
 	local bc=c:GetBattleTarget()
-	local dam=bc:GetAttack()/2
+	local dam=bc:GetTextAttack()/2
 	if dam<0 then dam=0 end
 	Duel.SetTargetPlayer(1-tp)
 	Duel.SetTargetParam(dam)

--- a/script/c88071625.lua
+++ b/script/c88071625.lua
@@ -19,25 +19,20 @@ function c88071625.initial_effect(c)
 	c:RegisterEffect(e2)
 	--atk
 	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE)
-	e3:SetCode(EFFECT_MATERIAL_CHECK)
-	e3:SetValue(c88071625.valcheck)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_SUMMON_SUCCESS)
+	e3:SetOperation(c88071625.atkop)
 	c:RegisterEffect(e3)
-	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e4:SetCode(EVENT_SUMMON_SUCCESS)
-	e4:SetOperation(c88071625.atkop)
-	c:RegisterEffect(e4)
 	--copy
-	local e5=Effect.CreateEffect(c)
-	e5:SetDescription(aux.Stringid(88071625,1))
-	e5:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
-	e5:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e5:SetCode(EVENT_SUMMON_SUCCESS)
-	e5:SetCondition(c88071625.copycon)
-	e5:SetTarget(c88071625.copytg)
-	e5:SetOperation(c88071625.copyop)
-	c:RegisterEffect(e5)
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(88071625,1))
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e4:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e4:SetCode(EVENT_SUMMON_SUCCESS)
+	e4:SetCondition(c88071625.copycon)
+	e4:SetTarget(c88071625.copytg)
+	e4:SetOperation(c88071625.copyop)
+	c:RegisterEffect(e4)
 end
 function c88071625.otcon(e,c)
 	if c==nil then return true end
@@ -48,25 +43,33 @@ function c88071625.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	c:SetMaterial(sg)
 	Duel.Release(sg, REASON_SUMMON+REASON_MATERIAL)
 end
-function c88071625.valcheck(e,c)
-	local g=c:GetMaterial()
-	c88071625.atk=g:GetSum(Card.GetBaseAttack)
-	c88071625.def=g:GetSum(Card.GetBaseDefence)
-end
 function c88071625.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:GetMaterialCount()==0 then return end
 	local e1=Effect.CreateEffect(c)
+	local mg=c:GetMaterial()
+	local tc=mg:GetFirst()
+	local atk=0
+	local def=0
+	while tc do
+		local catk=tc:GetTextAttack()
+		local cdef=tc:GetTextDefence()
+		if catk<0 then catk=0 end
+		if cdef<0 then cdef=0 end
+		atk=atk+catk
+		def=def+cdef
+		tc=mg:GetNext()
+	end
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_UPDATE_ATTACK)
 	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e1:SetRange(LOCATION_MZONE)
-	e1:SetValue(c88071625.atk)
+	e1:SetValue(atk)
 	e1:SetReset(RESET_EVENT+0x1ff0000)
 	c:RegisterEffect(e1)
 	local e2=e1:Clone()
 	e2:SetCode(EFFECT_UPDATE_DEFENCE)
-	e2:SetValue(c88071625.def)
+	e2:SetValue(def)
 	c:RegisterEffect(e2)
 end
 function c88071625.copycon(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c98645731.lua
+++ b/script/c98645731.lua
@@ -12,7 +12,7 @@ function c98645731.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c98645731.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not Duel.CheckSpecialSummonActivity(tp) and Duel.GetFlagEffect(tp,98645732)==0 end
+	if chk==0 then return not Duel.CheckSpecialSummonActivity(tp) and Duel.GetFlagEffect(tp,98645731)==0 end
 	--oath effects
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
@@ -21,7 +21,7 @@ function c98645731.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	e1:SetTargetRange(1,0)
 	Duel.RegisterEffect(e1,tp)
-	Duel.RegisterFlagEffect(tp,98645732,RESET_PHASE+PHASE_END,EFFECT_FLAG_OATH,1)
+	Duel.RegisterFlagEffect(tp,98645731,RESET_PHASE+PHASE_END,EFFECT_FLAG_OATH,1)
 end
 function c98645731.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then 


### PR DESCRIPTION
29669359 No.61 ヴォルカザウルス
Now No.61 ヴォルカザウルス can destroy a monster which is changed into face down in chain (By Konami database FAQ), and the attack caluculation is changed  into GetTextAttack().

6614221 霧の王
Now the attack caluculation is changed  into GetTextAttack().

69890967  幻魔皇ラビエル
Add the check for monster with text attack '?'.

85121942  CNo.105 BK 彗星のカエストス
Now damage when battle destroying a monster is calculated by GetTextAttack().

88071625 Ｔｈｅ　ｔｙｒａｎｔ　ＮＥＰＴＵＮＥ
Now the attck and deffense calculation is using GetTextAttack(), and the summation is changed into the way similar to 6614221.

98645731  強欲で謙虚な壺
Now the card ID in Flag Effect is the correct ID.
