### PR TITLE
fix

### DIFF
--- a/script/c43455065.lua
+++ b/script/c43455065.lua
@@ -16,7 +16,7 @@ function c43455065.filter(c)
 end
 function c43455065.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=Duel.GetMatchingGroupCount(c43455065.filter,tp,0,LOCATION_ONFIELD,nil)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp,ct) end
+	if chk==0 then return ct>0 and Duel.IsPlayerCanDraw(tp,ct) end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetTargetParam(ct)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,ct)

--- a/script/c69757518.lua
+++ b/script/c69757518.lua
@@ -38,16 +38,20 @@ function c69757518.atkval(e,c)
 end
 function c69757518.atcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return Duel.GetAttacker()==c and c:IsChainAttackable()
+	return Duel.GetAttacker()==c and Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)~=0
 end
 function c69757518.atcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c69757518.atop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetHandler():IsRelateToBattle() and e:GetHandler():IsChainAttackable(2,true) then
-		Duel.ChainAttack()
-	end
+	Duel.ChainAttack()
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_CANNOT_DIRECT_ATTACK)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+	e:GetHandler():RegisterEffect(e1)
 end
 function c69757518.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/script/c85771019.lua
+++ b/script/c85771019.lua
@@ -53,7 +53,7 @@ function c85771019.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,0,0)
 end
 function c85771019.spop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,85771020,0,0x4011,1800,1300,5,RACE_FAIRY,ATTRIBUTE_DARK) then
 		local token=Duel.CreateToken(tp,85771020)
 		Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP)

--- a/script/c9047460.lua
+++ b/script/c9047460.lua
@@ -24,7 +24,7 @@ function c9047460.initial_effect(c)
 end
 function c9047460.tkcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:IsFaceup() and c:GetLocation()~=LOCATION_DECK
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetLocation()~=LOCATION_DECK
 end
 function c9047460.tktg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
c43455065 魔力の泉
This card can be activated only if the opponent has at least 1 s/t card. (According to Konami database)

c9047460 BF－隠れ蓑のスチーム
The 1st effect can be activated onlt if previous position is POS_FACEUP.

c85771019 堕天使アスモディウス
The 2 tokens are generated at the same time, so the player must have at least 2 slots to sp_summon these tokens.

c69757518 CNo.5 亡朧龍カオス・キマイラ・ドラゴン
http://yugioh-wiki.net/index.php?%A1%D4%A3%C3%A3%CE%A3%EF.%A3%B5%20%CB%B4%DB%B0%CE%B6%20%A5%AB%A5%AA%A5%B9%A1%A6%A5%AD%A5%DE%A5%A4%A5%E9%A1%A6%A5%C9%A5%E9%A5%B4%A5%F3%A1%D5
The chain attack does not have count limit, and the target is restricted to monsters.
