### PR TITLE
fix

### DIFF
--- a/script/c63504681.lua
+++ b/script/c63504681.lua
@@ -41,7 +41,7 @@ function c63504681.initial_effect(c)
 	e5:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e5:SetRange(LOCATION_MZONE)
 	e5:SetCode(EFFECT_IMMUNE_EFFECT)
-	e5:SetValue(1)
+	e5:SetValue(c63504681.efilter)
 	e5:SetCondition(c63504681.effcon)
 	e5:SetLabel(3)
 	c:RegisterEffect(e5)
@@ -83,6 +83,9 @@ function c63504681.rmop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c63504681.effcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetOverlayCount()>=e:GetLabel()
+end
+function c63504681.efilter(e,te)
+	return te:GetHandler()~=e:GetHandler()
 end
 function c63504681.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDestructable,tp,0,LOCATION_ONFIELD,1,nil) end


### PR DESCRIPTION
Ｑ：《Ｈ・Ｃ エクストラ・ソード》を含めた３体をエクシーズ素材にしてこのモンスターをエクシーズ召喚しました。
　　この場合「●３つ以上：」の効果が適用されているこのモンスターに、《Ｈ・Ｃ エクストラ・ソード》の『●』の効果は適用されますか？
Ａ：《Ｈ・Ｃ エクストラ・ソード》の『●』の効果は、《Ｈ・Ｃ エクストラ・ソード》をエクシーズ素材とした、《Ｎｏ.８６ Ｈ−Ｃ ロンゴミアント》自身が受ける効果となります。
　　したがって、《Ｎｏ.８６ Ｈ−Ｃ ロンゴミアント》の攻撃力は1000アップします。(14/05/03)