### PR TITLE
Update c51543904.lua

### DIFF
--- a/script/c51543904.lua
+++ b/script/c51543904.lua
@@ -33,10 +33,9 @@ function c51543904.cfilter(c)
 	return c:IsSetCard(0x95) and c:IsType(TYPE_SPELL) and c:IsDiscardable()
 end
 function c51543904.ovfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x7f)
+	return c:IsFaceup() and c:IsSetCard(0x7f) and Duel.IsExistingMatchingCard(c51543904.cfilter,tp,LOCATION_HAND,0,1,nil)
 end
 function c51543904.xyzop(e,tp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c51543904.cfilter,tp,LOCATION_HAND,0,1,nil) end
 	Duel.DiscardHand(tp,c51543904.cfilter,1,1,REASON_COST+REASON_DISCARD)
 end
 function c51543904.filter(c,e,tp)


### PR DESCRIPTION
修正可以在手牌无“升阶魔法”的情况下用第二方法超量召唤No.99 希望皇龍ホープドラグーン
