### PR TITLE
fix

### DIFF
--- a/script/c47942531.lua
+++ b/script/c47942531.lua
@@ -1,33 +1,24 @@
 --偉大魔獣 ガーゼット
 function c47942531.initial_effect(c)
-	--atk
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e1:SetCode(EVENT_SUMMON_SUCCESS)
-	e1:SetOperation(c47942531.atop)
-	c:RegisterEffect(e1)
 	--tribute check
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_MATERIAL_CHECK)
-	e2:SetValue(c47942531.valcheck)
-	e2:SetLabelObject(e1)
-	c:RegisterEffect(e2)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_MATERIAL_CHECK)
+	e1:SetValue(c47942531.valcheck)
+	c:RegisterEffect(e1)
 end
 function c47942531.valcheck(e,c)
 	local tc=c:GetMaterial():GetFirst()
-	local atk=tc:GetTextAttack()
+	local atk=0
+	if tc then atk=tc:GetTextAttack()*2 end
 	if atk<0 then atk=0 end
-	e:GetLabelObject():SetLabel(atk*2)
-end
-function c47942531.atop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
+	--atk continuous effect
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SET_ATTACK)
 	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e1:SetRange(LOCATION_MZONE)
-	e1:SetValue(e:GetLabel())
-	e1:SetReset(RESET_EVENT+0x1ff0000)
-	c:RegisterEffect(e1)
+	e1:SetValue(atk)
+	e1:SetReset(RESET_EVENT+0xff0000)
+	c:RegisterEffect(e1)	
 end

--- a/script/c6614221.lua
+++ b/script/c6614221.lua
@@ -6,11 +6,11 @@ function c6614221.initial_effect(c)
 	e1:SetCode(EFFECT_DECREASE_TRIBUTE)
 	e1:SetValue(0x2)
 	c:RegisterEffect(e1)
-	--atk
+	--tribute check
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e2:SetCode(EVENT_SUMMON_SUCCESS)
-	e2:SetOperation(c6614221.atkop)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_MATERIAL_CHECK)
+	e2:SetValue(c6614221.valcheck)
 	c:RegisterEffect(e2)
 	--cannot release
 	local e3=Effect.CreateEffect(c)
@@ -21,23 +21,22 @@ function c6614221.initial_effect(c)
 	e3:SetTargetRange(1,1)
 	c:RegisterEffect(e3)
 end
-function c6614221.atkop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local mg=c:GetMaterial()
-	local tc=mg:GetFirst()
+function c6614221.valcheck(e,c)
+	local g=c:GetMaterial()
+	local tc=g:GetFirst()
 	local atk=0
 	while tc do
 		local catk=tc:GetTextAttack()
-		if catk<0 then catk=0 end
-		atk=atk+catk
-		tc=mg:GetNext()
+		atk=atk+(catk>=0 and catk or 0)
+		tc=g:GetNext()
 	end
-	if atk~=0 then
-		local e1=Effect.CreateEffect(c)
-		e1:SetType(EFFECT_TYPE_SINGLE)
-		e1:SetCode(EFFECT_SET_ATTACK)
-		e1:SetValue(atk)
-		e1:SetReset(RESET_EVENT+0x1ff0000)
-		c:RegisterEffect(e1)
-	end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SET_ATTACK)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetValue(atk)
+	e1:SetReset(RESET_EVENT+0xff0000)
+	c:RegisterEffect(e1)
 end
+

--- a/script/c73333463.lua
+++ b/script/c73333463.lua
@@ -1,4 +1,4 @@
---ライトロード·エンジェル ケルビム
+--アーマロイドガイデンゴー
 function c73333463.initial_effect(c)
 	--summon success
 	local e1=Effect.CreateEffect(c)

--- a/script/c8794435.lua
+++ b/script/c8794435.lua
@@ -1,18 +1,11 @@
 --合成魔獣 ガーゼット
 function c8794435.initial_effect(c)
-	--atk
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e1:SetCode(EVENT_SUMMON_SUCCESS)
-	e1:SetOperation(c8794435.atop)
-	c:RegisterEffect(e1)
 	--tribute check
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_MATERIAL_CHECK)
-	e2:SetValue(c8794435.valcheck)
-	e2:SetLabelObject(e1)
-	c:RegisterEffect(e2)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_MATERIAL_CHECK)
+	e1:SetValue(c8794435.valcheck)
+	c:RegisterEffect(e1)
 end
 function c8794435.valcheck(e,c)
 	local g=c:GetMaterial()
@@ -23,16 +16,13 @@ function c8794435.valcheck(e,c)
 		atk=atk+(catk>=0 and catk or 0)
 		tc=g:GetNext()
 	end
-	e:GetLabelObject():SetLabel(atk)
-end
-function c8794435.atop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
+	--atk continuous effect
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SET_ATTACK)
 	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e1:SetRange(LOCATION_MZONE)
-	e1:SetValue(e:GetLabel())
-	e1:SetReset(RESET_EVENT+0x1ff0000)
+	e1:SetValue(atk)
+	e1:SetReset(RESET_EVENT+0xff0000)
 	c:RegisterEffect(e1)
 end

--- a/script/c88071625.lua
+++ b/script/c88071625.lua
@@ -17,11 +17,11 @@ function c88071625.initial_effect(c)
 	e2:SetOperation(c88071625.otop)
 	e2:SetValue(SUMMON_TYPE_ADVANCE)
 	c:RegisterEffect(e2)
-	--atk
+	--tribute check
 	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e3:SetCode(EVENT_SUMMON_SUCCESS)
-	e3:SetOperation(c88071625.atkop)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_MATERIAL_CHECK)
+	e3:SetValue(c88071625.valcheck)
 	c:RegisterEffect(e3)
 	--copy
 	local e4=Effect.CreateEffect(c)
@@ -43,30 +43,28 @@ function c88071625.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	c:SetMaterial(sg)
 	Duel.Release(sg, REASON_SUMMON+REASON_MATERIAL)
 end
-function c88071625.atkop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if c:GetMaterialCount()==0 then return end
-	local e1=Effect.CreateEffect(c)
-	local mg=c:GetMaterial()
-	local tc=mg:GetFirst()
+function c6614221.valcheck(e,c)
+	local g=c:GetMaterial()
+	local tc=g:GetFirst()
 	local atk=0
 	local def=0
 	while tc do
 		local catk=tc:GetTextAttack()
 		local cdef=tc:GetTextDefence()
-		if catk<0 then catk=0 end
-		if cdef<0 then cdef=0 end
-		atk=atk+catk
-		def=def+cdef
-		tc=mg:GetNext()
+		atk=atk+(catk>=0 and catk or 0)
+		def=def+(cdef>=0 and cdef or 0)
+		tc=g:GetNext()
 	end
+	--atk continuous effect
+	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_UPDATE_ATTACK)
 	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetValue(atk)
-	e1:SetReset(RESET_EVENT+0x1ff0000)
+	e1:SetReset(RESET_EVENT+0xff0000)
 	c:RegisterEffect(e1)
+	--def continuous effect
 	local e2=e1:Clone()
 	e2:SetCode(EFFECT_UPDATE_DEFENCE)
 	e2:SetValue(def)


### PR DESCRIPTION
47942531  偉大魔獣 ガーゼット
6614221  霧の王
8794435  合成魔獣 ガーゼット
88071625 Ｔｈｅ　ｔｙｒａｎｔ　ＮＥＰＴＵＮＥ
The atk setting/updating continuous effect was given at SUMMON_SUCCESS before, which may cause some problem with effects triggered at te same time.(ex. 83986578 王虎ワンフー)

Now the atk setting/updating continuous effect is given right after tribute check, which will be ready at SUMMON_SUCCESS.
Also, the RESET_EVENT is changed into 0xff0000.

P.S.
I. 
Current script uses text_attack when calculating atk, so the trap monster should have their own atk and def data in cards.cdb

Here is a brief list of trap mosters:
28649820 アポピスの化神                  1600/1800
3129635 カース・オブ・スタチュー            1800/1000
70406920 機械王－Ｂ.Ｃ.３０００       1000/1000
13955608 機動砦 ストロング・ホールド       0/2000
21843307 コピー・ナイト              0/0
90440725 サイバー・シャドー・ガードナー  ?/?
92099232 シェイプシスター               0/0
79852326 死霊ゾーマ                    1800/500
49514333 ソウル・オブ・スタチュー           1000/1800
26905245 メタル・リフレクト・スライム     0/3000

II.
20174189 ナチュル·バンブーシュート
20529766 超電磁稼動ボルテック·ドラゴン
50933533 古代の機械巨竜
74841885 天魔神 インヴィシル
86321248 古代の機械合成獣
These cards may have the same problem. Please check them if possible.
## 

73333463  アーマロイドガイデンゴー
Now the card name in the script is chaned into the correct one.
