### PR TITLE
Update c60202749.lua

### DIFF
--- a/script/c60202749.lua
+++ b/script/c60202749.lua
@@ -33,7 +33,7 @@ function c60202749.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		and Duel.IsExistingMatchingCard(c60202749.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_NO_TURN_RESET)
 	e1:SetCode(EVENT_PHASE+PHASE_END)
 	e1:SetRange(LOCATION_SZONE)
 	e1:SetCountLimit(1)


### PR DESCRIPTION
Fix: If Abyss-Sphere is not destroyed during the next Opponents End Phase, e.g. Imperial Custom, it will no longer try to destroy itself in each subsequent End Phase.
