### PR TITLE
fix

### DIFF
--- a/script/c76136345.lua
+++ b/script/c76136345.lua
@@ -26,7 +26,7 @@ function c76136345.initial_effect(c)
 	e4:SetDescription(aux.Stringid(76136345,1))
 	e4:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
 	e4:SetType(EFFECT_TYPE_IGNITION)
-	e4:SetRange(LOCATION_SZONE)
+	e4:SetRange(LOCATION_FZONE)
 	e4:SetCountLimit(1,76136345)
 	e4:SetCost(c76136345.thcost)
 	e4:SetTarget(c76136345.thtg)
@@ -44,7 +44,7 @@ function c76136345.filter(c,e,tp)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c76136345.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c76136345.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end


### PR DESCRIPTION
転回操車
The ② effect
If this card is not on the field zone during effect operation, the chain solving should be stopped.
The ① effect
If this card is not on the field zone, this effect cannot be activated.
