### PR TITLE
Update c18205590.lua

### DIFF
--- a/script/c18205590.lua
+++ b/script/c18205590.lua
@@ -30,12 +30,15 @@ end
 function c18205590.operation(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) or tc:IsFacedown() then return end
+	local code=tc:GetCode()
+	if not tc:IsRelateToEffect(e) or tc:IsFacedown() then code=0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c18205590.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp,tc:GetCode())
+	local g=Duel.SelectMatchingCard(tp,c18205590.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp,code)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
-		Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)
+		if code~=0 then
+			Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)
+		end
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD)
 		e1:SetRange(LOCATION_MZONE)


### PR DESCRIPTION
◇效果处理时对象怪物里侧表示存在于场上甚至不存在于场上的话，仍然进行特殊召唤，不进行返回卡组的处理。限制自己特殊召唤的效果依然适用。
