### PR TITLE
Update c48539234.lua

### DIFF
--- a/script/c48539234.lua
+++ b/script/c48539234.lua
@@ -6,9 +6,9 @@ function c48539234.initial_effect(c)
 	e1:SetCode(EVENT_DRAW)
 	e1:SetCondition(c48539234.condition)
 	c:RegisterEffect(e1)
-	--recover
+	--draw
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetProperty(EFFECT_FLAG_DELAY)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCode(EVENT_DRAW)
@@ -20,6 +20,6 @@ function c48539234.condition(e,tp,eg,ep,ev,re,r,rp)
 	return ep~=tp and Duel.GetCurrentPhase()~=PHASE_DRAW
 end
 function c48539234.operation(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Hint(HINT_CARD,0,48539234)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
 	Duel.Draw(tp,2,REASON_EFFECT)
 end


### PR DESCRIPTION
http://www.bbs.cnocg.com/read.php?tid=299510&ds=1&page=1&toread=1#tpc
原文：{
《便乘》 裁定变更
旧裁定：抽卡效果是否开连锁，调整中（持续6年之久）
新裁定：抽卡效果开连锁
变更评价：合理
}

早在2014年，这张卡就裁定为了开连锁，所以现在必须调整写法。