### PR TITLE
Update c2356994.lua

### DIFF
--- a/script/c2356994.lua
+++ b/script/c2356994.lua
@@ -31,7 +31,7 @@ end
 function c2356994.skipop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SKIP_BP)
+	e1:SetCode(EFFECT_CANNOT_BP)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetTargetRange(0,1)
 	if Duel.GetTurnPlayer()~=tp then


### PR DESCRIPTION
Fix: Now cannot enter Bp of the skipped turn. (Old Script allowed you to enter and then go to Main Phase 2)