### PR TITLE
fix D/D Magical Astronomer Galilei, D/D Magical Astronomer Kepler

### DIFF
--- a/script/c11609969.lua
+++ b/script/c11609969.lua
@@ -65,15 +65,16 @@ end
 function c11609969.scop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) or c:GetLeftScale()==1 then return end
-	local scl=math.max(1,c:GetLeftScale()-2)
+	local scl=2
+	if c:GetLeftScale()==2 then scl=1 end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetCode(EFFECT_CHANGE_LSCALE)
-	e1:SetValue(scl)
+	e1:SetCode(EFFECT_UPDATE_LSCALE)
+	e1:SetValue(-scl)
 	e1:SetReset(RESET_EVENT+0x1ff0000)
 	c:RegisterEffect(e1)
 	local e2=e1:Clone()
-	e2:SetCode(EFFECT_CHANGE_RSCALE)
+	e2:SetCode(EFFECT_UPDATE_RSCALE)
 	c:RegisterEffect(e2)
 	local g=Duel.GetMatchingGroup(c11609969.filter,tp,LOCATION_MZONE,0,nil,scl)
 	if g:GetCount()>0 then

--- a/script/c74605254.lua
+++ b/script/c74605254.lua
@@ -66,15 +66,16 @@ end
 function c74605254.scop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) or c:GetLeftScale()>=10 then return end
-	local scl=math.min(10,c:GetLeftScale()+2)
+	local scl=2
+	if c:GetLeftScale()==9 then scl=1 end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetCode(EFFECT_CHANGE_LSCALE)
+	e1:SetCode(EFFECT_UPDATE_LSCALE)
 	e1:SetValue(scl)
 	e1:SetReset(RESET_EVENT+0x1ff0000)
 	c:RegisterEffect(e1)
 	local e2=e1:Clone()
-	e2:SetCode(EFFECT_CHANGE_RSCALE)
+	e2:SetCode(EFFECT_UPDATE_RSCALE)
 	c:RegisterEffect(e2)
 	local g=Duel.GetMatchingGroup(c74605254.filter,tp,LOCATION_MZONE,0,nil,scl)
 	if g:GetCount()>0 then


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14174
Q.「DD魔導賢者ガリレイ」の『②：自分スタンバイフェイズに発動する。このカードのPスケールを２つ上げる（最大１０まで）。その後、このカードのPスケール以下のレベルを持つ、「DD」モンスター以外の自分フィールドのモンスターを全て破壊する』ペンデュラム効果の発動にチェーンして「ペンデュラム・ターン」を発動した場合、ペンデュラムスケールはどうなりますか？

また、その後に「ペンデュラム・ターン」の効果の適用がなくなった場合、ペンデュラムスケールはどうなりますか？
A.ペンデュラムスケールが１の「DD魔導賢者ガリレイ」のペンデュラム効果の発動にチェーンして、「ペンデュラム・ターン」を発動し、「DD魔導賢者ガリレイ」のペンデュラムスケールが１０になった場合、『このカードのPスケールを２つ上げる（最大１０まで）』効果の処理が適用されませんので、『その後、』の処理によってモンスターが破壊される事はありません。
（その後に、「ペンデュラム・ターン」の効果の適用がなくなった場合、「ペンデュラム・ターン」の効果が適用される前のペンデュラムスケール、つまり、１に戻ります。）

また、ペンデュラムスケールが１の「DD魔導賢者ガリレイ」のペンデュラム効果の発動にチェーンして、「ペンデュラム・ターン」を発動し、「DD魔導賢者ガリレイ」のペンデュラムスケールが８になった場合、『このカードのPスケールを２つ上げる（最大１０まで）』効果の処理が適用され、「DD魔導賢者ガリレイ」のペンデュラムスケールが１０になります。『その後、』の処理も通常通り適用され、「DD」と名のついたモンスター以外の自分フィールドのレベル１０以下のモンスターが全て破壊される事になります。（その後に、「ペンデュラム・ターン」の効果の適用がなくなった場合、「ペンデュラム・ターン」の効果が適用される前のペンデュラムスケールの数に『このカードのPスケールを２つ上げる』効果によって上がった分を加えたペンデュラムスケールになります。つまり、この場合、ペンデュラムスケールは３になります。）