### PR TITLE
fix ZW

### DIFF
--- a/script/c12927849.lua
+++ b/script/c12927849.lua
@@ -74,10 +74,11 @@ function c12927849.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c12927849.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 end
 function c12927849.eqlimit(e,c)
-	return c:IsSetCard(0x7f)
+	return c==e:GetLabelObject()
 end
 function c12927849.thcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=eg:GetFirst()

--- a/script/c18865703.lua
+++ b/script/c18865703.lua
@@ -53,6 +53,7 @@ function c18865703.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c18865703.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 	--atkup
 	local e2=Effect.CreateEffect(c)
@@ -63,7 +64,7 @@ function c18865703.eqop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e2)
 end
 function c18865703.eqlimit(e,c)
-	return c:IsSetCard(0x7f)
+	return c==e:GetLabelObject()
 end
 function c18865703.spfilter(c,e,tp)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/script/c2648201.lua
+++ b/script/c2648201.lua
@@ -52,6 +52,7 @@ function c2648201.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c2648201.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 	--atkup
 	local e2=Effect.CreateEffect(c)
@@ -62,7 +63,7 @@ function c2648201.eqop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e2)
 end
 function c2648201.eqlimit(e,c)
-	return c:IsSetCard(0x7f)
+	return c==e:GetLabelObject()
 end
 function c2648201.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/script/c29353756.lua
+++ b/script/c29353756.lua
@@ -63,6 +63,7 @@ function c29353756.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c29353756.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 	--atkup
 	local e2=Effect.CreateEffect(c)
@@ -73,7 +74,7 @@ function c29353756.eqop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e2)
 end
 function c29353756.eqlimit(e,c)
-	return c:IsSetCard(0x7f)
+	return c==e:GetLabelObject()
 end
 function c29353756.negcon(e,tp,eg,ep,ev,re,r,rp)
 	return rp~=tp and Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)==LOCATION_SZONE

--- a/script/c40941889.lua
+++ b/script/c40941889.lua
@@ -47,6 +47,7 @@ function c40941889.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c40941889.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 	--atkup
 	local e2=Effect.CreateEffect(c)
@@ -57,5 +58,5 @@ function c40941889.eqop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e2)
 end
 function c40941889.eqlimit(e,c)
-	return c:IsSetCard(0x7f)
+	return c==e:GetLabelObject()
 end

--- a/script/c45082499.lua
+++ b/script/c45082499.lua
@@ -57,6 +57,7 @@ function c45082499.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c45082499.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 	--atkup
 	local e2=Effect.CreateEffect(c)
@@ -67,7 +68,7 @@ function c45082499.eqop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e2)
 end
 function c45082499.eqlimit(e,c)
-	return c:IsSetCard(0x7f)
+	return c==e:GetLabelObject()
 end
 function c45082499.indval(e,re,tp)
 	return e:GetHandler():GetControler()~=tp

--- a/script/c60992364.lua
+++ b/script/c60992364.lua
@@ -84,6 +84,7 @@ function c60992364.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c60992364.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 	--atkup
 	local e2=Effect.CreateEffect(c)
@@ -94,7 +95,7 @@ function c60992364.eqop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e2)
 end
 function c60992364.eqlimit(e,c)
-	return c:IsSetCard(0x7f)
+	return c==e:GetLabelObject()
 end
 function c60992364.atcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp and Duel.GetCurrentPhase()==PHASE_BATTLE and Duel.GetCurrentChain()==0

--- a/script/c6330307.lua
+++ b/script/c6330307.lua
@@ -52,10 +52,11 @@ function c6330307.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c6330307.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 end
 function c6330307.eqlimit(e,c)
-	return c:IsSetCard(0x7f) and c:IsSetCard(0x1048)
+	return c==e:GetLabelObject()
 end
 function c6330307.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()

--- a/script/c76080032.lua
+++ b/script/c76080032.lua
@@ -48,6 +48,7 @@ function c76080032.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c76080032.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 	--atkup
 	local e2=Effect.CreateEffect(c)
@@ -75,5 +76,5 @@ function c76080032.disop(e,tp,eg,ep,ev,re,r,rp)
 	tc:RegisterEffect(e2)
 end
 function c76080032.eqlimit(e,c)
-	return c:IsCode(56840427)
+	return c==e:GetLabelObject()
 end

--- a/script/c81471108.lua
+++ b/script/c81471108.lua
@@ -55,6 +55,7 @@ function c81471108.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c81471108.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 	--atkup
 	local e2=Effect.CreateEffect(c)
@@ -65,7 +66,7 @@ function c81471108.eqop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e2)
 end
 function c81471108.eqlimit(e,c)
-	return c:IsSetCard(0x7f)
+	return c==e:GetLabelObject()
 end
 function c81471108.indval(e,re,tp)
 	return e:GetHandler():GetControler()~=tp

--- a/script/c87008374.lua
+++ b/script/c87008374.lua
@@ -50,6 +50,7 @@ function c87008374.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c87008374.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 	--atkup
 	local e2=Effect.CreateEffect(c)
@@ -75,5 +76,5 @@ function c87008374.damop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Damage(p,d,REASON_EFFECT)
 end
 function c87008374.eqlimit(e,c)
-	return c:IsCode(56840427)
+	return c==e:GetLabelObject()
 end


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A3%DA%A3%D7#k58c1fd6
Ｑ：《ＣＮｏ.３９ 希望皇ホープレイ》扱いの《ファントム・オブ・カオス》に《ＺＷ－一角獣皇槍》、《ＺＷ－阿修羅副腕》を装備しました。
　　エンドフェイズに名前が元に戻った場合、これらのカードは破壊されますか？
Ａ：カード名が《ファントム・オブ・カオス》に戻った後も装備されたままとなります。(14/09/05)

Ｑ：《ＺＷ－雷神猛虎剣》等が自身の効果で装備カードになっている時に装備モンスターの希望皇ホープと名のついたモンスターのカード名が《ヒーロー・マスク》の効果で変わった場合、《ＺＷ－雷神猛虎剣》等は破壊されますか？
Ａ：いいえ、破壊されず装備されたままになります。(13/07/06)

Ｑ：《移り気な仕立屋》で、自身の効果で装備カード状態の《ＺＷ－雷神猛虎剣》等を他の自分の希望皇ホープと名のついたモンスターに移せますか？
Ａ：いいえ、移せません。(13/12/19)