### PR TITLE
Update c42776960.lua

### DIFF
--- a/script/c42776960.lua
+++ b/script/c42776960.lua
@@ -38,7 +38,7 @@ function c42776960.activate(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetCode(EVENT_LEAVE_FIELD)
 		e2:SetLabel(1-tp)
 		e2:SetOperation(c42776960.leaveop)
-		e2:SetReset(RESET_EVENT+RESET_OVERLAY)
+		e2:SetReset(RESET_EVENT+RESET_OVERLAY+0x47e0000)
 		tc:RegisterEffect(e2)
 	end
 end


### PR DESCRIPTION
Fix: Will no longer cause you to lose if the monster is flipped face-down and destroyed or flipped face-down and then back up and then destroyed.