### PR TITLE
Update processor.cpp

### DIFF
--- a/ocgcore/processor.cpp
+++ b/ocgcore/processor.cpp
@@ -1797,7 +1797,7 @@ int32 field::process_point_event(int16 step, int32 special, int32 skip_new) {
 		}
 		for (auto clit = core.new_ochain_s.begin(); clit != core.new_ochain_s.end(); ++clit) {
 			effect* peffect = clit->triggering_effect;
-			if((!(peffect->flag & (EFFECT_FLAG_EVENT_PLAYER | EFFECT_FLAG_BOTH_SIDE)) && peffect->handler->is_has_relation(peffect))
+			if((!(peffect->flag & (EFFECT_FLAG_EVENT_PLAYER | EFFECT_FLAG_BOTH_SIDE)) && peffect->handler->is_has_relation(peffect) && !peffect->type & EFFECT_TYPE_FLIP)
 			        || (!(peffect->flag & EFFECT_FLAG_FIELD_ONLY) && (peffect->type & EFFECT_TYPE_FIELD)
 			            && (peffect->range & LOCATION_HAND) && peffect->handler->current.location == LOCATION_HAND)) {
 				if(!peffect->handler->is_has_relation(peffect))


### PR DESCRIPTION
Ｑ：《強制転移》にチェーンして《砂漠の光》を発動しました。
　　リバースしたシャドールモンスターのコントロールを移した場合、「リバースした場合」の効果はどちらのプレイヤーが発動できますか？
Ａ：《砂漠の光》で表側表示にしたプレイヤーが発動できます。(14/06/20)

http://yugioh-wiki.net/index.php?cmd=read&page=%A5%B7%A5%E3%A5%C9%A1%BC%A5%EB&word=%20%A5%B7%A5%E3%A5%C9%A1%BC%A5%EB%A1%A6%A5%D3%A1%BC%A5%B9%A5%C8
