### PR TITLE
fix

### DIFF
--- a/script/c20368763.lua
+++ b/script/c20368763.lua
@@ -71,7 +71,7 @@ end
 function c20368763.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
-		local token=Duel.CreateToken(tp,20368764)
+		local token=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c22110647.lua
+++ b/script/c22110647.lua
@@ -55,9 +55,9 @@ end
 function c22110647.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=1 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
-		local token1=Duel.CreateToken(tp,22110648)
+		local token1=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummonStep(token1,0,tp,tp,false,false,POS_FACEUP)
-		local token2=Duel.CreateToken(tp,22110648)
+		local token2=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummonStep(token2,0,tp,tp,false,false,POS_FACEUP)
 		Duel.SpecialSummonComplete()
 	end

--- a/script/c30811116.lua
+++ b/script/c30811116.lua
@@ -66,7 +66,7 @@ end
 function c30811116.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
-		local token=Duel.CreateToken(tp,30811117)
+		local token=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c31480215.lua
+++ b/script/c31480215.lua
@@ -60,7 +60,7 @@ function c31480215.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
-		local token=Duel.CreateToken(tp,31480216)
+		local token=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c4417407.lua
+++ b/script/c4417407.lua
@@ -64,7 +64,7 @@ end
 function c4417407.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
-		local token=Duel.CreateToken(tp,4417408)
+		local token=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c66200210.lua
+++ b/script/c66200210.lua
@@ -61,9 +61,9 @@ end
 function c66200210.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=1 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
-		local token1=Duel.CreateToken(tp,66200211)
+		local token1=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummonStep(token1,0,tp,tp,false,false,POS_FACEUP)
-		local token2=Duel.CreateToken(tp,66200211)
+		local token2=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummonStep(token2,0,tp,tp,false,false,POS_FACEUP)
 		Duel.SpecialSummonComplete()
 	end

--- a/script/c67489919.lua
+++ b/script/c67489919.lua
@@ -60,7 +60,7 @@ end
 function c67489919.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
-		local token=Duel.CreateToken(tp,67489920)
+		local token=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c67922702.lua
+++ b/script/c67922702.lua
@@ -63,7 +63,7 @@ end
 function c67922702.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
-		local token=Duel.CreateToken(tp,67922703)
+		local token=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c70875955.lua
+++ b/script/c70875955.lua
@@ -53,7 +53,7 @@ function c70875955.spop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	if e:GetLabel()==0 or Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
-		local token=Duel.CreateToken(tp,70875956)
+		local token=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c904185.lua
+++ b/script/c904185.lua
@@ -30,7 +30,7 @@ function c904185.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<e:GetLabel() then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
 		for i=1,e:GetLabel() do
-			local token=Duel.CreateToken(tp,904186)
+			local token=Duel.CreateToken(tp,31533705)
 			Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP)
 		end
 		Duel.SpecialSummonComplete()

--- a/script/c94973028.lua
+++ b/script/c94973028.lua
@@ -69,9 +69,9 @@ end
 function c94973028.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=1 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
-		local token=Duel.CreateToken(tp,94973029)
+		local token=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP)
-		token=Duel.CreateToken(tp,94973029)
+		token=Duel.CreateToken(tp,31533705)
 		Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP)
 		Duel.SpecialSummonComplete()
 	end

--- a/script/c98012938.lua
+++ b/script/c98012938.lua
@@ -1,4 +1,4 @@
---ª•Éñ¥ô¥¡¥ë¥«¥ó
+--ç£ç¥ãƒ´ã‚¡ãƒ«ã‚«ãƒ³
 function c98012938.initial_effect(c)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)


### PR DESCRIPTION
fix: 98012938, Mecha Phantom Beast Token

98012938 獣神ヴァルカン
fix the card name in the script file

"Mecha Phantom Beast Token" related cards
(11 cards, except 31533704 幻獣機メガラプター itself)
Now "Mecha Phantom Beast Token" generated by all cards have the same ID
31533705, which is used in IsPlayerCanSpecialSummonMonster() checking.
