### PR TITLE
fix Inzektor Giga-Weevil, Inzektor Giga-Mantis, Inzektor Giga-Cricket

### DIFF
--- a/script/c21977828.lua
+++ b/script/c21977828.lua
@@ -53,10 +53,11 @@ function c21977828.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c21977828.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 end
 function c21977828.eqlimit(e,c)
-	return c:IsSetCard(0x56)
+	return c==e:GetLabelObject()
 end
 function c21977828.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/script/c65844845.lua
+++ b/script/c65844845.lua
@@ -55,8 +55,9 @@ function c65844845.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c65844845.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 end
 function c65844845.eqlimit(e,c)
-	return c:IsSetCard(0x56)
+	return c==e:GetLabelObject()
 end

--- a/script/c94573223.lua
+++ b/script/c94573223.lua
@@ -53,10 +53,11 @@ function c94573223.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(c94573223.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
 end
 function c94573223.eqlimit(e,c)
-	return c:IsSetCard(0x56)
+	return c==e:GetLabelObject()
 end
 function c94573223.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
Fix this: If Inzektor Giga-Mantis, Inzektor Giga-Weevil and Inzektor Giga-Cricket become Equip Card, You can Switch 1 Equip Card equipped to Inzektor Giga-Mantis, Inzektor Giga-Weevil and Inzektor Giga-Cricket to another correct target in Tailor of the Fickle's effect.

http://yugioh-wiki.net/index.php?%B9%C3%C3%EE%C1%F5%B5%A1#g98ec540
Ｑ：《甲虫装機 ギガウィービル》や《甲虫装機 ギガマンティス》が自身の効果で装備カードになっています。
　　この時、《力の集約》や《移り気な仕立屋》等で他のモンスターに装備対象を変更できますか？
Ａ：いいえ、できません。(11/11/21)