### PR TITLE
fix Illusory Snatcher

### DIFF
--- a/script/c35073065.lua
+++ b/script/c35073065.lua
@@ -33,13 +33,21 @@ function c35073065.spop(e,tp,eg,ep,ev,re,r,rp)
 			local e1=Effect.CreateEffect(c)
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetCode(EFFECT_CHANGE_RACE)
-			e1:SetValue(ec:GetRace())
+			if ec:IsHasEffect(EFFECT_ADD_RACE) then
+				e1:SetValue(ec:GetOriginalRace())
+			else
+				e1:SetValue(ec:GetRace())
+			end
 			e1:SetReset(RESET_EVENT+0x1ff0000)
 			c:RegisterEffect(e1)
 			local e2=Effect.CreateEffect(c)
 			e2:SetType(EFFECT_TYPE_SINGLE)
 			e2:SetCode(EFFECT_CHANGE_ATTRIBUTE)
-			e2:SetValue(ec:GetAttribute())
+			if ec:IsHasEffect(EFFECT_ADD_ATTRIBUTE) then
+				e2:SetValue(ec:GetOriginalAttribute())
+			else
+				e2:SetValue(ec:GetAttribute())
+			end
 			e2:SetReset(RESET_EVENT+0x1ff0000)
 			c:RegisterEffect(e2)
 			local e3=Effect.CreateEffect(c)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6102
http://yugioh-wiki.net/index.php?%A1%D4%A5%A4%A5%EA%A5%E5%A1%BC%A5%B8%A5%E7%A5%F3%A1%A6%A5%B9%A5%CA%A5%C3%A5%C1%A1%D5#faq
Ｑ：《ダーク・シムルグ》のアドバンス召喚成功時にこのカードの誘発効果を発動しました。
　　このカードの属性はどうなりますか？
Ａ：《ダーク・シムルグ》の元々の属性である闇属性として扱います。(12/05/16)

Ｑ：《ＤＮＡ改造手術》の効果で戦士族と宣言されている時にこのカードの誘発効果を発動しました。
　　このカードの種族はどうなりますか？
　　また、特殊召喚後に《ＤＮＡ改造手術》が破壊された場合、このカードの種族はどうなりますか？
Ａ：その状況の場合、戦士族として扱います。
　　なお、《ＤＮＡ改造手術》が破壊された後もこのカードは戦士族のモンスターとして扱います。(15/03/11)