### PR TITLE
fix Deskbot 003

### DIFF
--- a/script/c75944053.lua
+++ b/script/c75944053.lua
@@ -51,20 +51,18 @@ function c75944053.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SelectTarget(tp,c75944053.filter,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function c75944053.operation(e,tp,eg,ep,ev,re,r,rp)
+	local val=Duel.GetMatchingGroupCount(c75944053.filter,tp,LOCATION_ONFIELD,0,nil)*500
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e1:SetValue(c75944053.adval)
+		e1:SetValue(val)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e1)
 		local e2=e1:Clone()
 		e2:SetCode(EFFECT_UPDATE_DEFENCE)
 		tc:RegisterEffect(e2)
 	end
-end
-function c75944053.adval(e,c)
-	return Duel.GetMatchingGroupCount(c75944053.filter,c:GetControler(),LOCATION_ONFIELD,0,nil)*500
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=148
Q.「ブンボーグ００３」の『②：１ターンに１度、自分フィールドの「ブンボーグ」モンスター１体を対象として発動できる。そのモンスターの攻撃力・守備力はターン終了時まで、自分フィールドの「ブンボーグ」カードの数×５００アップする。この効果は相手ターンでも発動できる』効果が適用された後、自分フィールドに表側表示で存在する「ブンボーグ」と名のついたモンスターの数が変化した場合、攻撃力はどうなりますか？
A.「ブンボーグ００３」の効果適用後に、自分フィールドに表側表示で存在する「ブンボーグ」と名のついたモンスターの数が変化した場合でも、「ブンボーグ００３」の効果によってアップしている数値は変化しません。