### PR TITLE
fix Volcanic Shell

### DIFF
--- a/script/c33365932.lua
+++ b/script/c33365932.lua
@@ -24,6 +24,7 @@ function c33365932.tg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function c33365932.op(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstMatchingCard(c33365932.filter,tp,LOCATION_DECK,0,nil)
 	if tc then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)


### PR DESCRIPTION
Ｑ：このカードの発動に《Ｄ.Ｄ.クロウ》をチェーンされ、このカードを除外された場合、デッキから《ヴォルカニック・バレット》を加える事はできますか？
Ａ：いいえ、できません。
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9
http://yugioh-wiki.net/index.php?%A1%D4%A5%F4%A5%A9%A5%EB%A5%AB%A5%CB%A5%C3%A5%AF%A1%A6%A5%D0%A5%EC%A5%C3%A5%C8%A1%D5#g9c73265