### PR TITLE
fix Berserker Soul

### DIFF
--- a/script/c15381252.lua
+++ b/script/c15381252.lua
@@ -28,7 +28,7 @@ function c15381252.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c15381252.activate(e,tp,eg,ep,ev,re,r,rp)
 	local count=8
-	while count>0 and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 do
+	while count>0 and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 and Duel.GetLP(1-tp)>0 do
 		Duel.ConfirmDecktop(tp,1)
 		local g=Duel.GetDecktopGroup(tp,1)
 		local tc=g:GetFirst()


### PR DESCRIPTION
Fix this: Your opponent's LP is 0, you can excavate the top card of your Deck.

http://yugioh-wiki.net/index.php?%A1%D4%B6%B8%C0%EF%BB%CE%A4%CE%BA%B2%A1%D5#faq
Ｑ：《狂戦士の魂》の効果ダメージにより相手のライフが０になりましたが、まだ《狂戦士の魂》の効果処理が終了していません。
　　この場合まだデュエルは終了せず、モンスター以外をめくる、もしくは８回目の処理を行うまで、「デッキの一番上のカードをめくり～」の処理を繰り返しますか？
Ａ：《狂戦士の魂》の効果処理中に相手ライフポイントが０になった場合は、その時点でデュエルが終了となります。(14/08/08)