### PR TITLE
fix: summon location

### DIFF
--- a/script/c2055403.lua
+++ b/script/c2055403.lua
@@ -10,7 +10,7 @@ function c2055403.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c2055403.filter(c,tp)
-	return c:GetSummonPlayer()~=tp and c:IsPreviousLocation(LOCATION_HAND+LOCATION_EXTRA) and c:IsAbleToDeck()
+	return c:GetSummonPlayer()~=tp and bit.band(c:GetSummonLocation(),LOCATION_HAND+LOCATION_EXTRA)~=0 and c:IsAbleToDeck()
 end
 function c2055403.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=eg:Filter(c2055403.filter,nil,tp)

--- a/script/c26257572.lua
+++ b/script/c26257572.lua
@@ -5,37 +5,21 @@ function c26257572.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	c:RegisterEffect(e1)
-	--reg
+	--disable
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
-	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_CANNOT_TRIGGER)
 	e2:SetRange(LOCATION_SZONE)
-	e2:SetOperation(c26257572.regop)
+	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e2:SetTarget(c26257572.target)
 	c:RegisterEffect(e2)
-	--
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetCode(EFFECT_CANNOT_TRIGGER)
-	e3:SetRange(LOCATION_SZONE)
-	e3:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
-	e3:SetTarget(c26257572.target)
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_DISABLE)
 	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetCode(EFFECT_DISABLE)
+	local e4=e2:Clone()
+	e4:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
 	c:RegisterEffect(e4)
-	local e5=e3:Clone()
-	e5:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
-	c:RegisterEffect(e5)
-end
-function c26257572.regop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=eg:GetFirst()
-	while tc do
-		if tc:IsPreviousLocation(LOCATION_DECK) then
-			tc:RegisterFlagEffect(26257572,RESET_EVENT+0x16e0000,0,1)
-		end
-		tc=eg:GetNext()
-	end
 end
 function c26257572.target(e,c)
-	return c:GetFlagEffect(26257572)~=0
+	return c:GetSummonLocation()==LOCATION_DECK
 end

--- a/script/c26674724.lua
+++ b/script/c26674724.lua
@@ -53,8 +53,7 @@ function c26674724.thop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c26674724.tdfilter(c)
-	return c:IsPreviousLocation(LOCATION_EXTRA)
-		and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL and c:IsAbleToDeck()
+	return c:GetSummonLocation()==LOCATION_EXTRA and c:IsAbleToDeck()
 end
 function c26674724.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c26674724.tdfilter(chkc) end

--- a/script/c37675138.lua
+++ b/script/c37675138.lua
@@ -20,7 +20,7 @@ function c37675138.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c37675138.descon(e,tp,eg,ep,ev,re,r,rp)
-	return re:GetOwner():IsRace(RACE_ZOMBIE) and e:GetHandler():IsPreviousLocation(LOCATION_GRAVE)
+	return re:GetOwner():IsRace(RACE_ZOMBIE) and e:GetHandler():GetSummonLocation()==LOCATION_GRAVE
 		and e:GetHandler():GetPreviousControler()==tp
 end
 function c37675138.desfilter(c)

--- a/script/c44394295.lua
+++ b/script/c44394295.lua
@@ -9,23 +9,6 @@ function c44394295.initial_effect(c)
 	e1:SetTarget(c44394295.target)
 	e1:SetOperation(c44394295.activate)
 	c:RegisterEffect(e1)
-	if not c44394295.global_check then
-		c44394295.global_check=true
-		local ge1=Effect.CreateEffect(c)
-		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		ge1:SetCode(EVENT_SPSUMMON_SUCCESS)
-		ge1:SetOperation(c44394295.checkop)
-		Duel.RegisterEffect(ge1,0)
-	end
-end
-function c44394295.checkop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=eg:GetFirst()
-	while tc do
-		if tc:IsPreviousLocation(LOCATION_EXTRA) then
-			tc:RegisterFlagEffect(44394295,RESET_EVENT+0x46e0000,0,0)
-		end
-		tc=eg:GetNext()
-	end
 end
 function c44394295.filter1(c,e)
 	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
@@ -36,7 +19,7 @@ function c44394295.filter2(c,e,tp,m,f,chkf)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
 function c44394295.cfilter(c)
-	return c:GetFlagEffect(44394295)~=0
+	return c:GetSummonLocation()==LOCATION_EXTRA
 end
 function c44394295.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/script/c52846880.lua
+++ b/script/c52846880.lua
@@ -60,8 +60,7 @@ function c52846880.condition(e,tp,eg,ep,ev,re,r,rp)
 	local bc=Duel.GetAttackTarget()
 	if not bc then return false end
 	if tc:IsControler(1-tp) then tc,bc=bc,tc end
-	if tc:IsSetCard(0xb4) and bc:IsPreviousLocation(LOCATION_EXTRA)
-		and bit.band(bc:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL then
+	if tc:IsSetCard(0xb4) and bc:GetSummonLocation()==LOCATION_EXTRA then
 		e:SetLabelObject(bc)
 		return true
 	else return false end

--- a/script/c66762372.lua
+++ b/script/c66762372.lua
@@ -49,7 +49,7 @@ function c66762372.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c66762372.cfilter(c,tp)
-	return c:IsFaceup() and c:IsSetCard(0x79) and c:IsPreviousLocation(LOCATION_EXTRA) and c:GetPreviousControler()==tp
+	return c:IsFaceup() and c:IsSetCard(0x79) and c:GetSummonLocation()==LOCATION_EXTRA and c:GetPreviousControler()==tp
 end
 function c66762372.setcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c66762372.cfilter,1,nil,tp)

--- a/script/c88724332.lua
+++ b/script/c88724332.lua
@@ -22,12 +22,12 @@ end
 function c88724332.target(e,c)
 	return c:IsPosition(POS_FACEUP_ATTACK) and not c:IsRace(RACE_WYRM)
 		and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
-		and c:IsPreviousLocation(LOCATION_DECK+LOCATION_EXTRA)
+		and bit.band(c:GetSummonLocation(),LOCATION_DECK+LOCATION_EXTRA)~=0
 end
 function c88724332.deftg(e,c)
 	return c:IsFaceup() and not c:IsRace(RACE_WYRM)
 		and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
-		and c:IsPreviousLocation(LOCATION_DECK+LOCATION_EXTRA)
+		and bit.band(c:GetSummonLocation(),LOCATION_DECK+LOCATION_EXTRA)~=0
 end
 function c88724332.defval(e,c)
 	return -c:GetBaseDefence()

--- a/script/c89463537.lua
+++ b/script/c89463537.lua
@@ -50,6 +50,5 @@ function c89463537.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c89463537.distg(e,c)
-	return c:IsPreviousLocation(LOCATION_EXTRA)
-		and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
+	return c:GetSummonLocation()==LOCATION_EXTRA
 end

--- a/script/c91468551.lua
+++ b/script/c91468551.lua
@@ -16,5 +16,5 @@ function c91468551.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c91468551.atktg(e,c)
-	return bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)~=0 and c:IsPreviousLocation(LOCATION_GRAVE)
+	return bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)~=0 and c:GetSummonLocation()==LOCATION_GRAVE
 end

--- a/script/c99185129.lua
+++ b/script/c99185129.lua
@@ -57,8 +57,7 @@ function c99185129.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
 function c99185129.filter(c)
-	return c:IsPreviousLocation(LOCATION_EXTRA)
-		and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
+	return c:GetSummonLocation()==LOCATION_EXTRA and not (c:GetAttack()==0 and c:IsDisabled())
 end
 function c99185129.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c99185129.filter(chkc) end

--- a/script/c99311109.lua
+++ b/script/c99311109.lua
@@ -13,8 +13,7 @@ function c99311109.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c99311109.cfilter(c)
-	return c:IsPreviousLocation(LOCATION_EXTRA)
-		and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
+	return c:GetFlagEffect(LOCATION_EXTRA)~=0
 end
 function c99311109.condition(e,tp,eg,ep,ev,re,r,rp)
 	return not Duel.IsExistingMatchingCard(c99311109.cfilter,tp,LOCATION_MZONE,0,1,nil)
@@ -30,8 +29,7 @@ function c99311109.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e1,tp)
 end
 function c99311109.filter(c)
-	return c:IsFaceup() and c:IsPreviousLocation(LOCATION_EXTRA) and c:IsControlerCanBeChanged()
-		and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
+	return c:IsFaceup() and c:IsControlerCanBeChanged() and c:GetSummonLocation()==LOCATION_EXTRA
 end
 function c99311109.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c99311109.filter(chkc) end


### PR DESCRIPTION
影霊衣
c26257572 苦痛の回廊
c37675138 ボーンクラッシャー
c44394295 影依融合
c88724332 ナイト・ドラゴリッチ
c66762372 孤炎星－ロシシン
c91468551 太陽の祭壇
c99311109 戦友の誓い
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13975&keyword=&tag=-1
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13946&keyword=&tag=-1
Use GetSummonLocation() in filter function to determine "sp_summon from..."
「從...場所特殊召喚的怪獸」條件都改為GetSummonLocation()

c99185129 クラウソラスの影霊衣
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13977&keyword=&tag=-1
This card cannot target a monster which is both disabled and atk=0
不能指定攻擊力0且效果無效的怪獸
