### PR TITLE
fix: hand sp_summon

### DIFF
--- a/script/c38667773.lua
+++ b/script/c38667773.lua
@@ -32,5 +32,11 @@ function c38667773.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,c38667773.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	elseif not Duel.IsPlayerAffectedByEffect(tp,EFFECT_CANNOT_SPECIAL_SUMMON) then
+		local hg=Duel.GetFieldGroup(tp,LOCATION_HAND,0)
+		if hg:GetCount()>0 then 
+			Duel.ConfirmCards(1-tp,hg)
+			Duel.ShuffleHand(tp)
+		end
 	end
 end

--- a/script/c440556.lua
+++ b/script/c440556.lua
@@ -40,9 +40,9 @@ function c440556.spop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		c:RegisterEffect(e1)
-	else
+	elseif not Duel.IsPlayerAffectedByEffect(tp,EFFECT_CANNOT_SPECIAL_SUMMON) then
 		local cg=Duel.GetFieldGroup(tp,LOCATION_EXTRA,0)
-		if cg and cg:GetCount()>0 then
+		if cg:GetCount()>0 then
 			Duel.ConfirmCards(1-tp,cg)
 		end
 	end

--- a/script/c60080151.lua
+++ b/script/c60080151.lua
@@ -16,14 +16,13 @@ end
 function c60080151.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tg=Duel.GetAttacker()
 	if chk==0 then return tg:IsOnField() and tg:IsAbleToRemove() end
-	Duel.SetTargetCard(tg)
 	local dam=tg:GetAttack()
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,tp,dam)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,tg,1,0,0)
 end
 function c60080151.activate(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	local tc=Duel.GetAttacker()
+	if tc and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED) then
 		local dam=tc:GetAttack()
 		if Duel.Damage(tp,dam,REASON_EFFECT)>0 and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)>0 then
 			local e1=Effect.CreateEffect(e:GetHandler())

--- a/script/c8875971.lua
+++ b/script/c8875971.lua
@@ -25,5 +25,11 @@ function c8875971.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,c8875971.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	elseif not Duel.IsPlayerAffectedByEffect(tp,EFFECT_CANNOT_SPECIAL_SUMMON) then
+		local hg=Duel.GetFieldGroup(tp,LOCATION_HAND,0)
+		if hg:GetCount()>0 then 
+			Duel.ConfirmCards(1-tp,hg)
+			Duel.ShuffleHand(tp)
+		end
 	end
 end


### PR DESCRIPTION
c38667773 星因士 ベガ
c8875971 光天使ウィングス
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9065&keyword=&tag=-1
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8653&keyword=&tag=-1
If there are no sp_summonable monsters in the player's  hand while resolving the effect, the opponent can check the hand.
The confirm will not be applied if the player cannot sp_summon while resolving the effect.

c440556 バハムート·シャーク
The confirm will not be applied if the player cannot sp_summon while resolving the effect.

c60080151 好敵手の記憶
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10297
It is not an target effect, so the attacker should be determined while resolving the effect.
The condition is changed in order to match the text "自分は攻撃モンスターの攻撃力分のダメージを受け".
