### PR TITLE
fix

### DIFF
--- a/script/c31077447.lua
+++ b/script/c31077447.lua
@@ -32,7 +32,7 @@ function c31077447.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)
 		e1:SetValue(-val)
-		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
 		tc:RegisterEffect(e1)
 	end
 end

--- a/script/c44256816.lua
+++ b/script/c44256816.lua
@@ -7,6 +7,7 @@ function c44256816.initial_effect(c)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCountLimit(1,44256816+EFFECT_COUNT_CODE_OATH)
 	e1:SetCost(c44256816.cost)
+	e1:SetCondition(c44256816.con)
 	e1:SetTarget(c44256816.target)
 	e1:SetOperation(c44256816.activate)
 	c:RegisterEffect(e1)
@@ -31,6 +32,9 @@ function c44256816.checkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 	if p1 then Duel.RegisterFlagEffect(0,44256816,RESET_PHASE+PHASE_END,0,1) end
 	if p2 then Duel.RegisterFlagEffect(1,44256816,RESET_PHASE+PHASE_END,0,1) end
+end
+function c44256816.con(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0
 end
 function c44256816.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFlagEffect(tp,44256816)==0 end

--- a/script/c65305468.lua
+++ b/script/c65305468.lua
@@ -11,13 +11,6 @@ function c65305468.initial_effect(c)
 	e1:SetOperation(c65305468.xyzop)
 	e1:SetValue(SUMMON_TYPE_XYZ)
 	c:RegisterEffect(e1)
-	--rank
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e2:SetCode(EFFECT_CHANGE_RANK)
-	e2:SetValue(1)
-	c:RegisterEffect(e2)
 	--indes
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)

--- a/script/c66127916.lua
+++ b/script/c66127916.lua
@@ -33,8 +33,9 @@ function c66127916.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectMatchingCard(tp,c66127916.filter2,tp,LOCATION_DECK,0,1,1,nil,cg:GetFirst())
 	if g:GetCount()>0 then
-		Duel.SendtoGrave(g,REASON_EFFECT)
-		local tc=Duel.GetFirstMatchingCard(c66127916.filter3,tp,LOCATION_DECK,0,nil)
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+		local tc=Duel.GetFirstMatchingCard(c66127916.filter3,tp,LOCATION_GRAVE,0,nil)
 		if tc and Duel.SelectYesNo(tp,aux.Stringid(66127916,0)) then
 			Duel.SendtoHand(tc,nil,REASON_EFFECT)
 			Duel.ConfirmCards(1-tp,tc)

--- a/script/c67249508.lua
+++ b/script/c67249508.lua
@@ -18,7 +18,7 @@ function c67249508.condition(e,tp,eg,ep,ev,re,r,rp)
 end
 function c67249508.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local tc=Duel.GetAttackTarget()
+	local tc=e:GetLabelObject()
 	if tc:IsRelateToBattle() then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
c44256816 独奏の第1楽章
Condition is added.

c65305468 FNo.0 未来皇ホープ
The rank 1 statemnet is not a part of its effect, so it is a rank 1 xyz monster.
It should be rank 1 in cards.cdb since its original rank is 1, and this effect is not needed.

c66127916 融合準備
Now it can send the monster to hand and get 融合 from grave.

c67249508 竜星の凶暴化
Now the atk changing effect has correct target.

c31077447 びっくり箱
Now the atk decreasing effect is permanant.
