### PR TITLE
Update c33145233.lua

### DIFF
--- a/script/c33145233.lua
+++ b/script/c33145233.lua
@@ -29,7 +29,7 @@ function c33145233.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
 		e1:SetValue(c33145233.tglimit)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e1)
+		rc:RegisterEffect(e1,true)
 		rc:RegisterFlagEffect(33145233,RESET_EVENT+0x1fe0000,0,1)
 	end
 end


### PR DESCRIPTION
仪式魔人的效果不是对仪式怪兽的影响，不应检查仪式怪兽的效果耐性。
顺便一提，给仪式怪兽注册效果的写法其实并不严谨的感觉。