### PR TITLE
Update c27279764.lua

### DIFF
--- a/script/c27279764.lua
+++ b/script/c27279764.lua
@@ -73,7 +73,7 @@ function c27279764.immop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCode(EFFECT_IMMUNE_EFFECT)
 	e1:SetValue(c27279764.efilter)
-	e1:SetReset(RESET_EVENT+0x1fe0000)
+	e1:SetReset(RESET_EVENT+0xfc0000)
 	c:RegisterEffect(e1)
 end
 function c27279764.efilter(e,te)


### PR DESCRIPTION
①：通常召唤的这张卡不受魔法·陷阱卡的效果影响，也不受原本的等级或者阶级比这张卡的等级低的怪兽发动的效果影响。
◇这个效果适用后，如果此卡被其他卡的效果变成里侧表示后再变回表侧表示，这个效果会再次适用。
