### PR TITLE
fix Card of Sanctity

### DIFF
--- a/script/c42664989.lua
+++ b/script/c42664989.lua
@@ -13,7 +13,7 @@ function c42664989.initial_effect(c)
 end
 function c42664989.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToRemoveAsCost,tp,LOCATION_HAND,0,1,e:GetHandler())
-		and Duel.IsExistingMatchingCard(Card.IsAbleToRemoveAsCost,tp,LOCATION_ONFIELD,0,1,e:GetHandler())end
+		or Duel.IsExistingMatchingCard(Card.IsAbleToRemoveAsCost,tp,LOCATION_ONFIELD,0,1,e:GetHandler()) end
 	local g=Duel.GetMatchingGroup(Card.IsAbleToRemoveAsCost,tp,LOCATION_HAND+LOCATION_ONFIELD,0,e:GetHandler())
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
@@ -27,7 +27,7 @@ end
 function c42664989.operation(e,tp,eg,ep,ev,re,r,rp)
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
 	local ht=Duel.GetFieldGroupCount(p,LOCATION_HAND,0)
-	if(ht<2) then
+	if ht<2 then
 		Duel.Draw(p,2-ht,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13543&keyword=&tag=-1
Q.「天よりの宝札」を発動する場合、その発動する「天よりの宝札」以外に、自分の手札と自分フィールドの両方にカードが存在していなければなりませんか？
A.「天よりの宝札」は、自分の手札または自分フィールドのいずれかにカードが存在していない場合でも発動する事ができます。

例えば、自分の手札が「天よりの宝札」を含めて2枚以上存在するという状況であれば、自分フィールドにカードが1枚もない場合でも、手札から「天よりの宝札」を発動する事ができます。
逆に、自分フィールドにセットされている「天よりの宝札」を含めて2枚以上のカードが存在するという状況であれば、自分の手札が0枚の場合でも、セットされている「天よりの宝札」を発動する事ができます。

なお、自分の手札が「天よりの宝札」1枚のみで、自分フィールドにカードが１枚もない、というような場合には「天よりの宝札」を発動する事はできません。