### PR TITLE
fix Cobalt Eagle

### DIFF
--- a/script/c21698716.lua
+++ b/script/c21698716.lua
@@ -47,7 +47,7 @@ function c21698716.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c21698716.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6628&keyword=&tag=0
Q.「宝玉獣 コバルト・イーグル」の『１ターンに１度、自分のメインフェイズ時に発動できる。自分フィールド上の「宝玉獣」と名のついたカード１枚を選択して持ち主のデッキの一番上に戻す』効果を発動し、対象として、自分のモンスターゾーンに表側表示で存在する「宝玉獣 トパーズ・タイガー」を選択しました。

その効果の発動にチェーンして「月の書」が発動し、「宝玉獣 トパーズ・タイガー」が裏側守備表示になった場合、「宝玉獣 コバルト・イーグル」の効果処理はどうなりますか？
A.質問の状況のように、「宝玉獣 コバルト・イーグル」の効果の対象として選択した「宝玉獣 トパーズ・タイガー」が効果処理時に裏側守備表示になっている場合には、『持ち主のデッキの一番上に戻す』処理は適用されません。
（「宝玉獣 トパーズ・タイガー」はフィールドに残ります。）