### PR TITLE
fix Chaos Atlandis

### DIFF
--- a/script/c6387204.lua
+++ b/script/c6387204.lua
@@ -69,7 +69,7 @@ function c6387204.eqlimit(e,c)
 	return e:GetOwner()==c
 end
 function c6387204.lpcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetOverlayGroup():IsExists(Card.IsCode,1,nil,9161357)
+	return Duel.GetLP(1-tp)~=100 and e:GetHandler():GetOverlayGroup():IsExists(Card.IsCode,1,nil,9161357)
 end
 function c6387204.filter(c)
 	return c:GetFlagEffect(6387204)~=0 and c:IsSetCard(0x48) and c:IsAbleToGraveAsCost()


### PR DESCRIPTION
Fix this: If your opponent' LP is 100, Chaos Atlandis can activate.

遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
相手のライフポイントが１００の時に「ＣＮｏ.６ 先史遺産カオス・アトランタル」の「相手のライフポイントを１００にする」効果を発動できますか？
A.
相手プレイヤーのライフポイントが100の場合、「CNo.6 先史遺産カオス・アトランタル」の『相手のライフポイントを100にする』効果は発動する事ができません。


これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。