### PR TITLE
Perfect fix for "Relay Soul"

### DIFF
--- a/script/c42776960.lua
+++ b/script/c42776960.lua
@@ -32,17 +32,29 @@ function c42776960.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
 		e1:SetTargetRange(1,0)
 		e1:SetValue(0)
-		tc:RegisterEffect(e1)
+		tc:RegisterEffect(e1,true)
 		local e2=Effect.CreateEffect(e:GetHandler())
 		e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 		e2:SetCode(EVENT_LEAVE_FIELD)
 		e2:SetLabel(1-tp)
 		e2:SetOperation(c42776960.leaveop)
-		e2:SetReset(RESET_EVENT+RESET_OVERLAY)
-		tc:RegisterEffect(e2)
+		e2:SetReset(RESET_EVENT+RESET_OVERLAY+RESET_TURN_SET)
+		tc:RegisterEffect(e2,true)
+		local e3=Effect.GlobalEffect()
+		e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e3:SetCode(EVENT_ADJUST)
+		e3:SetOperation(c42776960.adjust(e2))
+		Duel.RegisterEffect(e3,tp)
 	end
 end
 function c42776960.leaveop(e,tp,eg,ep,ev,re,r,rp)
 	local WIN_REASON_RELAY_SOUL=0x1a
 	Duel.Win(e:GetLabel(),WIN_REASON_RELAY_SOUL)
+end
+function c42776960.adjust(e2)
+	return function(e,tp,eg,ep,ev,re,r,rp)
+		local tc=e2:GetHandler()
+		if not tc then e:Reset() return end
+		if tc:IsLocation(LOCATION_SZONE) then e2:Reset() e:Reset() end
+	end
 end


### PR DESCRIPTION
因为用他的效果特殊召唤的怪兽，不但变成里侧表示·变成超量素材会重置状态，被移动到魔法&陷阱区域也会被重置状态，而目前并没有一个RESET的FLAG，名为RESET_TO_SZONE，这种时候就只有自己写一个ADJUST了。

如果效果e已经被重置，则e:GetHandler()会返回nil。

相关的FAQ，nekrozar前辈已经提供了，这里不再赘述。