### PR TITLE
fix The Wicked Avatar

### DIFF
--- a/script/c21208154.lua
+++ b/script/c21208154.lua
@@ -59,6 +59,7 @@ function c21208154.adval(e,c)
 	end
 end
 function c21208154.regop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)


### PR DESCRIPTION
Fix this: When The Wicked Avatar's effect negate, your opponent cannot activate Spell/Trap cards.

遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
「邪神アバター」の①の効果の発動にチェーンして「デモンズ・チェーン」を発動した場合、「邪神アバター」の①の効果は適用されますか？
また発動後２ターンの間に「デモンズ・チェーン」が破壊された場合、「邪神アバター」の①の効果は適用されますか？
A.
「邪神アバター」の『①』の効果が「デモンズ・チェーン」の効果で無効になった場合、『相手ターンで数えて２ターンの間、相手は魔法・罠カードを発動できない』効果は適用されません。
また、その後「デモンズ・チェーン」を破壊しても、『①』の効果が再び適用される事はありません。

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。