### PR TITLE
fix Secret Pass to the Treasures

### DIFF
--- a/script/c77876207.lua
+++ b/script/c77876207.lua
@@ -1,5 +1,4 @@
 --財宝への隠し通路
---not fully implemented
 function c77876207.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -21,15 +20,11 @@ function c77876207.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c77876207.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and c77876207.filter(tc) then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_DIRECT_ATTACK)
-		e1:SetCondition(c77876207.atcon)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e1)
 	end
-end
-function c77876207.atcon(e)
-	return e:GetHandler():IsAttackBelow(1000)
 end


### PR DESCRIPTION
Fix this: If the monster ATK of effect has been applied monster of "Secret Pass to the Treasures" is higher than 1000, that monster cannot attack directly.

http://yugioh-wiki.net/index.php?%A1%D4%BA%E2%CA%F5%A4%D8%A4%CE%B1%A3%A4%B7%C4%CC%CF%A9%A1%D5#n19ff887
Ｑ：このカードの効果が適用されたモンスターの攻撃力が1000より高くなった場合、直接攻撃できますか？
Ａ：はい、直接攻撃できます(14/09/01)