### PR TITLE
fix Red Nova Dragon, Vylon Omega

### DIFF
--- a/script/c55863245.lua
+++ b/script/c55863245.lua
@@ -21,6 +21,13 @@ function c55863245.initial_effect(c)
 	e2:SetCode(EFFECT_IMMUNE_EFFECT)
 	e2:SetValue(c55863245.efilter)
 	c:RegisterEffect(e2)
+	--
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e3:SetCondition(c55863245.syncon)
+	e3:SetCode(55863245)
+	c:RegisterEffect(e3)
 end
 function c55863245.synfilter1(c,syncard,tuner,f)
 	return c:IsFaceup() and c:IsCanBeSynchroMaterial(syncard,tuner) and (f==nil or f(c))

--- a/script/c93157004.lua
+++ b/script/c93157004.lua
@@ -46,24 +46,32 @@ function c93157004.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c93157004.matfilter1(c,syncard)
-	return c:IsType(TYPE_TUNER) and c:IsFaceup() and c:IsCanBeSynchroMaterial(syncard)
+	return c:IsType(TYPE_TUNER) and (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and c:IsCanBeSynchroMaterial(syncard)
 end
 function c93157004.matfilter2(c,syncard)
-	return c:IsNotTuner() and c:IsFaceup() and c:IsSetCard(0x30) and c:IsCanBeSynchroMaterial(syncard)
+	return c:IsNotTuner() and (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and c:IsSetCard(0x30) and c:IsCanBeSynchroMaterial(syncard)
 end
-function c93157004.synfilter1(c,syncard,lv,g1,g2)
+function c93157004.synfilter1(c,syncard,lv,g1,g2,g3,g4)
 	local tlv=c:GetSynchroLevel(syncard)
 	if lv-tlv<=0 then return false end
 	local f1=c.tuner_filter
-	return g1:IsExists(c93157004.synfilter2,1,c,syncard,lv-tlv,g2,f1,c)
+	if c:IsHasEffect(55863245) then
+		return g3:IsExists(c93157004.synfilter2,1,c,syncard,lv-tlv,g2,g4,f1,c)
+	else
+		return g1:IsExists(c93157004.synfilter2,1,c,syncard,lv-tlv,g2,g4,f1,c)
+	end
 end
-function c93157004.synfilter2(c,syncard,lv,g2,f1,tuner1)
+function c93157004.synfilter2(c,syncard,lv,g2,g4,f1,tuner1)
 	local tlv=c:GetSynchroLevel(syncard)
 	if lv-tlv<=0 then return false end
 	local f2=c.tuner_filter
 	if f1 and not f1(c) then return false end
 	if f2 and not f2(tuner1) then return false end
-	return g2:IsExists(c93157004.synfilter3,1,nil,syncard,lv-tlv,f1,f2)
+	if (tuner1:IsHasEffect(55863245) and not c:IsLocation(LOCATION_HAND)) or c:IsHasEffect(55863245) then
+		return g4:IsExists(c93157004.synfilter3,1,nil,syncard,lv-tlv,f1,f2)
+	else
+		return g2:IsExists(c93157004.synfilter3,1,nil,syncard,lv-tlv,f1,f2)
+	end
 end
 function c93157004.synfilter3(c,syncard,lv,f1,f2)
 	local mlv=c:GetSynchroLevel(syncard)
@@ -77,6 +85,8 @@ function c93157004.syncon(e,c,tuner)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<-2 then return false end
 	local g1=Duel.GetMatchingGroup(c93157004.matfilter1,tp,LOCATION_MZONE,LOCATION_MZONE,nil,c)
 	local g2=Duel.GetMatchingGroup(c93157004.matfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,nil,c)
+	local g3=Duel.GetMatchingGroup(c93157004.matfilter1,tp,LOCATION_MZONE+LOCATION_HAND,LOCATION_MZONE,nil,c)
+	local g4=Duel.GetMatchingGroup(c93157004.matfilter2,tp,LOCATION_MZONE+LOCATION_HAND,LOCATION_MZONE,nil,c)
 	local pe=Duel.IsPlayerAffectedByEffect(tp,EFFECT_MUST_BE_SMATERIAL)
 	local lv=c:GetLevel()
 	if tuner then
@@ -84,21 +94,23 @@ function c93157004.syncon(e,c,tuner)
 		if lv-tlv<=0 then return false end
 		local f1=tuner.tuner_filter
 		if not pe then
-			return g1:IsExists(c93157004.synfilter2,1,tuner,c,lv-tlv,g2,f1,tuner)
+			return g1:IsExists(c93157004.synfilter2,1,tuner,c,lv-tlv,g2,g4,f1,tuner)
 		else
-			return c93157004.synfilter2(pe:GetOwner(),c,lv-tlv,g2,f1,tuner)
+			return c93157004.synfilter2(pe:GetOwner(),c,lv-tlv,g2,nil,f1,tuner)
 		end
 	end
 	if not pe then
-		return g1:IsExists(c93157004.synfilter1,1,nil,c,lv,g1,g2)
+		return g1:IsExists(c93157004.synfilter1,1,nil,c,lv,g1,g2,g3,g4)
 	else
-		return c93157004.synfilter1(pe:GetOwner(),c,lv,g1,g2)
+		return c93157004.synfilter1(pe:GetOwner(),c,lv,g1,g2,g3,g4)
 	end
 end
 function c93157004.synop(e,tp,eg,ep,ev,re,r,rp,c,tuner)
 	local g=Group.CreateGroup()
 	local g1=Duel.GetMatchingGroup(c93157004.matfilter1,tp,LOCATION_MZONE,LOCATION_MZONE,nil,c)
 	local g2=Duel.GetMatchingGroup(c93157004.matfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,nil,c)
+	local g3=Duel.GetMatchingGroup(c93157004.matfilter1,tp,LOCATION_MZONE+LOCATION_HAND,LOCATION_MZONE,nil,c)
+	local g4=Duel.GetMatchingGroup(c93157004.matfilter2,tp,LOCATION_MZONE+LOCATION_HAND,LOCATION_MZONE,nil,c)
 	local pe=Duel.IsPlayerAffectedByEffect(tp,EFFECT_MUST_BE_SMATERIAL)
 	local lv=c:GetLevel()
 	if tuner then
@@ -108,7 +120,7 @@ function c93157004.synop(e,tp,eg,ep,ev,re,r,rp,c,tuner)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
 		local tuner2=nil
 		if not pe then
-			local t2=g1:FilterSelect(tp,c93157004.synfilter2,1,1,tuner,c,lv-lv1,g2,f1,tuner)
+			local t2=g1:FilterSelect(tp,c93157004.synfilter2,1,1,tuner,c,lv-lv1,g2,g4,f1,tuner)
 			tuner2=t2:GetFirst()
 		else
 			tuner2=pe:GetOwner()
@@ -117,14 +129,20 @@ function c93157004.synop(e,tp,eg,ep,ev,re,r,rp,c,tuner)
 		g:AddCard(tuner2)
 		local lv2=tuner2:GetSynchroLevel(c)
 		local f2=tuner2.tuner_filter
+		local m3=nil
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
-		local m3=g2:FilterSelect(tp,c93157004.synfilter3,1,1,nil,c,lv-lv1-lv2,f1,f2)
+		if tuner2:IsHasEffect(55863245) then
+			m3=g4:FilterSelect(tp,c93157004.synfilter3,1,1,nil,c,lv-lv1-lv2,f1,f2)
+		else
+			m3=g2:FilterSelect(tp,c93157004.synfilter3,1,1,nil,c,lv-lv1-lv2,f1,f2)
+		end
 		g:Merge(m3)
 	else
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
 		local tuner1=nil
+		local hand=nil
 		if not pe then
-			local t1=g1:FilterSelect(tp,c93157004.synfilter1,1,1,nil,c,lv,g1,g2)
+			local t1=g1:FilterSelect(tp,c93157004.synfilter1,1,1,nil,c,lv,g1,g2,g3,g4)
 			tuner1=t1:GetFirst()
 		else
 			tuner1=pe:GetOwner()
@@ -133,14 +151,26 @@ function c93157004.synop(e,tp,eg,ep,ev,re,r,rp,c,tuner)
 		g:AddCard(tuner1)
 		local lv1=tuner1:GetSynchroLevel(c)
 		local f1=tuner1.tuner_filter
+		local tuner2=nil
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
-		local t2=g1:FilterSelect(tp,c93157004.synfilter2,1,1,tuner1,c,lv-lv1,g2,f1,tuner1)
-		local tuner2=t2:GetFirst()
+		if tuner1:IsHasEffect(55863245) then
+			local t2=g3:FilterSelect(tp,c93157004.synfilter2,1,1,tuner1,c,lv-lv1,g2,g4,f1,tuner1)
+			tuner2=t2:GetFirst()
+		else
+			local t2=g1:FilterSelect(tp,c93157004.synfilter2,1,1,tuner1,c,lv-lv1,g2,g4,f1,tuner1)
+			tuner2=t2:GetFirst()
+		end
 		g:AddCard(tuner2)
 		local lv2=tuner2:GetSynchroLevel(c)
 		local f2=tuner2.tuner_filter
+		local m3=nil
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
-		local m3=g2:FilterSelect(tp,c93157004.synfilter3,1,1,nil,c,lv-lv1-lv2,f1,f2)
+		if (tuner1:IsHasEffect(55863245) and not tuner2:IsLocation(LOCATION_HAND))
+			or tuner2:IsHasEffect(55863245) then
+			m3=g4:FilterSelect(tp,c93157004.synfilter3,1,1,nil,c,lv-lv1-lv2,f1,f2)
+		else
+			m3=g2:FilterSelect(tp,c93157004.synfilter3,1,1,nil,c,lv-lv1-lv2,f1,f2)
+		end
 		g:Merge(m3)
 	end
 	c:SetMaterial(g)

--- a/script/c97489701.lua
+++ b/script/c97489701.lua
@@ -53,16 +53,20 @@ function c97489701.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c97489701.matfilter1(c,syncard)
-	return c:IsType(TYPE_TUNER) and c:IsFaceup() and c:IsCanBeSynchroMaterial(syncard)
+	return c:IsType(TYPE_TUNER) and (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and c:IsCanBeSynchroMaterial(syncard)
 end
 function c97489701.matfilter2(c,syncard)
 	return c:IsFaceup() and c:IsCode(70902743) and c:IsCanBeSynchroMaterial(syncard)
 end
-function c97489701.synfilter1(c,syncard,lv,g1,g2)
+function c97489701.synfilter1(c,syncard,lv,g1,g2,g3)
 	local tlv=c:GetSynchroLevel(syncard)
 	if lv-tlv<=0 then return false end
 	local f1=c.tuner_filter
-	return g1:IsExists(c97489701.synfilter2,1,c,syncard,lv-tlv,g2,f1,c)
+	if c:IsHasEffect(55863245) then
+		return g3:IsExists(c97489701.synfilter2,1,c,syncard,lv-tlv,g2,f1,c)
+	else
+		return g1:IsExists(c97489701.synfilter2,1,c,syncard,lv-tlv,g2,f1,c)
+	end
 end
 function c97489701.synfilter2(c,syncard,lv,g2,f1,tuner1)
 	local tlv=c:GetSynchroLevel(syncard)
@@ -84,6 +88,7 @@ function c97489701.syncon(e,c,tuner)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<-2 then return false end
 	local g1=Duel.GetMatchingGroup(c97489701.matfilter1,tp,LOCATION_MZONE,LOCATION_MZONE,nil,c)
 	local g2=Duel.GetMatchingGroup(c97489701.matfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,nil,c)
+	local g3=Duel.GetMatchingGroup(c97489701.matfilter1,tp,LOCATION_MZONE+LOCATION_HAND,LOCATION_MZONE,nil,c)
 	local pe=Duel.IsPlayerAffectedByEffect(tp,EFFECT_MUST_BE_SMATERIAL)
 	local lv=c:GetLevel()
 	if tuner then
@@ -97,7 +102,7 @@ function c97489701.syncon(e,c,tuner)
 		end
 	end
 	if not pe then
-		return g1:IsExists(c97489701.synfilter1,1,nil,c,lv,g1,g2)
+		return g1:IsExists(c97489701.synfilter1,1,nil,c,lv,g1,g2,g3)
 	else
 		return c97489701.synfilter1(pe:GetOwner(),c,lv,g1,g2)
 	end
@@ -106,6 +111,7 @@ function c97489701.synop(e,tp,eg,ep,ev,re,r,rp,c,tuner)
 	local g=Group.CreateGroup()
 	local g1=Duel.GetMatchingGroup(c97489701.matfilter1,tp,LOCATION_MZONE,LOCATION_MZONE,nil,c)
 	local g2=Duel.GetMatchingGroup(c97489701.matfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,nil,c)
+	local g3=Duel.GetMatchingGroup(c97489701.matfilter1,tp,LOCATION_MZONE+LOCATION_HAND,LOCATION_MZONE,nil,c)
 	local pe=Duel.IsPlayerAffectedByEffect(tp,EFFECT_MUST_BE_SMATERIAL)
 	local lv=c:GetLevel()
 	if tuner then
@@ -131,7 +137,7 @@ function c97489701.synop(e,tp,eg,ep,ev,re,r,rp,c,tuner)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
 		local tuner1=nil
 		if not pe then
-			local t1=g1:FilterSelect(tp,c97489701.synfilter1,1,1,nil,c,lv,g1,g2)
+			local t1=g1:FilterSelect(tp,c97489701.synfilter1,1,1,nil,c,lv,g1,g2,g3)
 			tuner1=t1:GetFirst()
 		else
 			tuner1=pe:GetOwner()
@@ -140,8 +146,13 @@ function c97489701.synop(e,tp,eg,ep,ev,re,r,rp,c,tuner)
 		g:AddCard(tuner1)
 		local lv1=tuner1:GetSynchroLevel(c)
 		local f1=tuner1.tuner_filter
+		local t2=nil
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
-		local t2=g1:FilterSelect(tp,c97489701.synfilter2,1,1,tuner1,c,lv-lv1,g2,f1,tuner1)
+		if tuner1:IsHasEffect(55863245) then
+			t2=g3:FilterSelect(tp,c97489701.synfilter2,1,1,tuner1,c,lv-lv1,g2,f1,tuner1)
+		else
+			t2=g1:FilterSelect(tp,c97489701.synfilter2,1,1,tuner1,c,lv-lv1,g2,f1,tuner1)
+		end
 		local tuner2=t2:GetFirst()
 		g:AddCard(tuner2)
 		local lv2=tuner2:GetSynchroLevel(c)


### PR DESCRIPTION
Fix this: If you use the Child Dragon as Synchro Material, it cannot be a monster of your hand to the material.