### PR TITLE
fix

### DIFF
--- a/script/c50074392.lua
+++ b/script/c50074392.lua
@@ -63,5 +63,5 @@ function c50074392.lvop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e2,tp)
 end
 function c50074392.actfilter(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() and not c:IsAttribute(ATTRIBUTE_WATER)
+	return c:GetControler()==e:GetHandlerPlayer() and c:IsType(TYPE_MONSTER) and not c:IsAttribute(ATTRIBUTE_WATER)
 end


### PR DESCRIPTION
50074392 霊水鳥シレーヌ・オルカ
Now the activation limit only works on monster effects.
