### PR TITLE
fix Infernoid Piaty

### DIFF
--- a/script/c25811989.lua
+++ b/script/c25811989.lua
@@ -96,7 +96,7 @@ function c25811989.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep~=tp and Duel.GetAttacker()==e:GetHandler() and Duel.GetAttackTarget()~=nil
 end
 function c25811989.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)>0 end
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,0,0,1-tp,1)
 end
 function c25811989.thop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Fix this: When your opponent has no cards in your opponent's hand, Infernoid Piaty can activate.

遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
相手の手札が０枚の時に「インフェルノイド・アシュメダイ」の①の効果を発動できますか？
A.
相手の手札が0枚ですと、そもそもランダムに手札を選んで墓地に送る事ができません。
したがって、相手の手札が0枚の時に、「インフェルノイド・アシュメダイ」の『①』の効果を発動する事はできません。

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。