### PR TITLE
revert for some cards

### DIFF
--- a/script/c34471458.lua
+++ b/script/c34471458.lua
@@ -53,7 +53,7 @@ end
 function c34471458.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsReason(REASON_EFFECT) and not c:IsLocation(LOCATION_DECK)
-		and (c:IsPreviousPosition(POS_FACEUP) or c:IsLocation(LOCATION_HAND))
+		and c:IsPreviousPosition(POS_FACEUP)
 end
 function c34471458.spfilter(c,e,tp)
 	return c:IsSetCard(0x31) and c:IsCanBeSpecialSummoned(e,0x8,tp,false,false)

--- a/script/c47297616.lua
+++ b/script/c47297616.lua
@@ -91,6 +91,7 @@ function c47297616.opspsum(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Destroy(dg,REASON_EFFECT)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
+		Duel.BreakEffect()
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c54704216.lua
+++ b/script/c54704216.lua
@@ -56,13 +56,6 @@ function c54704216.operation(e,tp,eg,ep,ev,re,r,rp)
 		local e2=e1:Clone()
 		e2:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
 		tc:RegisterEffect(e2,true)
-		local e3=Effect.CreateEffect(c)
-		e3:SetType(EFFECT_TYPE_SINGLE)
-		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-		e3:SetCode(EFFECT_CANNOT_FLIP_SUMMON)
-		e3:SetReset(RESET_EVENT+0x1fc0000)
-		e3:SetCondition(c54704216.rcon)
-		tc:RegisterEffect(e3)
 	end
 end
 function c54704216.rcon(e)

--- a/script/c73414375.lua
+++ b/script/c73414375.lua
@@ -10,25 +10,19 @@ function c73414375.initial_effect(c)
 	e1:SetOperation(c73414375.operation)
 	c:RegisterEffect(e1)
 end
-
-function c73414375.filter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsAbleToRemove()
-end
 function c73414375.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	if chk==0 then return true end
 	local g=Group.CreateGroup()
-	if Duel.IsExistingTarget(c73414375.filter,tp,0,LOCATION_GRAVE,1,nil) and Duel.SelectYesNo(tp,aux.Stringid(73414375,1)) then
+	if Duel.IsExistingTarget(Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,nil) and Duel.SelectYesNo(tp,aux.Stringid(73414375,1)) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-		local rg=Duel.SelectTarget(tp,c73414375.filter,tp,0,LOCATION_GRAVE,1,3,nil)
+		local rg=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,3,nil)
 		g:Merge(rg)
 	end
-	if Duel.IsExistingTarget(c73414375.filter,1-tp,0,LOCATION_GRAVE,1,nil) and Duel.SelectYesNo(1-tp,aux.Stringid(73414375,1)) then
+	if Duel.IsExistingTarget(Card.IsAbleToRemove,1-tp,0,LOCATION_GRAVE,1,nil) and Duel.SelectYesNo(1-tp,aux.Stringid(73414375,1)) then
 		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_REMOVE)
-		local rg=Duel.SelectTarget(1-tp,c73414375.filter,1-tp,0,LOCATION_GRAVE,1,3,nil)
-		if rg then 
-			g:Merge(rg)
-		end
+		local rg=Duel.SelectTarget(1-tp,Card.IsAbleToRemove,1-tp,0,LOCATION_GRAVE,1,3,nil)
+		g:Merge(rg)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
 end


### PR DESCRIPTION
34471458 フォーチュンレディ·ライティー
The original effect is correct.
Reverted to previos version.

47297616 光と闇の竜
Destroy and sp_summon are at different timing.
Reverted to original version.

54704216 拷問車輪
The original effect is correct.
Reverted to previos version.

73414375 ディメンション·ポッド
Effect taken from Konami database:
リバース：お互いのプレイヤーは、相手の墓地のカードを３枚までゲームから除外する事ができる。
In OCG version, this card can banish ALL KINDS of cards.
Reverted to previos version.
