### PR TITLE
Update c13959634.lua

### DIFF
--- a/script/c13959634.lua
+++ b/script/c13959634.lua
@@ -49,7 +49,7 @@ function c13959634.leaveop(e,tp,eg,ep,ev,re,r,rp)
 	local effp=e:GetHandler():GetPreviousControler()
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SKIP_BP)
+	e1:SetCode(EFFECT_CANNOT_BP)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetTargetRange(1,0)
 	if Duel.GetTurnPlayer()==effp then


### PR DESCRIPTION
Fix: Now cannot enter Bp of the skipped turn. (Old Script allowed you to enter and then go to Main Phase 2)