### PR TITLE
Update c69270537.lua

### DIFF
--- a/script/c69270537.lua
+++ b/script/c69270537.lua
@@ -28,7 +28,7 @@ function c69270537.activate(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() and Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)~=0
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1 and tc:IsLocation(LOCATION_EXTRA) then
 		local sg=Duel.GetMatchingGroup(c69270537.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
-		if tc:CheckFusionMaterial(sg,nil,PLAYER_NONE) and Duel.SelectYesNo(tp,aux.Stringid(69270537,0)) then
+		if tc.material_count>=2 and tc:CheckFusionMaterial(sg,nil,PLAYER_NONE) and Duel.SelectYesNo(tp,aux.Stringid(69270537,0)) then
 			local mats=Duel.SelectFusionMaterial(tp,tc,sg,nil,PLAYER_NONE)
 			Duel.SpecialSummon(mats,0,tp,tp,false,false,POS_FACEUP)
 		end

--- a/script/c69270537.lua
+++ b/script/c69270537.lua
@@ -28,7 +28,8 @@ function c69270537.activate(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() and Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)~=0
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1 and tc:IsLocation(LOCATION_EXTRA) then
 		local sg=Duel.GetMatchingGroup(c69270537.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
-		if tc.material_count>=2 and tc:CheckFusionMaterial(sg,nil,PLAYER_NONE) and Duel.SelectYesNo(tp,aux.Stringid(69270537,0)) then
+		local count=tc.material_count
+		if count and count>=2 and tc:CheckFusionMaterial(sg,nil,PLAYER_NONE) and Duel.SelectYesNo(tp,aux.Stringid(69270537,0)) then
 			local mats=Duel.SelectFusionMaterial(tp,tc,sg,nil,PLAYER_NONE)
 			Duel.SpecialSummon(mats,0,tp,tp,false,false,POS_FACEUP)
 		end


### PR DESCRIPTION
根据新余骑士的调整，新余骑士被接触分离送回去不能特殊召唤一组素材。
接触分离仅当送回了“使用的素材均为确指的卡名”的融合怪兽的场合，才能特殊召唤一组素材。
根据现有的融合手续写法，这个是修改幅度最小的BUG修正方式。