### PR TITLE
Update c30492798.lua

### DIFF
--- a/script/c30492798.lua
+++ b/script/c30492798.lua
@@ -29,7 +29,7 @@ function c30492798.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_IMMUNE_EFFECT)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
 		e1:SetValue(c30492798.efilter)
-		rc:RegisterEffect(e1)
+		rc:RegisterEffect(e1,true)
 		rc:RegisterFlagEffect(30492798,RESET_EVENT+0x1fe0000,0,1)
 	end
 end


### PR DESCRIPTION
仪式魔人的效果不是对仪式怪兽的影响，不应检查仪式怪兽的效果耐性。
顺便一提，给仪式怪兽注册效果的写法其实并不严谨的感觉。