### PR TITLE
Update c28388296.lua

### DIFF
--- a/script/c28388296.lua
+++ b/script/c28388296.lua
@@ -33,7 +33,7 @@ function c28388296.initial_effect(c)
 end
 function c28388296.cfilter(c,tp)
 	return c:IsSetCard(0x24) and c:IsType(TYPE_MONSTER) and bit.band(c:GetReason(),0x41)==0x41
-		and c:GetPreviousControler()==tp and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
+		and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
 end
 function c28388296.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c28388296.cfilter,1,nil,tp)


### PR DESCRIPTION
场上表侧表示存在的名字带有「废铁」的怪兽被卡的效果破坏送去墓地时
不限制于自己场上
