### PR TITLE
Revert "custom attack activity counter"

### DIFF
--- a/ocgcore/processor.cpp
+++ b/ocgcore/processor.cpp
@@ -3071,7 +3071,6 @@ int32 field::process_battle_command(uint16 step) {
 		core.sub_attacker = 0;
 		core.sub_attack_target = (card*)0xffffffff;
 		core.attack_state_count[infos.turn_player]++;
-		check_card_counter(core.attacker,5,infos.turn_player);
 		pduel->write_buffer8(MSG_ATTACK);
 		pduel->write_buffer32(core.attacker->get_info_location());
 		if(core.attack_target) {

--- a/script/c17655904.lua
+++ b/script/c17655904.lua
@@ -10,10 +10,20 @@ function c17655904.initial_effect(c)
 	e1:SetTarget(c17655904.target)
 	e1:SetOperation(c17655904.activate)
 	c:RegisterEffect(e1)
-	Duel.AddCustomActivityCounter(17655904,ACTIVITY_ATTACK,c17655904.counterfilter)
+	if not c17655904.global_check then
+		c17655904.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_ATTACK_ANNOUNCE)
+		ge1:SetOperation(c17655904.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
 end
-function c17655904.counterfilter(c)
-    return not c:IsCode(89631139)
+function c17655904.checkop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	if tc:IsCode(89631139) then
+		Duel.RegisterFlagEffect(tc:GetControler(),17655904,RESET_PHASE+PHASE_END,0,1)
+	end
 end
 function c17655904.cfilter(c)
 	return c:IsFaceup() and c:IsCode(89631139)
@@ -22,7 +32,7 @@ function c17655904.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c17655904.cfilter,tp,LOCATION_ONFIELD,0,1,nil)
 end
 function c17655904.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetCustomActivityCount(17655904,tp,ACTIVITY_ATTACK)==0 end
+	if chk==0 then return Duel.GetFlagEffect(tp,17655904)==0 end
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)

--- a/script/constant.lua
+++ b/script/constant.lua
@@ -675,6 +675,6 @@ ACTIVITY_SUMMON			=1		--
 ACTIVITY_NORMALSUMMON	=2		--
 ACTIVITY_SPSUMMON		=3		--
 ACTIVITY_FLIPSUMMON		=4		--
-ACTIVITY_ATTACK			=5		--
+ACTIVITY_ATTACK			=5		-- only available in custom counter
 ACTIVITY_BATTLE_PHASE	=6		-- not available in custom counter
 ACTIVITY_CHAIN			=7		-- only available in custom counter


### PR DESCRIPTION
This reverts commit 67f14fdbc0728934a6d66ce64b56b44ea41fdf45.
attack activity counter is different with attack announce count
global check is better