### PR TITLE
RUM Update(Set Material; "Admiration of the Thousands" ' fixup

### DIFF
--- a/script/c33252803.lua
+++ b/script/c33252803.lua
@@ -38,6 +38,7 @@ function c33252803.activate(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()

--- a/script/c43476205.lua
+++ b/script/c43476205.lua
@@ -64,6 +64,7 @@ function c43476205.activate(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()

--- a/script/c45950291.lua
+++ b/script/c45950291.lua
@@ -56,6 +56,7 @@ function c45950291.activate(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()

--- a/script/c47660516.lua
+++ b/script/c47660516.lua
@@ -40,6 +40,7 @@ function c47660516.activate(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()

--- a/script/c48333324.lua
+++ b/script/c48333324.lua
@@ -41,6 +41,7 @@ function c48333324.activate(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()

--- a/script/c57734012.lua
+++ b/script/c57734012.lua
@@ -63,6 +63,7 @@ function c57734012.activate(e,tp,eg,ep,ev,re,r,rp)
 		local g2=Duel.SelectMatchingCard(tp,c57734012.filter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc1,tc1.xyz_number)
 		local tc2=g2:GetFirst()
 		if tc2 then
+			tc2:SetMaterial(g1)
 			Duel.Overlay(tc2,g1)
 			Duel.SpecialSummon(tc2,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 			tc2:CompleteProcedure()

--- a/script/c92365601.lua
+++ b/script/c92365601.lua
@@ -38,6 +38,7 @@ function c92365601.activate(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()

--- a/script/c94220427.lua
+++ b/script/c94220427.lua
@@ -52,6 +52,7 @@ function c94220427.activate(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()

--- a/script/c96142517.lua
+++ b/script/c96142517.lua
@@ -25,51 +25,70 @@ end
 function c96142517.sumlimit(e,c,sump,sumtype,sumpos,targetp,se)
 	return e:GetHandler()~=se:GetHandler()
 end
-function c96142517.filter1(c,e,tp)
+function c96142517.filter1(c,e)
+	return c:IsType(TYPE_XYZ) and c:IsCanBeEffectTarget(e)
+end
+function c96142517.filter2(c,e,tp)
+	return (c:IsSetCard(0x1048) or c:IsSetCard(0x1073)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c96142517.spfilter(c,e,tp,rk,mg)
+	if c:GetOriginalCode()==6165656 and mg:FilterCount(Card.IsCode,nil,48995978)==0 then return false end
+	return c:IsRank(rk) and (c:IsSetCard(0x1048) or c:IsSetCard(0x1073)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c96142517.targetcheck1(c,g2,g3)
 	local rk=c:GetRank()
-	return c:IsType(TYPE_XYZ)
-		and Duel.IsExistingMatchingCard(c96142517.filter2,tp,0,LOCATION_GRAVE,1,nil,e,tp,rk)
-		and Duel.IsExistingMatchingCard(c96142517.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,rk+1)
+	return g2:IsExists(Card.IsRank,1,nil,rk) and g3:IsExists(Card.IsRank,1,nil,rk+1)
 end
-function c96142517.filter2(c,e,tp,rk)
-	return c:IsType(TYPE_XYZ) and c:GetRank()==rk and c:IsCanBeEffectTarget(e)
+function c96142517.targetcheck2(c)
+	return c:GetOriginalCode()~=6165656
 end
-function c96142517.spfilter(c,e,tp,rk)
-	return c:GetRank()==rk and (c:IsSetCard(0x1048) or c:IsSetCard(0x1073))
-		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+function c96142517.targetcheck3(c,rk)
+	return not c:IsRank(rk)
 end
 function c96142517.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingTarget(c96142517.filter1,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	local g1=Duel.GetMatchingGroup(c96142517.filter1,tp,LOCATION_GRAVE,0,nil,e) --avaliable targets in your graveyard
+	local g2=Duel.GetMatchingGroup(c96142517.filter1,tp,0,LOCATION_GRAVE,nil,e) --avaliable targets in opponent's graveyard
+	local g3=Duel.GetMatchingGroup(c96142517.filter2,tp,LOCATION_EXTRA,0,nil,e,tp) --avaliable group to special summon
+	local tg=g1:Filter(c96142517.targetcheck1,nil,g2,g3)
+	--a group of avaliable targets that has at least 1 same-ranked target in opponent's graveyard. 
+	local v1,v2=g3:FilterCount(c96142517.targetcheck2,nil)==0,
+		g1:FilterCount(Card.IsCode,nil,48995978)+g2:FilterCount(Card.IsCode,nil,48995978)==0
+	--if "v1" is true, means you have nothing to special summon but C88.
+	--if "v2" is true, means there are no 88 to target in either's graveyard. 
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and tg:GetCount()~=0 and not (v1 and v2) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	local g1=Duel.SelectTarget(tp,c96142517.filter1,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
-	local rk=g1:GetFirst():GetRank()
-	e:SetLabel(rk)
+	local tg1=tg:Select(tp,1,1,nil)
+	Duel.HintSelection(tg1)
+	local rank=tg1:GetFirst():GetRank()
+	e:SetLabel(rank)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	local g2=Duel.SelectTarget(tp,c96142517.filter2,tp,0,LOCATION_GRAVE,1,1,nil,e,tp,rk)
-	g1:Merge(g2)
-	local g=Duel.GetMatchingGroup(c96142517.filter2,tp,LOCATION_GRAVE,LOCATION_GRAVE,nil,e,tp,rk)
-	g:Sub(g1)
-	if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(96142517,1)) then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-		local sg=g:Select(tp,1,99,nil)
-		Duel.SetTargetCard(sg)
-		g1:Merge(sg)
+	local tg2=g2:FilterSelect(tp,Card.IsRank,1,1,nil,rank)
+	Duel.HintSelection(tg2)
+	g1:Sub(tg1) g2:Sub(tg2) g1:Merge(g2)
+	if v1 and tg1:FilterCount(Card.IsCode,nil,48995978)+tg2:FilterCount(Card.IsCode,nil,48995978)==0 then
+		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(96142517,0))
+		local tg4=g1:Filter(Card.IsRank,nil,rank):FilterSelect(tp,Card.IsCode,1,1,nil,48995978)
+		tg1:Merge(tg4) g1:Sub(tg4)
 	end
+	if g1:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(96142517,1)) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+		local tg3=g1:FilterSelect(tp,Card.IsRank,1,99,nil,rank)
+		Duel.HintSelection(tg3)
+	end
+	tg1:Merge(tg2) tg1:Merge(tg3)
+	Duel.SetTargetCard(tg1)
 	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g1,g1:GetCount(),0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c96142517.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local rk=e:GetLabel()
+	local mg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c96142517.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,rk+1)
+	local g=Duel.SelectMatchingCard(tp,c96142517.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,rk+1,mg)
 	local sc=g:GetFirst()
-	if sc then
-		local mg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
-		sc:SetMaterial(mg)
+	if sc and Duel.SpecialSummon(sc,0,tp,tp,false,false,POS_FACEUP)~=0 then
 		Duel.Overlay(sc,mg)
-		Duel.SpecialSummon(sc,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c96142517.lua
+++ b/script/c96142517.lua
@@ -68,6 +68,7 @@ function c96142517.activate(e,tp,eg,ep,ev,re,r,rp)
 	local sc=g:GetFirst()
 	if sc then
 		local mg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+		sc:SetMaterial(mg)
 		Duel.Overlay(sc,mg)
 		Duel.SpecialSummon(sc,0,tp,tp,false,false,POS_FACEUP)
 	end

--- a/script/c96142517.lua
+++ b/script/c96142517.lua
@@ -42,9 +42,6 @@ end
 function c96142517.targetcheck2(c)
 	return c:GetOriginalCode()~=6165656
 end
-function c96142517.targetcheck3(c,rk)
-	return not c:IsRank(rk)
-end
 function c96142517.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	local g1=Duel.GetMatchingGroup(c96142517.filter1,tp,LOCATION_GRAVE,0,nil,e) --avaliable targets in your graveyard

--- a/script/c96142517.lua
+++ b/script/c96142517.lua
@@ -80,9 +80,10 @@ function c96142517.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c96142517.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
-	local rk=e:GetLabel()
 	local mg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local rg=mg:Filter(Card.IsRelateToEffect,nil,e)
+	if rg:GetCount()==0 then return end
+	local rk=e:GetLabel()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c96142517.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,rk+1,mg)
 	local sc=g:GetFirst()

--- a/script/c96142517.lua
+++ b/script/c96142517.lua
@@ -81,11 +81,12 @@ end
 function c96142517.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local rk=e:GetLabel()
-	local mg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	local mg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local rg=mg:Filter(Card.IsRelateToEffect,nil,e)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c96142517.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,rk+1,mg)
 	local sc=g:GetFirst()
 	if sc and Duel.SpecialSummon(sc,0,tp,tp,false,false,POS_FACEUP)~=0 then
-		Duel.Overlay(sc,mg)
+		Duel.Overlay(sc,rg)
 	end
 end


### PR DESCRIPTION
RUM的特殊召唤，也是使用目标怪兽为素材进行的超量召唤，也就是说，用星光之力奈亚子出霸王黑龙，霸王黑龙的效果也是能发动的。
这里必须补上这一句，来预防霸王黑龙的BUG。

顺便说一句，RUM在原本不设置目标怪兽为素材的行为是个BUG，只是暂时没有霸王黑龙那样的卡，所以当时我懒得说-。-霸王黑龙的效果出来后果断还是来改吧→_→