### PR TITLE
fix Hieratic Dragon of Tefnuit

### DIFF
--- a/script/c77901552.lua
+++ b/script/c77901552.lua
@@ -28,6 +28,7 @@ end
 function c77901552.hspop(e,tp,eg,ep,ev,re,r,rp,c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EFFECT_CANNOT_ATTACK)
 	e1:SetReset(RESET_EVENT+0xff0000+RESET_PHASE+PHASE_END)
 	c:RegisterEffect(e1)


### PR DESCRIPTION
Fix this: If Hieratic Dragon of Tefnuit Special Summoned from your hand while Skill Drain actived on the field, you can attack Hieratic Dragon of Tefnuit.

http://yugioh-wiki.net/index.php?%A1%D4%C0%BB%B9%EF%CE%B6%A1%DD%A5%C8%A5%D5%A5%A7%A5%CB%A5%C9%A5%E9%A5%B4%A5%F3%A1%D5#pa3cecf9
Ｑ：《スキルドレイン》が存在する時にこのカードを自身の効果で特殊召喚した場合、このターンこのカードは攻撃できますか？
Ａ：いいえ、攻撃できません。