### PR TITLE
Shuffle

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1043,6 +1043,12 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 			mainGame->btnEP->setEnabled(true);
 			mainGame->btnEP->setPressed(false);
 		}
+		if (BufferIO::ReadInt8(pbuf)) {
+			mainGame->canShuffle = true;
+		}
+		else {
+			mainGame->canShuffle = false;
+		}
 		return false;
 	}
 	case MSG_SELECT_EFFECTYN: {

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -250,6 +250,12 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				mainGame->HideElement(mainGame->wANCard, true);
 				break;
 			}
+			case BUTTON_CMD_SHUFFLE: {
+				mainGame->wCmdMenu->setVisible(false);
+				DuelClient::SetResponseI(8);
+				DuelClient::SendResponse();
+				break;
+			}
 			case BUTTON_CMD_ACTIVATE: {
 				mainGame->wCmdMenu->setVisible(false);
 				if(!list_command) {
@@ -984,17 +990,17 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					break;
 				}
 				case LOCATION_HAND: {
-										if (!clicked_card)
-											break;
-										int command_flag = clicked_card->cmdFlag;
-										if (clicked_card->overlayed.size())
-											command_flag |= COMMAND_LIST;
-										list_command = 0;
-										if (hovered_location & LOCATION_HAND && mainGame->canShuffle
-											&& mainGame->dInfo.curMsg == MSG_SELECT_IDLECMD)
-											command_flag |= COMMAND_SHUFFLE;
-										ShowMenu(command_flag, x, y);
-										break;
+					if (!clicked_card)
+						break;
+					int command_flag = clicked_card->cmdFlag;
+					if (clicked_card->overlayed.size())
+						command_flag |= COMMAND_LIST;
+					list_command = 0;
+					if (hovered_location & LOCATION_HAND && mainGame->canShuffle
+						&& mainGame->dInfo.curMsg == MSG_SELECT_IDLECMD)
+						command_flag |= COMMAND_SHUFFLE;
+					ShowMenu(command_flag, x, y);
+					break;
 				}
 				case LOCATION_MZONE:
 				case LOCATION_SZONE: {

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -983,7 +983,19 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					ShowMenu(command_flag, x, y);
 					break;
 				}
-				case LOCATION_HAND:
+				case LOCATION_HAND: {
+										if (!clicked_card)
+											break;
+										int command_flag = clicked_card->cmdFlag;
+										if (clicked_card->overlayed.size())
+											command_flag |= COMMAND_LIST;
+										list_command = 0;
+										if (hovered_location & LOCATION_HAND && mainGame->canShuffle
+											&& mainGame->dInfo.curMsg == MSG_SELECT_IDLECMD)
+											command_flag |= COMMAND_SHUFFLE;
+										ShowMenu(command_flag, x, y);
+										break;
+				}
 				case LOCATION_MZONE:
 				case LOCATION_SZONE: {
 					if(!clicked_card)
@@ -1675,6 +1687,12 @@ void ClientField::ShowMenu(int flag, int x, int y) {
 		return;
 	}
 	int height = 1;
+	if (flag & COMMAND_SHUFFLE) {
+		mainGame->btnShuffle->setVisible(true);
+		mainGame->btnShuffle->setRelativePosition(position2di(1, height));
+		height += 21;
+	}
+	else mainGame->btnShuffle->setVisible(false);
 	if(flag & COMMAND_ACTIVATE) {
 		mainGame->btnActivate->setVisible(true);
 		mainGame->btnActivate->setRelativePosition(position2di(1, height));

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -355,6 +355,7 @@ bool Game::Initialize() {
 	btnRepos = env->addButton(rect<s32>(1, 106, 99, 126), wCmdMenu, BUTTON_CMD_REPOS, dataManager.GetSysString(1154));
 	btnAttack = env->addButton(rect<s32>(1, 127, 99, 147), wCmdMenu, BUTTON_CMD_ATTACK, dataManager.GetSysString(1157));
 	btnShowList = env->addButton(rect<s32>(1, 148, 99, 168), wCmdMenu, BUTTON_CMD_SHOWLIST, dataManager.GetSysString(1158));
+	btnShuffle = env->addButton(rect<s32>(1, 169, 99, 189), wCmdMenu, BUTTON_CMD_SHUFFLE, dataManager.GetSysString(1307));
 	//deck edit
 	wDeckEdit = env->addStaticText(L"", rect<s32>(309, 8, 605, 130), true, false, 0, -1, true);
 	wDeckEdit->setVisible(false);

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -112,6 +112,7 @@ public:
 	std::vector<int> logParam;
 	std::wstring chatMsg[8];
 
+	bool canShuffle;
 	int hideChatTimer;
 	bool hideChat;
 	int chatTiming[8];

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -428,6 +428,7 @@ extern Game* mainGame;
 #define BUTTON_CMD_REPOS			245
 #define BUTTON_CMD_ATTACK			246
 #define BUTTON_CMD_SHOWLIST			247
+#define BUTTON_CMD_SHUFFLE			248
 #define BUTTON_ANNUMBER_OK			250
 #define BUTTON_ANCARD_OK			251
 #define EDITBOX_ANCARD				252

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -299,6 +299,7 @@ public:
 	irr::gui::IGUIButton* btnRepos;
 	irr::gui::IGUIButton* btnAttack;
 	irr::gui::IGUIButton* btnShowList;
+	irr::gui::IGUIButton* btnShuffle;
 	//chat window
 	irr::gui::IGUIWindow* wChat;
 	irr::gui::IGUIListBox* lstChatLog;

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -250,7 +250,7 @@ bool ReplayMode::ReplayAnalyze(char* msg, unsigned int len) {
 			count = BufferIO::ReadInt8(pbuf);
 			pbuf += count * 7;
 			count = BufferIO::ReadInt8(pbuf);
-			pbuf += count * 11 + 2;
+			pbuf += count * 11 + 3;
 			ReplayRefresh();
 			return ReadReplayResponse();
 		}

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -637,7 +637,7 @@ int SingleDuel::Analyze(char* msgbuffer, unsigned int len) {
 			count = BufferIO::ReadInt8(pbuf);
 			pbuf += count * 7;
 			count = BufferIO::ReadInt8(pbuf);
-			pbuf += count * 11 + 2;
+			pbuf += count * 11 + 3;
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -161,7 +161,7 @@ bool SingleMode::SinglePlayAnalyze(char* msg, unsigned int len) {
 			count = BufferIO::ReadInt8(pbuf);
 			pbuf += count * 7;
 			count = BufferIO::ReadInt8(pbuf);
-			pbuf += count * 11 + 2;
+			pbuf += count * 11 + 3;
 			SinglePlayRefresh();
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -570,7 +570,7 @@ int TagDuel::Analyze(char* msgbuffer, unsigned int len) {
 			count = BufferIO::ReadInt8(pbuf);
 			pbuf += count * 7;
 			count = BufferIO::ReadInt8(pbuf);
-			pbuf += count * 11 + 2;
+			pbuf += count * 11 + 3;
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);

--- a/ocgcore/field.cpp
+++ b/ocgcore/field.cpp
@@ -27,6 +27,7 @@ field::field(duel* pduel) {
 	this->pduel = pduel;
 	infos.field_id = 1;
 	infos.copy_id = 1;
+	infos.shuffle_count = 0;
 	infos.turn_id = 0;
 	infos.card_id = 1;
 	infos.phase = 0;

--- a/ocgcore/field.h
+++ b/ocgcore/field.h
@@ -114,6 +114,7 @@ struct field_info {
 	uint8 phase;
 	uint8 turn_player;
 	uint8 priorities[2];
+	uint8 shuffle_count;
 };
 struct lpcost {
 	int32 count;

--- a/ocgcore/playerop.cpp
+++ b/ocgcore/playerop.cpp
@@ -139,11 +139,15 @@ int32 field::select_idle_command(uint16 step, uint8 playerid) {
 			pduel->write_buffer8(1);
 		else
 			pduel->write_buffer8(0);
+		if(infos.shuffle_count <5 && player[(uint32)playerid].list_hand.size() > 1)
+			pduel->write_buffer8(1);
+		else
+			pduel->write_buffer8(0);
 		return FALSE;
 	} else {
 		uint32 t = returns.ivalue[0] & 0xffff;
 		uint32 s = returns.ivalue[0] >> 16;
-		if(t < 0 || t > 7 || s < 0
+		if(t < 0 || t > 8 || s < 0
 		        || (t == 0 && s >= core.summonable_cards.size())
 		        || (t == 1 && s >= core.spsummonable_cards.size())
 		        || (t == 2 && s >= core.repositionable_cards.size())
@@ -151,7 +155,8 @@ int32 field::select_idle_command(uint16 step, uint8 playerid) {
 		        || (t == 4 && s >= core.ssetable_cards.size())
 		        || (t == 5 && s >= core.select_chains.size())
 		        || (t == 6 && (infos.phase != PHASE_MAIN1 || !core.to_bp))
-		        || (t == 7 && !core.to_ep)) {
+		        || (t == 7 && !core.to_ep)
+				|| (t == 8 && !(infos.shuffle_count <5 && player[(uint32)playerid].list_hand.size() > 1))) {
 			pduel->write_buffer8(MSG_RETRY);
 			return FALSE;
 		}

--- a/ocgcore/processor.cpp
+++ b/ocgcore/processor.cpp
@@ -2701,6 +2701,11 @@ int32 field::process_idle_command(uint16 step) {
 		} else if(ctype == 4) {
 			core.units.begin()->step = 8;
 			return FALSE;
+		} else if (ctype == 8) {
+			core.units.begin()->step = -1;
+			shuffle(infos.turn_player, LOCATION_HAND);
+			infos.shuffle_count++;
+			return FALSE;
 		} else {
 			core.units.begin()->step = 9;
 			pduel->write_buffer8(MSG_HINT);
@@ -2789,6 +2794,7 @@ int32 field::process_idle_command(uint16 step) {
 	}
 	case 11: {
 		returns.ivalue[0] = core.units.begin()->arg1;
+		infos.shuffle_count = 0;
 		return TRUE;
 	}
 	case 12: {


### PR DESCRIPTION
added the option for the turn player to manually shuffle his hand in his main phase ( max. 5 times per turn)