### PR TITLE
fix Nekroz Cycle

### DIFF
--- a/script/c97211663.lua
+++ b/script/c97211663.lua
@@ -22,7 +22,7 @@ function c97211663.initial_effect(c)
 end
 function c97211663.filter(c,e,tp,m)
 	if not c:IsSetCard(0xb4) or bit.band(c:GetType(),0x81)~=0x81
-		or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,true,true) then return false end
+		or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,true,true) or c:IsHasEffect(EFFECT_NECRO_VALLEY) then return false end
 	local mg=nil
 	if c.mat_filter then
 		mg=m:Filter(c.mat_filter,c)


### PR DESCRIPTION
Fix this: When Necrovalley actived on the field, "Nekroz" Ritual Monster can be Special Summon Nekroz Cycle's effect in Graveyard.
https://github.com/Fluorohydride/ygopro/issues/1095#issue-56493562