### PR TITLE
Xyz Gain Effect Fixup

### DIFF
--- a/script/c12948099.lua
+++ b/script/c12948099.lua
@@ -82,10 +82,10 @@ function c12948099.efop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
-		e2:SetCode(EFFECT_CHANGE_TYPE)
-		e2:SetValue(TYPE_MONSTER+TYPE_EFFECT+TYPE_XYZ)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetValue(TYPE_EFFECT)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e2)
+		rc:RegisterEffect(e2,true)
 	end
 end
 function c12948099.drcon2(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c24610207.lua
+++ b/script/c24610207.lua
@@ -39,10 +39,10 @@ function c24610207.efop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
-		e2:SetCode(EFFECT_CHANGE_TYPE)
-		e2:SetValue(TYPE_MONSTER+TYPE_EFFECT+TYPE_XYZ)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetValue(TYPE_EFFECT)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e2)
+		rc:RegisterEffect(e2,true)
 	end
 end
 function c24610207.drcon(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c34143852.lua
+++ b/script/c34143852.lua
@@ -26,10 +26,10 @@ function c34143852.efop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
-		e2:SetCode(EFFECT_CHANGE_TYPE)
-		e2:SetValue(TYPE_MONSTER+TYPE_EFFECT+TYPE_XYZ)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetValue(TYPE_EFFECT)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e2)
+		rc:RegisterEffect(e2,true)
 	end
 end
 function c34143852.atkcon(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c3606728.lua
+++ b/script/c3606728.lua
@@ -64,10 +64,10 @@ function c3606728.efop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
-		e2:SetCode(EFFECT_CHANGE_TYPE)
-		e2:SetValue(TYPE_MONSTER+TYPE_EFFECT+TYPE_XYZ)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetValue(TYPE_EFFECT)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e2)
+		rc:RegisterEffect(e2,true)
 	end
 end
 function c3606728.atkcon(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c38331564.lua
+++ b/script/c38331564.lua
@@ -57,10 +57,10 @@ function c38331564.effop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
-		e2:SetCode(EFFECT_CHANGE_TYPE)
-		e2:SetValue(TYPE_MONSTER+TYPE_EFFECT+TYPE_XYZ)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetValue(TYPE_EFFECT)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e2)
+		rc:RegisterEffect(e2,true)
 	end
 end
 function c38331564.descon(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c64605089.lua
+++ b/script/c64605089.lua
@@ -58,10 +58,10 @@ function c64605089.efop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
-		e2:SetCode(EFFECT_CHANGE_TYPE)
-		e2:SetValue(TYPE_MONSTER+TYPE_EFFECT+TYPE_XYZ)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetValue(TYPE_EFFECT)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e2)
+		rc:RegisterEffect(e2,true)
 	end
 end
 function c64605089.valcon(e,re,r,rp)

--- a/script/c64726269.lua
+++ b/script/c64726269.lua
@@ -64,10 +64,10 @@ function c64726269.effop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
-		e2:SetCode(EFFECT_CHANGE_TYPE)
-		e2:SetValue(TYPE_MONSTER+TYPE_EFFECT+TYPE_XYZ)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetValue(TYPE_EFFECT)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e2)
+		rc:RegisterEffect(e2,true)
 	end
 end
 function c64726269.drcon(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c7080743.lua
+++ b/script/c7080743.lua
@@ -26,10 +26,10 @@ function c7080743.efop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
-		e2:SetCode(EFFECT_CHANGE_TYPE)
-		e2:SetValue(TYPE_MONSTER+TYPE_EFFECT+TYPE_XYZ)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetValue(TYPE_EFFECT)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e2)
+		rc:RegisterEffect(e2,true)
 	end
 end
 function c7080743.atkcon(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c83272895.lua
+++ b/script/c83272895.lua
@@ -22,9 +22,9 @@ function c83272895.efop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
-		e2:SetCode(EFFECT_CHANGE_TYPE)
-		e2:SetValue(TYPE_MONSTER+TYPE_EFFECT+TYPE_XYZ)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetValue(TYPE_EFFECT)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e2)
+		rc:RegisterEffect(e2,true)
 	end
 end

--- a/script/c8696773.lua
+++ b/script/c8696773.lua
@@ -47,10 +47,10 @@ function c8696773.effop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
-		e2:SetCode(EFFECT_CHANGE_TYPE)
-		e2:SetValue(TYPE_MONSTER+TYPE_EFFECT+TYPE_XYZ)
+		e2:SetCode(EFFECT_ADD_TYPE)
+		e2:SetValue(TYPE_EFFECT)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		rc:RegisterEffect(e2)
+		rc:RegisterEffect(e2,true)
 	end
 end
 function c8696773.matcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
所有的「用此卡作为超量素材来超量召唤的怪兽得到以下效果。●巴拉巴拉」的怪兽，最后都必须检查是否是效果怪兽，若不是，将其变为效果怪兽。
但是这个裁定的旧写法是，直接把他变成“超量效果怪兽”，导致如果那只怪兽本身还具有“超量怪兽”以外的标签，则会失去那个标签。只是以前一直没有超量怪兽带有除“效果”以外的标签，所以这个BUG并不明显。
事实上，更严谨的写法是给那只怪兽添加效果怪兽的种类，而不是直接把他变成“超量效果怪兽”。霸王黑龙，头一只带有除“超量”、“效果”、“怪兽”以外的标签的怪兽出现了，如果霸王黑龙不是效果怪兽，而用这一类怪兽来超量，会失去“灵摆”的标签。
因此，用以下的写法更更为严谨。