### PR TITLE
fix Madolche Chateau

### DIFF
--- a/script/c14001430.lua
+++ b/script/c14001430.lua
@@ -52,10 +52,16 @@ function c14001430.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 		and re:GetHandler():IsSetCard(0x71) and eg:IsExists(c14001430.repfilter,1,nil,tp) end
 	if Duel.SelectYesNo(tp,aux.Stringid(14001430,0)) then
 		local g=eg:Filter(c14001430.repfilter,nil,tp)
+		local ct=g:GetCount()
+		if ct>1 then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
+			g=g:Select(tp,1,ct,nil)
+		end
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
-		return true
-	else return false end
+		if g:GetCount()==ct then return true end
+	end
+	return false
 end
 function c14001430.repval(e,c)
 	return c14001430.repfilter(c,e:GetHandlerPlayer())


### PR DESCRIPTION
Fix this: Cannnot possible to select the card to be returned to your hand by the effect of Madolche Chateau.

http://yugioh-wiki.net/index.php?%A1%D4%A5%DE%A5%C9%A5%EB%A5%C1%A5%A7%A1%A6%A5%B7%A5%E3%A5%C8%A1%BC%A1%D5#ha9e745b
Ｑ：《クイーンマドルチェ・ティアラミス》の効果対象にマドルチェと名のついたモンスター２体を選択しました。
このカードの効果でその内片方だけを手札に戻す事はできますか？
Ａ：２枚のうち片方だけ手札に戻す事もできます。