### PR TITLE
fix Mechquipped Angineer

### DIFF
--- a/script/c15914410.lua
+++ b/script/c15914410.lua
@@ -28,7 +28,7 @@ function c15914410.postg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c15914410.posop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsPosition(POS_FACEUP_ATTACK) and tc:IsRelateToEffect(e) then
+	if tc and tc:IsRelateToEffect(e) then
 		Duel.ChangePosition(tc,POS_FACEUP_DEFENCE)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12886&keyword=&tag=-1
Q.「機装天使エンジネル」の効果の対象として選択したモンスターが、チェーンして発動した「月の書」等によって、効果処理時に裏側守備表示になっている場合、そのモンスターは戦闘及びカードの効果では破壊されなくなりますか？
A.「機装天使エンジネル」の効果の対象として選択したモンスターが、チェーンして発動した「月の書」等によって効果処理時に裏側守備表示になっている場合でも、効果処理は通常通り適用されます。

選択したモンスターは表側守備表示になり、『このターンそのモンスターは戦闘及びカードの効果では破壊されない』効果も適用されます。
（そのモンスターがリバースモンスター等であった場合、その効果は一連のチェーン処理後に発動する事になります。）