### PR TITLE
fix Yosenju Oyamabiko

### DIFF
--- a/script/c69838592.lua
+++ b/script/c69838592.lua
@@ -52,10 +52,14 @@ function c69838592.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummon(e:GetHandler(),0,tp,tp,false,false,POS_FACEUP)
 	end
 end
+function c69838592.filter(c,tc)
+	if not c:IsFaceup() then return false end
+	return tc:GetBaseAttack()~=c:GetAttack() or c:GetBaseAttack()~=c:GetDefence()
+end
 function c69838592.condition(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local bc=c:GetBattleTarget()
-	return c:IsRelateToBattle() and bc and bc:IsFaceup() and bc:IsRelateToBattle()
+	return c:IsRelateToBattle() and bc and c69838592.filter(c,bc) and bc:IsFaceup() and bc:IsRelateToBattle()
 end
 function c69838592.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14850&keyword=&tag=-1
Q.攻撃力が２０００として扱われている「冥府の使者カイエントークン」が相手のモンスターゾーンに存在しています。

その「冥府の使者カイエントークン」と、自分の「妖仙獣 大幽谷響」が戦闘を行う場合、『②：このカードが相手モンスターと戦闘を行うダメージステップ開始時に発動できる。このカードの攻撃力・守備力はターン終了時まで、戦闘を行う相手モンスターの元々の攻撃力と同じになる』効果を発動する事はできますか？
A.「妖仙獣 大幽谷響」の攻撃力は？（つまり、フィールドでの攻撃力は０）であり、戦闘を行う相手の「冥府の使者カイエントークン」の元々の攻撃力は？です。

質問の状況の場合、既に「妖仙獣 大幽谷響」の攻撃力が戦闘を行う相手モンスターの元々の攻撃力と同じですので、「妖仙獣 大幽谷響」の効果を発動する事はできません。