### PR TITLE
fixed EFFECT_EXTRA_RELEASE_SUM and double tribute

### DIFF
--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -4212,7 +4212,9 @@ int32 field::select_tribute_cards(int16 step, uint8 playerid, uint8 cancelable, 
 			rmax += (*cit)->operation_param;
 		core.temp_var[0] = 0;
 		if(rmax < min)
-			returns.ivalue[0] = TRUE;
+			returns.ivalue[0] = TRUE;	
+			if(min == 2)
+				core.temp_var[0] = 1;
 		else if(!core.release_cards_ex_sum.empty()) {
 			if(rmax == 0 && min == 2)
 				core.temp_var[0] = 1;


### PR DESCRIPTION
fixed sometimes being able to Tribute a wrong monster for a 2 Tribute Summon using EFFECT_EXTRA_RELEASE_SUM

Example:
Use Monarchs Stormforth to tribute Gorz while Opponent has Double Coston and another Monster that can only act as 1 Material.
