### PR TITLE
fix DDD Kaiser the Conqueror

### DIFF
--- a/script/c44186624.lua
+++ b/script/c44186624.lua
@@ -71,12 +71,13 @@ function c44186624.desop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
 	local ct=Duel.Destroy(g,REASON_EFFECT)
-	if ct>0 and c:IsRelateToEffect(e) and c:IsFaceup() then
+	if ct>0 and c:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_EXTRA_ATTACK)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetValue(ct)
-		e1:SetReset(RESET_EVENT+0x1ff0000+RESET_PHASE+PHASE_END)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		c:RegisterEffect(e1)
 	end
 end


### PR DESCRIPTION
Fix this: When DDD Kaiser the Conqueror negate effect after effect activated, DDD Kaiser the Conqueror cannot be attack twice.

http://yugioh-wiki.net/index.php?%A1%D4%A3%C4%A3%C4%A3%C4%C0%A9%C7%C6%B2%A6%A5%AB%A5%A4%A5%BC%A5%EB%A1%D5#fd837f13
Ｑ：(2)の効果が適用され複数回攻撃できる状態の時に《禁じられた聖杯》の効果でモンスター効果が無効にされた場合でも、自身の効果で複数回攻撃できますか？
Ａ：はい、できます。
Ｑ：(2)の効果解決時にこのカードが裏側表示になり、このカードの効果でカードが破壊されました。
　　その後そのターンにこのカードが他の効果で表側攻撃表示になった場合、自身の効果で複数回攻撃できますか？
Ａ：はい、できます。