### PR TITLE
"Set Material" fixup

### DIFF
--- a/script/c18326736.lua
+++ b/script/c18326736.lua
@@ -60,6 +60,7 @@ function c18326736.spop(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(c))
 		Duel.Overlay(sc,Group.FromCards(c))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()

--- a/script/c46008667.lua
+++ b/script/c46008667.lua
@@ -94,6 +94,7 @@ function c46008667.spop(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()

--- a/script/c71345905.lua
+++ b/script/c71345905.lua
@@ -39,6 +39,7 @@ function c71345905.activate(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()

--- a/script/c83319610.lua
+++ b/script/c83319610.lua
@@ -107,6 +107,7 @@ function c83319610.spop(e,tp,eg,ep,ev,re,r,rp)
 		if mg:GetCount()~=0 then
 			Duel.Overlay(sc,mg)
 		end
+		sc:SetMaterial(Group.FromCards(tc))
 		Duel.Overlay(sc,Group.FromCards(tc))
 		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		sc:CompleteProcedure()


### PR DESCRIPTION
上次的给RUM补充"Set Material"的工作还没有做完，仍然有许多不是RUM却进行以XXX为素材的超量召唤的卡存在。就在这个Branch把他们全部修理掉吧。

已经检查完毕。
「No.53 伪骸神 心地心」竟然早就有了"Set Material"，大吃一惊。
其他的未设置"Set Material"的都已经设置好了。