### PR TITLE
fix Magical Star Illusion

### DIFF
--- a/script/c18752707.lua
+++ b/script/c18752707.lua
@@ -16,19 +16,18 @@ function c18752707.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 end
 function c18752707.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g1=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
-	local val1=g1:GetSum(Card.GetLevel)
-	local g2=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
-	local val2=g2:GetSum(Card.GetLevel)
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_UPDATE_ATTACK)
-	e1:SetTargetRange(LOCATION_MZONE,0)
-	e1:SetValue(val1*100)
-	e1:SetReset(RESET_PHASE+RESET_END)
-	Duel.RegisterEffect(e1,tp)
-	local e2=e1:Clone()
-	e2:SetTargetRange(0,LOCATION_MZONE)
-	e2:SetValue(val2*100)
-	Duel.RegisterEffect(e2,tp)
+	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local tc=g:GetFirst()
+	while tc do
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(c18752707.atkval)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+		tc=g:GetNext()
+	end
+end
+function c18752707.atkval(e,c)
+	return Duel.GetMatchingGroup(Card.IsFaceup,c:GetControler(),LOCATION_MZONE,0,nil):GetSum(Card.GetLevel)*100
 end


### PR DESCRIPTION
Fix this: If you summon a monster after invoking the " Magical Star Illusion ", gain that summoned monster's  ATK.

遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
「マジカル・スター・イリュージョン」を発動後に別のモンスターを召喚・特殊召喚した場合、そのモンスターの攻撃力はアップしますか？
A.
「マジカル・スター・イリュージョン」を発動し、その効果が適用された後に召喚・特殊召喚されたモンスターの攻撃力はアップしません。

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。