### PR TITLE
fix Prime Photon Dragon

### DIFF
--- a/script/c31801517.lua
+++ b/script/c31801517.lua
@@ -59,8 +59,9 @@ function c31801517.atkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c31801517.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return rp~=tp and e:GetHandler():IsReason(REASON_EFFECT)
-		and e:GetHandler():GetOverlayGroup():IsExists(Card.IsCode,1,nil,93717133)
+	local c=e:GetHandler()
+	return rp~=tp and c:IsReason(REASON_EFFECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and c:GetOverlayGroup():IsExists(Card.IsCode,1,nil,93717133)
 end
 function c31801517.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
Fix this: When Prime Photon Dragon that the Galaxy-Eyes Photon Dragon was materials has been destroyed "Solemn Warning" effect, Prime Photon Dragon can be activate Spesial Summon effect.
Ｑ：《銀河眼の光子竜》を素材としたこのカードが《神の警告》で破壊された場合、このカードの自身を特殊召喚する効果を発動できますか？
Ａ：発動できません。(15/02/04)
http://yugioh-wiki.net/index.php?%A1%D4%A3%CE%A3%EF.%A3%B6%A3%B2%20%B6%E4%B2%CF%B4%E3%A4%CE%B8%F7%BB%D2%CE%B5%B9%C4%A1%D5#yb1c2cde