### PR TITLE
Adjust at end of damage step

### DIFF
--- a/ocgcore/processor.cpp
+++ b/ocgcore/processor.cpp
@@ -3824,6 +3824,7 @@ int32 field::process_battle_command(uint16 step) {
 		if(core.attack_target)
 			raise_single_event(core.attack_target, 0, EVENT_DAMAGE_STEP_END, 0, 0, 0, 0, 1);
 		raise_event((card*)0, EVENT_DAMAGE_STEP_END, 0, 0, 0, 0, 0);
+		adjust_all();
 		process_single_event();
 		process_instant_event();
 		core.attacker->set_status(STATUS_BATTLE_DESTROYED, FALSE);


### PR DESCRIPTION
Adjust the field at the end of the damage step, before checking trigger effects. (Gozen Match, Yang Zing interaction)
