### PR TITLE
"Xyz Number" judgement fixup

### DIFF
--- a/script/c33252803.lua
+++ b/script/c33252803.lua
@@ -11,8 +11,9 @@ function c33252803.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c33252803.filter1(c,e,tp)
+	local m=_G["c" .. c:GetCode()]
 	return c:IsFaceup() and c:IsSetCard(0x48) and not c:IsSetCard(0x1048)
-		and Duel.IsExistingMatchingCard(c33252803.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,c:GetRank()+1,c.xyz_number)
+		and Duel.IsExistingMatchingCard(c33252803.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,c:GetRank()+1,m.xyz_number)
 end
 function c33252803.filter2(c,e,tp,mc,rk,no)
 	return c:GetRank()==rk and c:IsSetCard(0x1048) and c.xyz_number==no and mc:IsCanBeXyzMaterial(c)
@@ -30,8 +31,9 @@ function c33252803.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<0 then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) or tc:IsImmuneToEffect(e) then return end
+	local m=_G["c" .. tc:GetCode()]
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c33252803.filter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc,tc:GetRank()+1,tc.xyz_number)
+	local g=Duel.SelectMatchingCard(tp,c33252803.filter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc,tc:GetRank()+1,m.xyz_number)
 	local sc=g:GetFirst()
 	if sc then
 		local mg=tc:GetOverlayGroup()

--- a/script/c57734012.lua
+++ b/script/c57734012.lua
@@ -36,7 +36,8 @@ function c57734012.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()==PHASE_MAIN1 and not Duel.CheckPhaseActivity() and e:GetHandler():GetFlagEffect(57734012)~=0
 end
 function c57734012.filter1(c,e,tp)
-	local no=c.xyz_number
+	local m=_G["c" .. c:GetCode()]
+	local no=m.xyz_number
 	return no and no>=101 and no<=107 and c:IsSetCard(0x48) and not c:IsSetCard(0x1048)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 		and Duel.IsExistingMatchingCard(c57734012.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,no)
@@ -59,8 +60,9 @@ function c57734012.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g1=Duel.SelectMatchingCard(tp,c57734012.filter1,tp,LOCATION_GRAVE+LOCATION_EXTRA,0,1,1,nil,e,tp)
 	local tc1=g1:GetFirst()
 	if tc1 and Duel.SpecialSummon(tc1,0,tp,tp,false,false,POS_FACEUP)~=0 then
+		local m=_G["c" .. tc1:GetCode()]
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local g2=Duel.SelectMatchingCard(tp,c57734012.filter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc1,tc1.xyz_number)
+		local g2=Duel.SelectMatchingCard(tp,c57734012.filter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc1,m.xyz_number)
 		local tc2=g2:GetFirst()
 		if tc2 then
 			tc2:SetMaterial(g1)

--- a/script/c93238626.lua
+++ b/script/c93238626.lua
@@ -70,7 +70,8 @@ function c93238626.filter(c,e,tp,no)
 end
 function c93238626.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local no=Duel.GetAttackTarget().xyz_number
+		local m=_G["c" .. Duel.GetAttackTarget():GetCode()]
+		local no=m.xyz_number
 		return no and Duel.IsExistingMatchingCard(c93238626.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,no)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
@@ -80,14 +81,16 @@ function c93238626.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<0 then return end
 	local tc=Duel.GetAttackTarget()
 	if tc:IsFacedown() or not tc:IsRelateToBattle() or tc:IsControler(1-tp) or tc:IsImmuneToEffect(e) then return end
+	local m=_G["tc" .. Duel.GetAttackTarget():GetCode()]
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c93238626.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc.xyz_number)
+	local g=Duel.SelectMatchingCard(tp,c93238626.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,m.xyz_number)
 	local sc=g:GetFirst()
 	if sc then
 		local mg=tc:GetOverlayGroup()
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()


### PR DESCRIPTION
复制卡名时，只复制卡名，却不连带复制"Xyz Number"，然而毫无疑问，"Xyz Number"会连着卡名一块复制。

而按照旧的方法判断，判断一个原本卡名不是「No.39 希望皇 霍普」却被当作「No.39 希望皇 霍普」使用的卡的"Xyz Number"的时候，会得出nil，或者得出他的原本卡名的No.数字，然而这明显会出BUG。

比如，被当作「No.39 希望皇 霍普」使用的「No.8 纹章王 基因组继承者」，被「升阶魔法-速攻混沌」取为对象，不能出「混沌No.39 希望皇 霍普雷V」，以至于不能被取为对象。这是旧的判断方式引起的一个显性BUG。

所以在判断"Xyz Number"的时候，最好是用下面的方法来判断，免得引起BUG。