### PR TITLE
fix Legendary Maju Garzett

### DIFF
--- a/script/c12338068.lua
+++ b/script/c12338068.lua
@@ -35,7 +35,7 @@ function c12338068.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	local atk=0
 	local tc=g:GetFirst()
 	while tc do
-		local batk=tc:GetBaseAttack()
+		local batk=tc:GetTextAttack()
 		if batk>0 then
 			atk=atk+batk
 		end


### PR DESCRIPTION
遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
手札の「真魔獣 ガーゼット」を、自身の効果で特殊召喚された「幻影騎士団シャドーベイル」１体と「深淵のスタングレイ」１体をリリースして特殊召喚した場合、「真魔獣 ガーゼット」の攻撃力はどのようになりますか？
A.
「幻影騎士団シャドーベイル」の元々の攻撃力は0、「深淵のスタングレイ」の元々の攻撃力は1900です。
したがって、「真魔獣 ガーゼット」の攻撃力は1900になります。

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。