### PR TITLE
fix

### DIFF
--- a/script/c44394295.lua
+++ b/script/c44394295.lua
@@ -11,10 +11,10 @@ function c44394295.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c44394295.filter0(c)
-	return c:IsCanBeFusionMaterial() and (c:IsAbleToGrave() or c:IsHasEffect(EFFECT_TO_GRAVE_REDIRECT))
+	return c:IsCanBeFusionMaterial() and c:IsAbleToGrave()
 end
 function c44394295.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and (c:IsAbleToGrave() or c:IsHasEffect(EFFECT_TO_GRAVE_REDIRECT)) and not c:IsImmuneToEffect(e)
+	return c:IsCanBeFusionMaterial() and c:IsAbleToGrave() and not c:IsImmuneToEffect(e)
 end
 function c44394295.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and c:IsSetCard(0x9d) and (not f or f(c))


### PR DESCRIPTION
次元要塞兵器/Dimension Fortress Weapon
Ｑ：このカードの永続効果と《マクロコスモス》の効果双方が適用されているとき墓地へ送る効果を持つ任意発動のカードを発動する事はできますか？
Ａ：いいえ、できません。(09/04/12)
http://yugioh-wiki.net/index.php?%A1%D4%BC%A1%B8%B5%CD%D7%BA%C9%CA%BC%B4%EF%A1%D5=