### PR TITLE
Update c4141820.lua

### DIFF
--- a/script/c4141820.lua
+++ b/script/c4141820.lua
@@ -28,7 +28,7 @@ function c4141820.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EVENT_BATTLE_DAMAGE)
 		e1:SetOperation(c4141820.hdop)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e1)
+		rc:RegisterEffect(e1,true)
 		rc:RegisterFlagEffect(4141820,RESET_EVENT+0x1fe0000,0,1)
 	end
 end


### PR DESCRIPTION
仪式魔人的效果不是对仪式怪兽的影响，不应检查仪式怪兽的效果耐性。
顺便一提，给仪式怪兽注册效果的写法其实并不严谨的感觉。