### PR TITLE
fix

### DIFF
--- a/script/c51316684.lua
+++ b/script/c51316684.lua
@@ -95,7 +95,7 @@ function c51316684.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
 function c51316684.rmcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetBattledGroup():GetCount()>0
+	return Duel.GetTurnPlayer()==tp and e:GetHandler():GetBattledGroup():GetCount()>0
 end
 function c51316684.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end

--- a/script/c73176465.lua
+++ b/script/c73176465.lua
@@ -22,6 +22,16 @@ function c73176465.initial_effect(c)
 	e2:SetTarget(c73176465.destg)
 	e2:SetOperation(c73176465.desop)
 	c:RegisterEffect(e2)
+	--cannot pendulum summon
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e3:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e3:SetValue(c73176465.splimit)
+	c:RegisterEffect(e3)
+end
+function c73176465.splimit(e,se,sp,st)
+	return se:GetCode()~=EFFECT_SPSUMMON_PROC_G
 end
 function c73176465.condtion(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT)~=0 and re:IsActiveType(TYPE_MONSTER)


### PR DESCRIPTION
光道弓手 ライトロード・アーチャー フェリス (73176465)
http://yugioh-wiki.net/?%A1%D4%A5%E9%A5%A4%A5%C8%A5%ED%A1%BC%A5%C9%A1%A6%A5%A2%A1%BC%A5%C1%A5%E3%A1%BC%20%A5%D5%A5%A7%A5%EA%A5%B9%A1%D5
Ｑ：このカードをペンデュラム召喚することは可能ですか？
Ａ：このカードをペンデュラム召喚によって特殊召喚する事はできません。(14/03/21)
这张卡不能P召唤

インフェルノイド・ヴァエル (51316684)
这张卡向对方怪兽攻击的战斗阶段结束时才能发动。
