### PR TITLE
fix

### DIFF
--- a/script/c440556.lua
+++ b/script/c440556.lua
@@ -30,9 +30,8 @@ end
 function c440556.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local c=e:GetHandler()
-	local cp=c:GetControler()
-	Duel.Hint(HINT_SELECTMSG,cp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(cp,c440556.filter,cp,LOCATION_EXTRA,0,1,1,nil,e,tp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c440556.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 		local e1=Effect.CreateEffect(e:GetHandler())
@@ -41,10 +40,10 @@ function c440556.spop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		c:RegisterEffect(e1)
-	elseif cp~=tp then
-		local cg=Duel.GetFieldGroup(cp,LOCATION_EXTRA,0)
+	else
+		local cg=Duel.GetFieldGroup(tp,LOCATION_EXTRA,0)
 		if cg and cg:GetCount()>0 then
-		Duel.ConfirmCards(cg,tp)
+			Duel.ConfirmCards(cg,1-tp)
 		end
 	end
 end

--- a/script/c69042950.lua
+++ b/script/c69042950.lua
@@ -12,6 +12,9 @@ end
 function c69042950.mfilter(c,clv)
 	return c:IsFaceup() and c:GetLevel()==clv
 end
+function c69042950.mfilter2(c)
+	return c:IsFaceup() and c:IsLevelBelow(4)
+end
 function c69042950.spfilter(c,e,tp)
 	local lv=c:GetLevel()
 	return lv>0 and lv<=4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
@@ -20,11 +23,11 @@ end
 function c69042950.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c69042950.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp)
-	end
+		and Duel.IsExistingMatchingCard(c69042950.mfilter2,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
 end
 function c69042950.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and Duel.SelectYesNo(tp,aux.Stringid(69042950,0)) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c69042950.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 		if g:GetCount()~=0 then


### PR DESCRIPTION
440556 バハムート·シャーク
The player who activates sp_summon effect will sp_summon the water xyz
monster, even if the control is changed to opponent.
(According to Konami database)

69042950 バグ·ロード
Fix the condition check.
The sp_summon of both players are selectable now.
