### PR TITLE
fix

### DIFF
--- a/script/c36261276.lua
+++ b/script/c36261276.lua
@@ -22,7 +22,7 @@ function c36261276.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c36261276.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() and Duel.Remove(tc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) and Duel.Remove(tc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_PHASE+PHASE_END)


### PR DESCRIPTION
36261276 亜空間物質転送装置
If the control of target monster is changed while resolving the effect, it will not be removed.
ref.
Ｑ：このカードの発動にチェーンして《ＴＧ１－ＥＭ１》を発動され、このカードの対象となったモンスターとＴＧと名のつくモンスターを対象に指定されました。この場合、どのように処理すればよいのでしょうか？
Ａ：このカードの効果処理を行う際に、対象のモンスターのコントロールが移っていた場合、除外は行いません。(11/05/04)
