### PR TITLE
fix Relay Soul

### DIFF
--- a/script/c42776960.lua
+++ b/script/c42776960.lua
@@ -38,7 +38,7 @@ function c42776960.activate(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetCode(EVENT_LEAVE_FIELD)
 		e2:SetLabel(1-tp)
 		e2:SetOperation(c42776960.leaveop)
-		e2:SetReset(RESET_EVENT+RESET_OVERLAY)
+		e2:SetReset(RESET_EVENT+RESET_OVERLAY+RESET_TURN_SET)
 		tc:RegisterEffect(e2)
 	end
 end


### PR DESCRIPTION
Fix this: If monster that was Special Summoned by Relay Soul's effect was changed to Defense Position, your opponent wins the Duel.
http://yugioh-wiki.net/?%A1%D4%BA%B2%A4%CE%A5%EA%A5%EC%A1%BC%A1%D5
また、特殊召喚したモンスターを裏側表示にした場合は、ダメージが０になる効果、デュエルに敗北する効果ともに適用されなくなる。(14/06/15)

But I cannnot fix this.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=94
Q.「魂のリレー」の効果によって手札から「宝玉獣 ルビー・カーバンクル」を特殊召喚しています。
その「宝玉獣 ルビー・カーバンクル」が破壊された際に、『このカードがモンスターカードゾーン上で破壊された場合、墓地へ送らずに永続魔法カード扱いとして自分の魔法＆罠カードゾーンに表側表示で置く事ができる』効果を適用し、魔法＆罠ゾーンに置きました。

その後、魔法&罠ゾーンに存在するその「宝玉獣 ルビー・カーバンクル」が「サイクロン」によって破壊され墓地へ送られた場合、「魂のリレー」の『そのモンスターがフィールドから離れた時に相手はデュエルに勝利する』によって、自分はデュエルに敗北しますか？
A.質問の状況のように、「魂のリレー」の効果で特殊召喚された「宝玉獣 ルビー・カーバンクル」が自身の効果によって永続魔法カード扱いとなった場合、『この効果で特殊召喚したモンスターが自分フィールドに表側表示で存在する限り、自分が受ける全てのダメージは０になる』処理は適用されなくなります。

また、「宝玉獣 ルビー・カーバンクル」が自身の効果によって永続魔法カード扱いとなった場合、「宝玉獣 ルビー・カーバンクル」はフィールドではモンスターカードとして扱われなくなりますので、その後に「サイクロン」によって破壊されたとしても、『そのモンスターがフィールドから離れた時に相手はデュエルに勝利する』処理が適用される事もありません。