### PR TITLE
Update c90075978.lua

### DIFF
--- a/script/c90075978.lua
+++ b/script/c90075978.lua
@@ -43,6 +43,7 @@ function c90075978.setop(e,tp,eg,ep,ev,re,r,rp)
 		if dt==0 or Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 		local sg=Duel.GetMatchingGroup(c90075978.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
 		if sg:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(90075978,0)) then
+			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 			Duel.SpecialSummon(sg:Select(tp,1,1,nil),0,tp,tp,false,false,POS_FACEUP)
 		end


### PR DESCRIPTION
--W星雲隕石
Ｑ：エンドフェイズの３つの効果の処理は同時に行いますか？
Ａ：いいえ、同時ではありません。
　　まず、裏側守備表示にする効果、次にドローする効果の処理を行います。
　　更に、デッキから特殊召喚する処理を適用する場合は、特殊召喚の効果処理を最後に行います。(11/02/17)
