### PR TITLE
fix

### DIFF
--- a/script/c50074392.lua
+++ b/script/c50074392.lua
@@ -63,5 +63,5 @@ function c50074392.lvop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e2,tp)
 end
 function c50074392.actfilter(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() and not c:IsAttribute(ATTRIBUTE_WATER)
+	return c:GetControler()==e:GetHandlerPlayer() and c:IsType(TYPE_MONSTER) and not c:IsAttribute(ATTRIBUTE_WATER)
 end

--- a/script/c67159705.lua
+++ b/script/c67159705.lua
@@ -55,10 +55,10 @@ function c67159705.repval(e,re,r,rp)
 	return bit.band(r,REASON_BATTLE)~=0
 end
 function c67159705.eqlimit(e,c)
-	return c:IsSetCard(0x103)
+	return c:IsCode(70095154) or c:IsSetCard(0x103)
 end
 function c67159705.filter(c)
-	return c:IsFaceup() and c:IsSetCard(0x103) and c:GetUnionCount()==0
+	return c:IsFaceup() and (c:IsCode(70095154) or c:IsSetCard(0x103)) and c:GetUnionCount()==0
 end
 function c67159705.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c67159705.filter(chkc) end


### PR DESCRIPTION
50074392 霊水鳥シレーヌ・オルカ
Now the activation limit only works on monster effects.

67159705 アーマード·サイバーン
Effect taken from Konami database:
１ターンに１度、自分のメインフェイズ時に装備カード扱いとして自分の「サイバー・ドラゴン」及び「サイバー・ドラゴン」が記されている融合モンスターに装備、または装備を解除して表側攻撃表示で特殊召喚できる。１ターンに１度、この効果でこのカードを装備したモンスターの攻撃力を１０００ポイントダウンし、フィールド上に表側表示で存在するモンスター１体を選択して破壊できる。（１体のモンスターが装備できるユニオンは１枚まで。装備モンスターが破壊される場合、代わりにこのカードを破壊する。）

The targets has 2 categorys:
I. 「サイバー・ドラゴン」
which contains all cards with card name "Cyber Dragon", 
including cards that change their code into 70095154 サイバー・ドラゴン such as 23893227 サイバー・ドラゴン・コア.

II. 「サイバー・ドラゴン」が記されている融合モンスター
which contains all fusion monster that has Cyber Dragon in the material list.
cards.cdb uses setcode 0x103 to recognize theses cards.

So the target filter should be (card_name==70095154 or setcode==0x103),
and in cards.cdb 70095154 Cyber Dragon only needs setcode 0x1093(Cyber Dragon)
