### PR TITLE
fix-SPTR

### DIFF
--- a/script/c28630501.lua
+++ b/script/c28630501.lua
@@ -82,7 +82,7 @@ function c28630501.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c28630501.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and c:IsFaceup() then
+	if c:IsRelateToEffect(e) then
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 	end
 end

--- a/script/c39853199.lua
+++ b/script/c39853199.lua
@@ -74,7 +74,7 @@ function c39853199.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c39853199.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and c:IsFaceup() then
+	if c:IsRelateToEffect(e) then
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 	end
 end

--- a/script/c65247798.lua
+++ b/script/c65247798.lua
@@ -85,7 +85,7 @@ function c65247798.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c65247798.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and c:IsFaceup() then
+	if c:IsRelateToEffect(e) then
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 	end
 end

--- a/script/c92246806.lua
+++ b/script/c92246806.lua
@@ -71,7 +71,7 @@ function c92246806.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c92246806.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and c:IsFaceup() then
+	if c:IsRelateToEffect(e) then
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 	end
 end

--- a/script/c93368494.lua
+++ b/script/c93368494.lua
@@ -102,7 +102,7 @@ function c93368494.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c93368494.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and c:IsFaceup() then
+	if c:IsRelateToEffect(e) then
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
妖仙獣
回到手牌的效果處理時怪獸變成裡測一樣會處理此效果
If the monster is face-down while resolving the effect, it should return to hand as normal.

Rer.
Q.
自分のエンドフェイズ
チェーン１：魔妖仙獣 大刃禍是 (3)
チェーン２：月の書（対象：魔妖仙獣 大刃禍是)
魔妖仙獣 大刃禍是の(3)の効果処理について、詳しく教えて下さい。
Q.
自分のエンドフェイズ
チェーン１：阿修羅(持ち主の手札に戻る)
チェーン２：月の書（対象：阿修羅)
阿修羅の効果処理について、詳しく教えて下さい。
A.
ご質問のどちらの場合でも、手札に戻る効果を発動していたモンスターは、通常通り手札に戻ります。
