### PR TITLE
fix Ritual Spell Cards

### DIFF
--- a/script/c27383110.lua
+++ b/script/c27383110.lua
@@ -26,10 +26,10 @@ function c27383110.filter(c,e,tp,m)
 	if cd~=44665365 or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,true,false) then return false end
 	if m:IsContains(c) then
 		m:RemoveCard(c)
-		result=m:CheckWithSumEqual(Card.GetRitualLevel,c:GetLevel(),1,99,c)
+		result=m:CheckWithSumEqual(Card.GetRitualLevel,c:GetOriginalLevel(),1,99,c)
 		m:AddCard(c)
 	else
-		result=m:CheckWithSumEqual(Card.GetRitualLevel,c:GetLevel(),1,99,c)
+		result=m:CheckWithSumEqual(Card.GetRitualLevel,c:GetOriginalLevel(),1,99,c)
 	end
 	return result
 end
@@ -48,7 +48,7 @@ function c27383110.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tc=tg:GetFirst()
 		mg:RemoveCard(tc)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-		local mat=mg:SelectWithSumEqual(tp,Card.GetRitualLevel,tc:GetLevel(),1,99,tc)
+		local mat=mg:SelectWithSumEqual(tp,Card.GetRitualLevel,tc:GetOriginalLevel(),1,99,tc)
 		tc:SetMaterial(mat)
 		Duel.ReleaseRitualMaterial(mat)
 		Duel.BreakEffect()

--- a/script/c34834619.lua
+++ b/script/c34834619.lua
@@ -1,16 +1,58 @@
 --光子竜降臨
 function c34834619.initial_effect(c)
-	aux.AddRitualProcEqual(c,aux.FilterBoolFunction(Card.IsCode,85346853))
-	--spsummon
+	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(34834619,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_GRAVE)
-	e1:SetCost(c34834619.spcost)
-	e1:SetTarget(c34834619.sptg)
-	e1:SetOperation(c34834619.spop)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c34834619.target)
+	e1:SetOperation(c34834619.activate)
 	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(34834619,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCost(c34834619.spcost)
+	e2:SetTarget(c34834619.sptg)
+	e2:SetOperation(c34834619.spop)
+	c:RegisterEffect(e2)
+end
+function c34834619.filter(c,e,tp,m)
+	local cd=c:GetCode()
+	if cd~=85346853 or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,true,false) then return false end
+	if m:IsContains(c) then
+		m:RemoveCard(c)
+		result=m:CheckWithSumEqual(Card.GetRitualLevel,c:GetOriginalLevel(),1,99,c)
+		m:AddCard(c)
+	else
+		result=m:CheckWithSumEqual(Card.GetRitualLevel,c:GetOriginalLevel(),1,99,c)
+	end
+	return result
+end
+function c34834619.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local mg=Duel.GetRitualMaterial(tp)
+		return Duel.IsExistingMatchingCard(c34834619.filter,tp,LOCATION_HAND,0,1,nil,e,tp,mg)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c34834619.activate(e,tp,eg,ep,ev,re,r,rp)
+	local mg=Duel.GetRitualMaterial(tp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local tg=Duel.SelectMatchingCard(tp,c34834619.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp,mg)
+	if tg:GetCount()>0 then
+		local tc=tg:GetFirst()
+		mg:RemoveCard(tc)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		local mat=mg:SelectWithSumEqual(tp,Card.GetRitualLevel,tc:GetOriginalLevel(),1,99,tc)
+		tc:SetMaterial(mat)
+		Duel.ReleaseRitualMaterial(mat)
+		Duel.BreakEffect()
+		Duel.SpecialSummon(tc,SUMMON_TYPE_RITUAL,tp,tp,true,false,POS_FACEUP)
+		tc:CompleteProcedure()
+	end
 end
 function c34834619.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
@@ -21,7 +63,7 @@ function c34834619.mtfilter(c,e)
 end
 function c34834619.spfilter(c,e,tp,m)
 	return c:IsCode(85346853) and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,true,false)
-		and m:CheckWithSumEqual(Card.GetRitualLevel,c:GetLevel(),1,99,c)
+		and m:CheckWithSumEqual(Card.GetRitualLevel,c:GetOriginalLevel(),1,99,c)
 end
 function c34834619.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
@@ -39,7 +81,7 @@ function c34834619.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:GetFirst()
 	if tc then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-		local mat=mg:SelectWithSumEqual(tp,Card.GetRitualLevel,tc:GetLevel(),1,99,tc)
+		local mat=mg:SelectWithSumEqual(tp,Card.GetRitualLevel,tc:GetOriginalLevel(),1,99,tc)
 		tc:SetMaterial(mat)
 		Duel.ReleaseRitualMaterial(mat)
 		Duel.BreakEffect()

--- a/script/utility.lua
+++ b/script/utility.lua
@@ -804,10 +804,10 @@ function Auxiliary.RPGFilter(c,filter,e,tp,m)
 	local result=false
 	if m:IsContains(c) then
 		m:RemoveCard(c)
-		result=m:CheckWithSumGreater(Card.GetRitualLevel,c:GetLevel(),c)
+		result=m:CheckWithSumGreater(Card.GetRitualLevel,c:GetOriginalLevel(),c)
 		m:AddCard(c)
 	else
-		result=m:CheckWithSumGreater(Card.GetRitualLevel,c:GetLevel(),c)
+		result=m:CheckWithSumGreater(Card.GetRitualLevel,c:GetOriginalLevel(),c)
 	end
 	return result
 end
@@ -829,7 +829,7 @@ function Auxiliary.RPGOperation(filter)
 					local tc=tg:GetFirst()
 					mg:RemoveCard(tc)
 					Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-					local mat=mg:SelectWithSumGreater(tp,Card.GetRitualLevel,tc:GetLevel(),tc)
+					local mat=mg:SelectWithSumGreater(tp,Card.GetRitualLevel,tc:GetOriginalLevel(),tc)
 					tc:SetMaterial(mat)
 					Duel.ReleaseRitualMaterial(mat)
 					Duel.BreakEffect()


### PR DESCRIPTION
Fix this: Dawn of the Herald, Luminous Dragon Ritual, Black Luster Ritual and so require the total Levels to be equal(or more) to the Level -2 of the Ritual Monster.
http://yugioh-wiki.net/index.php?%B5%B7%BC%B0%CB%E2%CB%A1#faq