### PR TITLE
Update c64496451.lua

### DIFF
--- a/script/c64496451.lua
+++ b/script/c64496451.lua
@@ -127,7 +127,7 @@ function c64496451.immop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCode(EFFECT_IMMUNE_EFFECT)
 	e1:SetValue(c64496451.efilter)
-	e1:SetReset(RESET_EVENT+0x1fe0000)
+	e1:SetReset(RESET_EVENT+0xfc0000)
 	c:RegisterEffect(e1)
 end
 function c64496451.efilter(e,te)


### PR DESCRIPTION
③：通常召唤的这张卡不受原本的等级或者阶级比这张卡的等级低的怪兽发动的效果影响。
◇这个效果适用后，如果此卡被其他卡的效果变成里侧表示后再变回表侧表示，这个效果会再次适用。
