### PR TITLE
fix

### DIFF
--- a/script/c24861088.lua
+++ b/script/c24861088.lua
@@ -32,12 +32,12 @@ function c24861088.initial_effect(c)
 end
 function c24861088.checkop(e,tp,eg,ep,ev,re,r,rp)
 	if not re:GetHandler():IsSetCard(0x70) then
-		Duel.RegisterFlagEffect(rp,24861088,RESET_PHASE+PHASE_END,0,1)
+		Duel.RegisterFlagEffect(rp,24861089,RESET_PHASE+PHASE_END,0,1)
 	end
 end
 function c24861088.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFlagEffect(tp,24861088)==0 end
-	Duel.RegisterFlagEffect(tp,24861088,RESET_PHASE+PHASE_END,EFFECT_FLAG_OATH,1)
+	Duel.RegisterFlagEffect(tp,24861088,RESET_PHASE+PHASE_END,0,1)
 end
 function c24861088.filter(c)
 	return c:IsSetCard(0x70) and not c:IsCode(24861088) and c:IsAbleToHand()
@@ -62,8 +62,8 @@ function c24861088.spcon(e,tp,eg,ep,ev,re,r,rp)
 		and not Duel.IsExistingMatchingCard(c24861088.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c24861088.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFlagEffect(tp,24861088)==0 end
-	Duel.RegisterFlagEffect(tp,24861088,RESET_PHASE+PHASE_END,EFFECT_FLAG_OATH,1)
+	if chk==0 then return Duel.GetFlagEffect(tp,24861088)==0 and Duel.GetFlagEffect(tp,24861089)==0 end
+	Duel.RegisterFlagEffect(tp,24861088,RESET_PHASE+PHASE_END,0,1)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)

--- a/script/c38007744.lua
+++ b/script/c38007744.lua
@@ -11,7 +11,7 @@ function c38007744.initial_effect(c)
 end
 function c38007744.spcon(e,c)
 	if c==nil then return true end
-	return Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,0)==0
-		and Duel.GetFieldGroupCount(c:GetControler(),0,LOCATION_MZONE)>0
+	return Duel.GetFieldGroupCount(c:GetControler(),LOCATION_ONFIELD,0)==0
+		and Duel.GetFieldGroupCount(c:GetControler(),0,LOCATION_ONFIELD)>0
 		and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end


### PR DESCRIPTION
24861088 先史遺産ネブラ・ディスク
There are 2 effects, and only the 2nd effect needs global check.
The global check flag effect is changed into 24861089, and flag 24861088 is changed into the form which once-per-turn monsters use.

38007744 先史遺産モアイキャリア
The condition is ALL cards on field, not only monster cards.
