### PR TITLE
fix Tachyon Transmigration

### DIFF
--- a/script/c8038143.lua
+++ b/script/c8038143.lua
@@ -20,8 +20,13 @@ function c8038143.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x107b)
 end
 function c8038143.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c8038143.cfilter,tp,LOCATION_MZONE,0,1,nil)
-		and rp~=tp and (re:IsActiveType(TYPE_MONSTER) or re:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(ev)
+	if not Duel.IsExistingMatchingCard(c8038143.cfilter,tp,LOCATION_MZONE,0,1,nil) then return false end
+	for i=1,ev do
+		local te,tgp=Duel.GetChainInfo(i,CHAININFO_TRIGGERING_EFFECT,CHAININFO_TRIGGERING_PLAYER)
+		if tgp~=tp and (te:IsActiveType(TYPE_MONSTER) or te:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(i) then
+			return true
+		end
+	end
 end
 function c8038143.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
@@ -32,7 +37,7 @@ function c8038143.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		if tgp~=tp and (te:IsActiveType(TYPE_MONSTER) or te:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(i) then
 			local tc=te:GetHandler()
 			ng:AddCard(tc)
-			if tc:IsOnField() and tc:IsRelateToEffect(te) and not tc:IsHasEffect(EFFECT_CANNOT_TO_DECK) then
+			if tc:IsOnField() and tc:IsRelateToEffect(te) and tc:IsAbleToDeck() then
 				dg:AddCard(tc)
 			end
 		end
@@ -48,7 +53,7 @@ function c8038143.activate(e,tp,eg,ep,ev,re,r,rp)
 		if tgp~=tp and (te:IsActiveType(TYPE_MONSTER) or te:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(i) then
 			Duel.NegateActivation(i)
 			local tc=te:GetHandler()
-			if tc:IsRelateToEffect(e) and tc:IsRelateToEffect(te) and not tc:IsHasEffect(EFFECT_CANNOT_TO_DECK) then
+			if tc:IsRelateToEffect(e) and tc:IsRelateToEffect(te) and tc:IsAbleToDeck() then
 				tc:CancelToGrave()
 				dg:AddCard(tc)
 			end


### PR DESCRIPTION
This card can be activated whenever there are effects that can be negated by this card in the chain, need not chain to this effect directly
Q.
チェーン1：相手の「サイクロン」のカードの発動
チェーン2：相手の発動済みの「血の代償」の効果の発動
に対し「タキオン・トランスミグレイション」は発動した場合、チェーン1のみ無効にするのですか？
A.
ご質問のように、チェーン3にて「タキオン・トランスミグレイション」を発動した場合、チェーン2の「血の代償」の効果は無効になりませんので、チェーン1の「サイクロン」の発動のみ無効にします。