### PR TITLE
fix

### DIFF
--- a/script/c56981417.lua
+++ b/script/c56981417.lua
@@ -4,6 +4,7 @@ function c56981417.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCondition(c56981417.condition)
 	e1:SetCost(c56981417.cost)
 	e1:SetTarget(c56981417.target)
@@ -34,22 +35,22 @@ end
 function c56981417.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c56981417.filter(chkc) end
 	if chk==0 then return Duel.IsExistingTarget(c56981417.filter,tp,LOCATION_GRAVE,0,1,nil) end
-	e:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e:SetCategory(0)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	Duel.SelectTarget(tp,c56981417.filter,tp,LOCATION_GRAVE,0,1,1,nil)
-end
-function c56981417.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) or tc:CheckActivateEffect(true,true,false)==nil then return end
-	local tpe=tc:GetType()
 	local te=tc:GetActivateEffect()
 	local tg=te:GetTarget()
-	local op=te:GetOperation()
 	e:SetCategory(te:GetCategory())
 	e:SetProperty(te:GetProperty())
 	Duel.ClearTargetCard()
 	if tg then tg(e,tp,eg,ep,ev,re,r,rp,1) end
-	Duel.BreakEffect()
+	e:SetLabelObject(tc)
+end
+function c56981417.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	if not tc:IsRelateToEffect(e) or tc:CheckActivateEffect(true,true,false)==nil then return end
+	local te=tc:GetActivateEffect()
+	local op=te:GetOperation()
 	if op then op(e,tp,eg,ep,ev,re,r,rp) end
 end


### PR DESCRIPTION
56981417 セフェルの魔導書
Now copying a spellbook with a taget effect (Ex. 25123082 ヒュグロの魔導書) will select the new target when activating.
