### PR TITLE
Update c69270537.lua

### DIFF
--- a/script/c69270537.lua
+++ b/script/c69270537.lua
@@ -28,7 +28,8 @@ function c69270537.activate(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() and Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)~=0
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1 and tc:IsLocation(LOCATION_EXTRA) then
 		local sg=Duel.GetMatchingGroup(c69270537.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
-		if tc:CheckFusionMaterial(sg,nil,PLAYER_NONE) and Duel.SelectYesNo(tp,aux.Stringid(69270537,0)) then
+		local count=tc.material_count
++		if count and count>=2 and tc:CheckFusionMaterial(sg,nil,PLAYER_NONE) and Duel.SelectYesNo(tp,aux.Stringid(69270537,0)) then
 			local mats=Duel.SelectFusionMaterial(tp,tc,sg,nil,PLAYER_NONE)
 			Duel.SpecialSummon(mats,0,tp,tp,false,false,POS_FACEUP)
 		end


### PR DESCRIPTION
根据「新余骑士」的调整，「接触分离」送回了「新余骑士」的场合，不能特殊召唤一组素材。
「接触分离」仅当送回了“融合素材皆为确指”的融合怪兽去额外卡组的场合，才能特殊召唤一组素材。
根据目前的融合手续写法，这是修改幅度最小的BUG修复方案。
此外，如果某一天出现了「」+「」+XX怪兽1只以上这类的，且他设定了material_count为2或者更大，这个判定就会出BUG。到时候再去修改那些融合怪兽的material_count为好。