### PR TITLE
Update c32441317.lua

### DIFF
--- a/script/c32441317.lua
+++ b/script/c32441317.lua
@@ -27,7 +27,7 @@ function c32441317.mgfilter(c,e,tp,sync)
 end
 function c32441317.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) then return end
+	if tc:IsFacedown() or not tc:IsRelateToEffect(e) then return end
 	local mg=tc:GetMaterial()
 	local sumable=true
 	local sumtype=tc:GetSummonType()


### PR DESCRIPTION
同调解除在那只同调怪兽中途被扣成里侧表示的场合，效果不适用，但是这里漏掉了这一判定