### PR TITLE
fix Plain-Coat

### DIFF
--- a/script/c23649496.lua
+++ b/script/c23649496.lua
@@ -29,8 +29,10 @@ function c23649496.initial_effect(c)
 end
 c23649496.xyz_number=18
 function c23649496.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
-	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+	local c=e:GetHandler()
+	if chk==0 then return c:CheckRemoveOverlayCard(tp,1,REASON_COST) and c:GetFlagEffect(23649496)==0 end
+	c:RemoveOverlayCard(tp,1,1,REASON_COST)
+	c:RegisterFlagEffect(23649496,RESET_CHAIN,0,1)
 end
 function c23649496.cfilter(c)
 	return c:IsFaceup() and Duel.IsExistingMatchingCard(c23649496.filter,0,LOCATION_MZONE,LOCATION_MZONE,1,c,c:GetCode())


### PR DESCRIPTION
Fix this: Number 18: Heraldic Progenitor Plain-Coat can be activate multiple times destroying effects in the same chain.
Ｑ：同一チェーン上で一つ目の効果を複数回発動できますか？
Ａ：いいえ、できません。(14/09/27)
http://yugioh-wiki.net/index.php?%A1%D4%A3%CE%A3%EF.%A3%B1%A3%B8%20%CC%E6%BE%CF%C1%C4%A5%D7%A5%EC%A5%A4%A5%F3%A1%A6%A5%B3%A1%BC%A5%C8%A1%D5#eac8af4e