### PR TITLE
Update c57734012.lua

### DIFF
--- a/script/c57734012.lua
+++ b/script/c57734012.lua
@@ -50,9 +50,9 @@ function c57734012.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		and Duel.GetFlagEffect(tp,57734012)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c57734012.filter1,tp,LOCATION_GRAVE+LOCATION_EXTRA,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE+LOCATION_EXTRA)
-	Duel.RegisterFlagEffect(tp,57734012,0,EFFECT_FLAG_OATH,0)
 end
 function c57734012.activate(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetFlagEffect(tp,57734012)~=0 then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	if not Duel.IsPlayerCanSpecialSummonCount(tp,2) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
@@ -68,4 +68,5 @@ function c57734012.activate(e,tp,eg,ep,ev,re,r,rp)
 			tc2:CompleteProcedure()
 		end
 	end
+	Duel.RegisterFlagEffect(tp,57734012,0,EFFECT_FLAG_OATH,0)
 end


### PR DESCRIPTION
按照调整是可以对应七皇之剑发动连续魔法的，且连续魔法获得的效果先适用，七皇之剑获得的效果靠后处理因此不适用。
现在的判定会导致无法对应七皇之剑而发动连续魔法。所以把给玩家注册FLAG的部分搬运去Operation，并在Operation里再次检测玩家FLAG，来解决此BUG。