### PR TITLE
fix Marshalling Field

### DIFF
--- a/script/c63881033.lua
+++ b/script/c63881033.lua
@@ -4,6 +4,8 @@ function c63881033.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c63881033.lvtg1)
+	e1:SetOperation(c63881033.lvop)
 	c:RegisterEffect(e1)
 	--disable spsummon
 	local e2=Effect.CreateEffect(c)
@@ -17,10 +19,11 @@ function c63881033.initial_effect(c)
 	--lv change
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(63881033,0))
-	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetType(EFFECT_TYPE_QUICK_O)
 	e3:SetCountLimit(1)
 	e3:SetRange(LOCATION_SZONE)
-	e3:SetTarget(c63881033.lvtg)
+	e3:SetCode(EVENT_FREE_CHAIN)
+	e3:SetTarget(c63881033.lvtg2)
 	e3:SetOperation(c63881033.lvop)
 	c:RegisterEffect(e3)
 	--destroy replace
@@ -44,21 +47,36 @@ function c63881033.initial_effect(c)
 	e5:SetOperation(c63881033.thop)
 	c:RegisterEffect(e5)
 end
+function c63881033.lvtg1(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	if Duel.IsExistingMatchingCard(c63881033.filter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.SelectYesNo(tp,aux.Stringid(63881033,4)) then
+		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(63881033,1))
+		local lv=Duel.AnnounceNumber(tp,5,6,7,8,9)
+		e:SetLabel(lv)
+		e:GetHandler():RegisterFlagEffect(63881033,RESET_PHASE+PHASE_END,0,1)
+	else
+		e:SetLabel(0)
+	end
+end
 function c63881033.splimit(e,c)
 	return c:GetRace()~=RACE_MACHINE
 end
 function c63881033.filter(c)
 	return c:IsFaceup() and c:IsLevelAbove(5) and c:IsRace(RACE_MACHINE)
 end
-function c63881033.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c63881033.filter,tp,LOCATION_MZONE,0,1,nil) end
+function c63881033.lvtg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(63881033)==0
+		and Duel.IsExistingMatchingCard(c63881033.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(63881033,1))
 	local lv=Duel.AnnounceNumber(tp,5,6,7,8,9)
 	e:SetLabel(lv)
+	e:GetHandler():RegisterFlagEffect(63881033,RESET_PHASE+PHASE_END,0,1)
 end
 function c63881033.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
+	if e:GetLabel()==0 then return end
 	local g=Duel.GetMatchingGroup(c63881033.filter,tp,LOCATION_MZONE,0,nil)
 	local tc=g:GetFirst()
 	while tc do


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11299
■『②：１ターンに１度、５～９までの任意のレベルを宣言して発動できる。自分フィールドのレベル５以上の機械族モンスターのレベルは宣言したレベルになる』効果は、チェーンブロックの作られる効果です。（対象を取る効果ではありません。ダメージステップでは発動する事ができません。セットされている「マーシャリング・フィールド」を裏から表にして発動する場合、カードの発動と同一のチェーンブロックにて効果の発動を行う事もできます。）


遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
「マーシャリング・フィールド」の②の効果は相手ターンにも発動できますか？
A.
「マーシャリング・フィールド」の『②』の効果を相手ターン中にて発動する事はできます。


これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。