### PR TITLE
Update c97211663.lua

### DIFF
--- a/script/c97211663.lua
+++ b/script/c97211663.lua
@@ -24,14 +24,10 @@ function c97211663.filter(c,e,tp,m)
 	if not c:IsSetCard(0xb4) or bit.band(c:GetType(),0x81)~=0x81
 		or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,true,true) or c:IsHasEffect(EFFECT_NECRO_VALLEY) then return false end
 	if c:IsCode(21105106) then return c:IsLocation(LOCATION_HAND) and c:ritual_custom_operation(m) end
-	local mg=nil
 	if c.mat_filter then
-		mg=m:Filter(c.mat_filter,c)
-	else
-		mg=m:Clone()
-		mg:RemoveCard(c)
+		m=m:Filter(c.mat_filter,c)
 	end
-	return mg:CheckWithSumEqual(Card.GetRitualLevel,c:GetLevel(),1,99,c)
+	return m:CheckWithSumEqual(Card.GetRitualLevel,c:GetLevel(),1,99,c)
 end
 function c97211663.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
@@ -51,7 +47,6 @@ function c97211663.activate(e,tp,eg,ep,ev,re,r,rp)
 			local mat=tc:GetMaterial()
 			Duel.ReleaseRitualMaterial(mat)
 		else
-			mg1:RemoveCard(tc)
 			if tc.mat_filter then
 				mg1=mg1:Filter(tc.mat_filter,nil)
 			end


### PR DESCRIPTION

Ｑ：コスト等で直接墓地へ送られた墓地の影霊衣儀式モンスターを指定し儀式召喚できますか？
Ａ：はい、できます。（14/11/15）

http://yugioh-wiki.net/?%A1%D4%B1%C6%CE%EE%B0%E1%A4%CE%C8%BF%BA%B2%BD%D1%A1%D5