### PR TITLE
Update c34358408.lua

### DIFF
--- a/script/c34358408.lua
+++ b/script/c34358408.lua
@@ -28,7 +28,7 @@ function c34358408.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EVENT_BATTLE_DESTROYING)
 		e1:SetOperation(c34358408.drawop)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e1)
+		rc:RegisterEffect(e1,true)
 		rc:RegisterFlagEffect(34358408,RESET_EVENT+0x1fe0000,0,1)
 	end
 end


### PR DESCRIPTION
仪式魔人的效果不是对仪式怪兽的影响，不应检查仪式怪兽的效果耐性。
顺便一提，给仪式怪兽注册效果的写法其实并不严谨的感觉。