### PR TITLE
fix The Kick Man

### DIFF
--- a/script/c90407382.lua
+++ b/script/c90407382.lua
@@ -3,7 +3,7 @@ function c90407382.initial_effect(c)
 	--equip
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(90407382,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
 	e1:SetCategory(CATEGORY_EQUIP)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)


### PR DESCRIPTION
Fix this: The Kick Man cannot activate Equip's effect in Damage Step.

http://yugioh-wiki.net/index.php?%A1%D4%A5%B6%A1%A6%A5%AD%A5%C3%A5%AF%A5%DE%A5%F3%A1%D5#b5ea3fa8
Ｑ：ダメージステップ中に特殊召喚した時にこのカードの効果を発動できますか？
Ａ：はい、発動できます。