### PR TITLE
fix

### DIFF
--- a/script/c20563387.lua
+++ b/script/c20563387.lua
@@ -31,7 +31,7 @@ function c20563387.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ)
 end
 function c20563387.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c20563387.filter(chkc) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c20563387.filter(chkc) and chkc~=e:GetHandler() end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
 		and Duel.IsExistingTarget(c20563387.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)

--- a/script/c33846209.lua
+++ b/script/c33846209.lua
@@ -33,7 +33,7 @@ function c33846209.tgfilter(c,e)
 	return c:IsDestructable() and c:IsCanBeEffectTarget(e)
 end
 function c33846209.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() and chkc:IsDestructable() end
+	if chkc then return chkc:IsOnField() and chkc:IsDestructable() and chkc~=e:GetHandler() end
 	if chk==0 then
 		if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return false end
 		if e:GetLabel()==1 then

--- a/script/c5318639.lua
+++ b/script/c5318639.lua
@@ -15,7 +15,7 @@ function c5318639.filter(c)
 	return c:IsDestructable() and c:IsType(TYPE_SPELL+TYPE_TRAP)
 end
 function c5318639.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() and c5318639.filter(chkc) end
+	if chkc then return chkc:IsOnField() and c5318639.filter(chkc) and chkc~=e:GetHandler() end
 	if chk==0 then return Duel.IsExistingTarget(c5318639.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,c5318639.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler())

--- a/script/c57734012.lua
+++ b/script/c57734012.lua
@@ -19,7 +19,7 @@ end
 function c57734012.regcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return Duel.GetFlagEffect(tp,57734012)==0 and Duel.GetCurrentPhase()==PHASE_DRAW
-		and c:IsReason(REASON_DRAW) and c:IsReason(REASON_RULE) and not c:IsPublic()
+		and c:IsReason(REASON_DRAW) and c:IsReason(REASON_RULE)
 end
 function c57734012.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -49,10 +49,9 @@ function c57734012.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		and Duel.GetFlagEffect(tp,57734012)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c57734012.filter1,tp,LOCATION_GRAVE+LOCATION_EXTRA,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE+LOCATION_EXTRA)
-	Duel.RegisterFlagEffect(tp,57734012,0,0,0)
+	Duel.RegisterFlagEffect(tp,57734012,0,EFFECT_FLAG_OATH,0)
 end
 function c57734012.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.IsPlayerAffectedByEffect(tp,23516703) and c23516703[tp]>0 then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g1=Duel.SelectMatchingCard(tp,c57734012.filter1,tp,LOCATION_GRAVE+LOCATION_EXTRA,0,1,1,nil,e,tp)

--- a/script/c61314842.lua
+++ b/script/c61314842.lua
@@ -44,7 +44,6 @@ function c61314842.filter2(c,e,tp)
 	return c:IsRelateToEffect(e) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c61314842.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.IsPlayerAffectedByEffect(tp,23516703) and c23516703[tp]>0 then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c61314842.filter2,nil,e,tp)
 	if g:GetCount()<2 then return end

--- a/script/c63227401.lua
+++ b/script/c63227401.lua
@@ -25,7 +25,7 @@ function c63227401.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c63227401.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() and chkc:IsControler(tp) end
+	if chkc then return chkc:IsOnField() and chkc:IsControler(tp) and chkc~=e:GetHandler() end
 	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_ONFIELD,0,1,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	Duel.SelectTarget(tp,nil,tp,LOCATION_ONFIELD,0,1,1,e:GetHandler())

--- a/script/c93568288.lua
+++ b/script/c93568288.lua
@@ -30,7 +30,7 @@ function c93568288.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ)
 end
 function c93568288.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c93568288.filter(chkc) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c93568288.filter(chkc) and chkc~=e:GetHandler() end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
 		and Duel.IsExistingTarget(c93568288.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)


### PR DESCRIPTION
c63227401 スキル・プリズナー
Now it cannot target itself.
The chks check is changed into correct condition.

c61314842 高等紋章術
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12510&keyword=&tag=-1
Sp_summon of the first part can work normally if サモンリミッター is activated in chain.

c57734012 RUM－七皇の剣
http://yugioh-wiki.net/?%A1%D4%A3%D2%A3%D5%A3%CD%A1%DD%BC%B7%B9%C4%A4%CE%B7%F5%A1%D5
Ｑ：フィールド上に《クリアー・ワールド》が存在し、自分フィールド上に光属性モンスターが存在します。
この時、通常のドローで《ＲＵＭ－七皇の剣》をドローした場合、《ＲＵＭ－七皇の剣》を発動はできますか？
Ａ：ご質問の状況の場合でも、《ＲＵＭ－七皇の剣》は通常通り発動する事ができます。(14/02/19)

Ｑ：《正々堂々》などの効果によって手札が公開されている場合も発動できますか？
Ａ：はい、その場合でも発動できます。(14/02/19)

Ｑ：このカードの発動が無効にされた場合、発動条件を満たした２枚目のこのカードを発動することはできますか？また、発動できる場合、効果を適用することはできますか？
Ａ：その状況においても、２枚目のこのカードを発動することができ、効果も適用できます。(14/02/17)
1. Sp_summon of the first part can work normally if サモンリミッター is activated in chain.
2. If the activation is negated, the player can activated a second one, so the flag_effect is changed into EFFECT_FLAG_OATH.
3. The "show this card" part is not a cost, so this card can be activated normally if it is already public.

c63227401 スキル・プリズナー
c5318639 サイクロン
c33846209 デュアルスパーク
c93568288 No.80 狂装覇王ラプソディ・イン・バーサーク
c20563387 CNo.80 葬装覇王レクイエム・イン・バーサーク
http://yugioh-wiki.net/index.php?%A1%D4%B0%C5%C1%AB%BB%CE%20%A5%AB%A5%F3%A5%B4%A5%EB%A5%B4%A1%BC%A5%E0%A1%D5
《暗遷士 カンゴルゴーム》
Ｑ：相手が《サイクロン》を発動した時、その《サイクロン》自身を対象に変更できますか？
Ａ：いいえ、できません。(14/02/15)
These card cannot target themselves, even if their effects are shifted by other effect.
