### PR TITLE
Update c90885155.lua

### DIFF
--- a/script/c90885155.lua
+++ b/script/c90885155.lua
@@ -10,152 +10,130 @@ function c90885155.initial_effect(c)
 	--splimit
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetRange(LOCATION_SZONE)
 	e2:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
 	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_CANNOT_DISABLE)
-	e2:SetRange(LOCATION_SZONE)
 	e2:SetTargetRange(1,0)
-	e2:SetCondition(c90885155.pendcon)
+	e2:SetCondition(c90885155.con)
 	e2:SetTarget(c90885155.splimit)
 	c:RegisterEffect(e2)
-	--atk down
+	--atk
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetRange(LOCATION_SZONE)
 	e3:SetCode(EFFECT_UPDATE_ATTACK)
+	e3:SetRange(LOCATION_SZONE)
 	e3:SetTargetRange(0,LOCATION_MZONE)
-	e3:SetCondition(c90885155.pendcon)
+	e3:SetCondition(c90885155.con)
 	e3:SetValue(-300)
-	c:RegisterEffect(e3)
+	c:RegisterEffect(e3)	
 	--summon with no tribute
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(90885155,0))
-	e4:SetType(EFFECT_TYPE_SINGLE)
 	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e4:SetType(EFFECT_TYPE_SINGLE)
 	e4:SetCode(EFFECT_SUMMON_PROC)
 	e4:SetCondition(c90885155.ntcon)
 	c:RegisterEffect(e4)
-	--change level
+	--act limit
 	local e5=Effect.CreateEffect(c)
-	e5:SetType(EFFECT_TYPE_SINGLE)
-	e5:SetCode(EFFECT_SUMMON_COST)
-	e5:SetOperation(c90885155.lvop)
+	e5:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e5:SetCode(EVENT_SUMMON_SUCCESS)
+	e5:SetOperation(c90885155.regop)
 	c:RegisterEffect(e5)
-	local e6=Effect.CreateEffect(c)
-	e6:SetType(EFFECT_TYPE_SINGLE)
-	e6:SetCode(EFFECT_SPSUMMON_COST)
-	e6:SetOperation(c90885155.lvop2)
+	local e6=e5:Clone()
+	e6:SetCode(EVENT_SPSUMMON_SUCCESS)
 	c:RegisterEffect(e6)
-	--immune
-	local e7=Effect.CreateEffect(c)
-	e7:SetType(EFFECT_TYPE_SINGLE)
-	e7:SetCode(EFFECT_IMMUNE_EFFECT)
-	e7:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
-	e7:SetRange(LOCATION_MZONE)
-	e7:SetCondition(c90885155.immcon)
-	e7:SetValue(c90885155.efilter)
-	c:RegisterEffect(e7)
-	--effect
+	--mat check
 	local e8=Effect.CreateEffect(c)
-	e8:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e8:SetCode(EVENT_SUMMON_SUCCESS)
-	e8:SetCondition(c90885155.effcon)
-	e8:SetOperation(c90885155.effop)
+	e8:SetType(EFFECT_TYPE_SINGLE)
+	e8:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e8:SetCode(EFFECT_MATERIAL_CHECK)
+	e8:SetValue(c90885155.valcheck)
 	c:RegisterEffect(e8)
-	--tribute check
+	--summon success
 	local e9=Effect.CreateEffect(c)
-	e9:SetType(EFFECT_TYPE_SINGLE)
-	e9:SetCode(EFFECT_MATERIAL_CHECK)
-	e9:SetValue(c90885155.valcheck)
-	e9:SetLabelObject(e8)
+	e9:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e9:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e9:SetCode(EVENT_SUMMON_SUCCESS)
+	e9:SetCondition(c90885155.effcon)
+	e9:SetOperation(c90885155.effop)
 	c:RegisterEffect(e9)
+	e9:SetLabelObject(e8)
 end
-function c90885155.pendcon(e)
-	return e:GetHandler():GetSequence()==6 or e:GetHandler():GetSequence()==7
+function c90885155.con(e,tp,eg,ep,ev,re,r,rp)
+	local seq=e:GetHandler():GetSequence()
+	return seq==6 or seq==7
 end
-function c90885155.splimit(e,c)
+function c90885155.splimit(e,c,tp,sumtp,sumpos)
 	return not c:IsSetCard(0xaa)
 end
 function c90885155.ntcon(e,c)
 	if c==nil then return true end
 	return c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
-function c90885155.lvcon(e)
-	return e:GetHandler():GetMaterialCount()==0
-end
-function c90885155.lvop(e,tp,eg,ep,ev,re,r,rp)
+function c90885155.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetCode(EFFECT_CHANGE_LEVEL)
-	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetCondition(c90885155.lvcon)
-	e1:SetValue(4)
-	e1:SetReset(RESET_EVENT+0xff0000)
-	c:RegisterEffect(e1)
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_SET_BASE_ATTACK)
-	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
-	e2:SetRange(LOCATION_MZONE)
-	e2:SetCondition(c90885155.lvcon)
-	e2:SetValue(1800)
-	e2:SetReset(RESET_EVENT+0xff0000)
-	c:RegisterEffect(e2)
-end
-function c90885155.lvop2(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetCode(EFFECT_CHANGE_LEVEL)
-	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetValue(4)
-	e1:SetReset(RESET_EVENT+0xff0000)
-	c:RegisterEffect(e1)
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_SET_BASE_ATTACK)
-	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
-	e2:SetRange(LOCATION_MZONE)
-	e2:SetValue(1800)
-	e2:SetReset(RESET_EVENT+0xff0000)
-	c:RegisterEffect(e2)
-end
-function c90885155.immcon(e)
-	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_NORMAL)==SUMMON_TYPE_NORMAL
+	if bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_NORMAL)==SUMMON_TYPE_NORMAL then 
+		--immune 	
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetCode(EFFECT_IMMUNE_EFFECT)
+		e1:SetReset(RESET_EVENT+0x5ee0000)
+		e1:SetValue(c90885155.efilter)
+		c:RegisterEffect(e1)
+		if c:GetSummonType()==SUMMON_TYPE_ADVANCE then return end
+	end
+	--search
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetReset(RESET_EVENT+0x1ff0000)
+	e5:SetCode(EFFECT_CHANGE_LEVEL)
+	e5:SetValue(4)
+	c:RegisterEffect(e5)
+	--search
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE)
+	e6:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e6:SetRange(LOCATION_MZONE)
+	e6:SetReset(RESET_EVENT+0x1ff0000)
+	e6:SetCode(EFFECT_SET_BASE_ATTACK)
+	e6:SetValue(1800)
+	c:RegisterEffect(e6)
 end
 function c90885155.efilter(e,te)
-	if not te:IsActiveType(TYPE_MONSTER) or not te:IsHasType(0x7e0) then return false end
-	local tc=te:GetHandler()
 	local lv=e:GetHandler():GetLevel()
-	if te:IsActiveType(TYPE_XYZ) then
-		return tc:GetOriginalRank()<lv
-	end
-	return tc:GetOriginalLevel()<lv
+	return te:IsActiveType(TYPE_MONSTER) 
+		and te:IsHasType(EFFECT_TYPE_ACTIONS) 
+		and (te:GetHandler():GetOriginalLevel()<lv or te:GetHandler():GetOriginalLevel()<lv)
+end
+function c90885155.valcheck(e,c)
+	local g=c:GetMaterial()
+	local flag=0
+	if g:IsExists(Card.IsSetCard,1,nil,0xaa) then flag=1 end
+	e:SetLabel(flag)
 end
 function c90885155.effcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetSummonType()==SUMMON_TYPE_ADVANCE and e:GetLabel()==1
+	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_ADVANCE)==SUMMON_TYPE_ADVANCE
+		and e:GetLabelObject():GetLabel()~=0
 end
 function c90885155.effop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
+	--extra att
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_EXTRA_ATTACK)
 	e1:SetValue(1)
-	e1:SetReset(RESET_EVENT+0x1ff0000)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
 	c:RegisterEffect(e1)
+	--pierce
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_PIERCE)
-	e2:SetReset(RESET_EVENT+0x1ff0000)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
 	c:RegisterEffect(e2)
-end
-function c90885155.valcheck(e,c)
-	local g=c:GetMaterial()
-	if g:IsExists(Card.IsSetCard,1,nil,0xaa) then
-		e:GetLabelObject():SetLabel(1)
-	else
-		e:GetLabelObject():SetLabel(0)
-	end
 end


### PR DESCRIPTION
③：通常召唤的这张卡不受原本的等级或者阶级比这张卡的等级低的怪兽发动的效果影响。
◇通常召唤的这张卡变成过裹侧表示再翻开，这个效果不适用(14/07/19)
◇效果被《禁じられた聖杯/禁忌的圣杯》无效过的场合，回合结束后效果再度适用(14/07/19)
