### PR TITLE
fix Dimension Slice

### DIFF
--- a/script/c73632127.lua
+++ b/script/c73632127.lua
@@ -15,12 +15,10 @@ function c73632127.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_TRAP_ACT_IN_SET_TURN)
 	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e2:SetCondition(c73632127.actcon)
 	c:RegisterEffect(e2)
 end
 function c73632127.condition(e,tp,eg,ep,ev,re,r,rp)
-	if eg:GetCount()==1 and eg:GetFirst():GetSummonType()==SUMMON_TYPE_XYZ
-		and eg:GetFirst():IsControler(tp) then return true end
-	if e:GetHandler():IsStatus(STATUS_SET_TURN) then return false end
 	return eg:IsExists(Card.IsControler,1,nil,tp)
 end
 function c73632127.filter(c)
@@ -37,5 +35,11 @@ function c73632127.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)
+	end
+end
+function c73632127.actcon(e)
+	local res,teg,tep,tev,tre,tr,trp=Duel.CheckEvent(EVENT_SPSUMMON_SUCCESS,true)
+	if res then
+		return teg:GetCount()==1 and teg:GetFirst():GetSummonType()==SUMMON_TYPE_XYZ
 	end
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14554&keyword=&tag=-1
Q.自分の魔法＆罠ゾーンには、この自分のターンにセットされた「ディメンション・スライド」が存在しています。

この状況にて、モンスターのエクシーズ召喚に成功した時に「ディメンション・スライド」を発動する場合、「王家の神殿」の『①：自分は罠カード１枚をセットしたターンに発動できる』効果と、「ディメンション・スライド」の『その特殊召喚がエクシーズ召喚だった場合、このカードはセットしたターンに発動できる』効果のどちらによって発動した事になりますか？
A.＜以下のルールは、2015年1月1日より適用されます＞

質問の状況の場合、そのターンにセットされた「ディメンション・スライド」をどちらの効果によって発動するかを選ぶ事ができます。

自身の『その特殊召喚がエクシーズ召喚だった場合、このカードはセットしたターンに発動できる』効果によって発動する事とした場合、「王家の神殿」の『①：自分は罠カード１枚をセットしたターンに発動できる』効果によって、他の罠カードをもう１枚発動する事ができます。

逆に、「王家の神殿」の『①：自分は罠カード１枚をセットしたターンに発動できる』効果によって「ディメンション・スライド」を発動した場合には、このターンにセットされた他の罠カードを発動する事はできません。