### PR TITLE
fix Superheavy Samurai Trumpeter(2)

### DIFF
--- a/script/c64373401.lua
+++ b/script/c64373401.lua
@@ -41,7 +41,7 @@ function c64373401.hspcon2(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SPECIAL+1
 end
 function c64373401.hspop(e,tp,eg,ep,ev,re,r,rp,c)
-	local e1=Effect.CreateEffect(c)
+	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)


### PR DESCRIPTION
Fix this: Superheavy Samurai Trumpeter Special Summoned turn, you can Special Summon other than "Superheavy Samurai" monster.