### PR TITLE
fix

### DIFF
--- a/script/c45742626.lua
+++ b/script/c45742626.lua
@@ -34,7 +34,7 @@ function c45742626.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c45742626.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,5) and Duel.IsPlayerCanDiscardDeck(1-tp,5) end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,5) or Duel.IsPlayerCanDiscardDeck(1-tp,5) end
 	Duel.SetOperationInfo(0,CATEGORY_DECKDES,nil,0,PLAYER_ALL,5)
 end
 function c45742626.operation(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13035&request_locale=ja

「巡死神リーパー」の効果を発動する際には、お互いのプレイヤーのデッキの枚数はどちらも5枚以上でなければ、効果を発動する事自体ができません。

なお、「巡死神リーパー」の効果処理時に、どちらかのプレイヤーのデッキの枚数が4枚以下になっている場合は効果処理は通常通り行われます。
（効果処理時にデッキの枚数が4枚以下になっているプレイヤーは自身のデッキのカードを全て墓地へ送る事になります。）