### PR TITLE
fix reveal card-discard check

### DIFF
--- a/script/c10406322.lua
+++ b/script/c10406322.lua
@@ -29,13 +29,13 @@ function c10406322.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c10406322.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 	Duel.Hint(HINT_SELECTMSG,tp,0)
 	local ac=Duel.AnnounceCard(tp)
 	e:SetLabel(ac)
 end
 function c10406322.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c10530913.lua
+++ b/script/c10530913.lua
@@ -49,10 +49,10 @@ function c10530913.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c10530913.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c10530913.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c10753491.lua
+++ b/script/c10753491.lua
@@ -23,9 +23,10 @@ function c10753491.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c10753491.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c10753491.operation(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	local ct=Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)
 	if ct==0 then return end
 	local ac=1

--- a/script/c11682713.lua
+++ b/script/c11682713.lua
@@ -21,10 +21,10 @@ function c11682713.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c11682713.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c11682713.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c15381252.lua
+++ b/script/c15381252.lua
@@ -24,11 +24,11 @@ function c15381252.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(g,REASON_COST+REASON_DISCARD)
 end
 function c15381252.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c15381252.activate(e,tp,eg,ep,ev,re,r,rp)
 	local count=8
-	while count>0 and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 and Duel.GetLP(1-tp)>0 do
+	while count>0 and Duel.IsPlayerCanDiscardDeck(tp,1) and Duel.GetLP(1-tp)>0 do
 		if count<8 then Duel.BreakEffect() end
 		Duel.ConfirmDecktop(tp,1)
 		local g=Duel.GetDecktopGroup(tp,1)

--- a/script/c18631392.lua
+++ b/script/c18631392.lua
@@ -46,7 +46,7 @@ function c18631392.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.SendtoGrave(g1,REASON_COST)
 end
 function c18631392.anctg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>=3 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,3) end
 	Duel.Hint(HINT_SELECTMSG,tp,0)
 	local ac1=Duel.AnnounceCard(tp)
 	Duel.Hint(HINT_SELECTMSG,tp,0)
@@ -62,6 +62,7 @@ end
 function c18631392.retop(code1,code2,code3)
 	return
 		function (e,tp,eg,ep,ev,re,r,rp)
+			if not Duel.IsPlayerCanDiscardDeck(tp,3) then return end
 			local c=e:GetHandler()
 			Duel.ConfirmDecktop(tp,3)
 			local g=Duel.GetDecktopGroup(tp,3)

--- a/script/c20579538.lua
+++ b/script/c20579538.lua
@@ -28,13 +28,13 @@ function c20579538.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
 function c20579538.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c20579538.tdfilter(c)
 	return c:IsSetCard(0xa6) and c:IsType(TYPE_MONSTER) and c:IsAbleToDeck()
 end
 function c20579538.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	Duel.DisableShuffleCheck()

--- a/script/c22796548.lua
+++ b/script/c22796548.lua
@@ -21,13 +21,14 @@ function c22796548.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,500)
 end
 function c22796548.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToHand,tp,LOCATION_DECK,0,1,nil) end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1)
+		and Duel.IsExistingMatchingCard(Card.IsAbleToHand,tp,LOCATION_DECK,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,0)
 	local ac=Duel.AnnounceCard(tp)
 	e:SetLabel(ac)
 end
 function c22796548.operation(e,tp,eg,ep,ev,re,r,rp)
-	if not e:GetHandler():IsRelateToEffect(e) or Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not e:GetHandler():IsRelateToEffect(e) or not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c25824484.lua
+++ b/script/c25824484.lua
@@ -19,10 +19,10 @@ function c25824484.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c25824484.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c25824484.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c36046926.lua
+++ b/script/c36046926.lua
@@ -23,9 +23,10 @@ function c36046926.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c36046926.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c36046926.operation(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	local ct=Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)
 	if ct==0 then return end
 	local ac=1

--- a/script/c47077318.lua
+++ b/script/c47077318.lua
@@ -27,10 +27,10 @@ function c47077318.condition(e,tp,eg,ep,ev,re,r,rp)
 		and c:GetPreviousControler()==tp
 end
 function c47077318.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c47077318.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c47741109.lua
+++ b/script/c47741109.lua
@@ -17,10 +17,10 @@ function c47741109.condition(e,tp,eg,ep,ev,re,r,rp)
 		(c:IsReason(REASON_REVEAL) or c:GetPreviousPosition()==POS_FACEUP_DEFENCE or Duel.IsPlayerAffectedByEffect(tp,EFFECT_REVERSE_DECK)))
 end
 function c47741109.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c47741109.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c49838105.lua
+++ b/script/c49838105.lua
@@ -36,16 +36,16 @@ end
 function c49838105.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
-		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 and Duel.SelectYesNo(tp,aux.Stringid(49838105,2)) then
+		and Duel.IsPlayerCanDiscardDeck(tp,1) and Duel.SelectYesNo(tp,aux.Stringid(49838105,2)) then
 		e:SetLabel(1)
 	else e:SetLabel(0) end
 end
 function c49838105.target2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c49838105.operation(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetLabel()==0 or not e:GetHandler():IsRelateToEffect(e) then return end
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c60990740.lua
+++ b/script/c60990740.lua
@@ -30,12 +30,12 @@ function c60990740.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
 end
 function c60990740.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGrave,tp,LOCATION_DECK,0,1,nil)
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1)
 		and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
 		and not Duel.IsPlayerAffectedByEffect(tp,EFFECT_CANNOT_SSET) end
 end
 function c60990740.operation(e,tp,eg,ep,ev,re,r,rp)
-	if not Duel.IsExistingMatchingCard(Card.IsAbleToGrave,tp,LOCATION_DECK,0,1,nil) then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local tc=Duel.GetDecktopGroup(tp,1):GetFirst()
 	Duel.DisableShuffleCheck()

--- a/script/c62017867.lua
+++ b/script/c62017867.lua
@@ -17,6 +17,7 @@ function c62017867.initial_effect(c)
 	e2:SetRange(LOCATION_GRAVE)
 	e2:SetCondition(c62017867.atkcon)
 	e2:SetCost(c62017867.atkcost)
+	e2:SetTarget(c62017867.atktg)
 	e2:SetOperation(c62017867.atkop)
 	c:RegisterEffect(e2)
 end
@@ -38,8 +39,11 @@ function c62017867.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
 end
+function c62017867.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
+end
 function c62017867.atkop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c62434031.lua
+++ b/script/c62434031.lua
@@ -21,10 +21,10 @@ function c62434031.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c62434031.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c62434031.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c63257623.lua
+++ b/script/c63257623.lua
@@ -26,10 +26,10 @@ function c63257623.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c63257623.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c63257623.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c63942761.lua
+++ b/script/c63942761.lua
@@ -6,18 +6,18 @@ function c63942761.initial_effect(c)
 	e1:SetCategory(CATEGORY_TOGRAVE)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetCode(EVENT_SUMMON_SUCCESS)
-	e1:SetCondition(c63942761.condition)
+	e1:SetTarget(c63942761.target)
 	e1:SetOperation(c63942761.operation)
 	c:RegisterEffect(e1)
 end
-function c63942761.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>=5
+function c63942761.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,5) end
 end
 function c63942761.filter(c)
 	return c:GetType()==0x82 or (c:IsSetCard(0x3a) and c:IsType(TYPE_MONSTER))
 end
 function c63942761.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)<5 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,5) then return end
 	Duel.ConfirmDecktop(tp,5)
 	local g=Duel.GetDecktopGroup(tp,5)
 	local sg=g:Filter(c63942761.filter,nil)

--- a/script/c70222318.lua
+++ b/script/c70222318.lua
@@ -53,11 +53,11 @@ function c70222318.tgcon(e,tp,eg,ep,ev,re,r,rp)
 	return tp~=Duel.GetTurnPlayer()
 end
 function c70222318.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c70222318.tgop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
-	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	Duel.ConfirmDecktop(tp,1)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()

--- a/script/c73136204.lua
+++ b/script/c73136204.lua
@@ -25,12 +25,12 @@ end
 function c73136204.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local ac=Duel.GetFieldGroupCount(tp,0,LOCATION_ONFIELD)
-		return ac>0 and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>=ac
+		return ac>0 and Duel.IsPlayerCanDiscardDeck(tp,ac)
 	end
 end
 function c73136204.operation(e,tp,eg,ep,ev,re,r,rp)
 	local ac=Duel.GetFieldGroupCount(tp,0,LOCATION_ONFIELD)
-	if ac==0 or Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)<ac then return end
+	if ac==0 or not Duel.IsPlayerCanDiscardDeck(tp,ac) then return end
 	Duel.ConfirmDecktop(tp,ac)
 	local g=Duel.GetDecktopGroup(tp,ac)
 	local sg=g:Filter(Card.IsRace,nil,RACE_PLANT)

--- a/script/c95239444.lua
+++ b/script/c95239444.lua
@@ -46,11 +46,12 @@ function c95239444.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c95239444.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1)
 		and Duel.IsExistingMatchingCard(Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
 end
 function c95239444.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	local ct=Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)
 	if ct==0 then return end
 	if ct>3 then ct=3 end

--- a/script/c99429730.lua
+++ b/script/c99429730.lua
@@ -23,9 +23,10 @@ function c99429730.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c99429730.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c99429730.operation(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	local ct=Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)
 	if ct==0 then return end
 	if ct>3 then ct=3 end

--- a/script/c99641328.lua
+++ b/script/c99641328.lua
@@ -23,9 +23,10 @@ function c99641328.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c99641328.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c99641328.operation(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
 	local ct=Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)
 	if ct==0 then return end
 	if ct>5 then ct=5 end


### PR DESCRIPTION
Effect that confirm the card on the top of deck and determine whether it can be sent to grave.
Although the uncertainty of whether it can be sent to grave, this kind of effect still cannot be activated if player cannot discard deck (when effect of 次元要塞兵器/Dimension Fortress Weapon(1596508) or 驚天動地/Earth Shattering(54407825) is applying)
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13629&keyword=&tag=-1
Further, when resolving these kind of effect, if player cannot discard deck, he/she event cannot excavate the top card.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14779&keyword=&tag=-1