### PR TITLE
Update c31531170.lua

### DIFF
--- a/script/c31531170.lua
+++ b/script/c31531170.lua
@@ -34,12 +34,6 @@ function c31531170.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetLabel(tc2:GetFieldID())
 	tc1:RegisterEffect(e1)
 end
-function c31531170.filter(c,e,tp,lscale,rscale)
-	local lv=c:GetLevel()
-	return c:IsFaceup() and c:IsType(TYPE_PENDULUM)
-		and lv>lscale and lv<rscale and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_PENDULUM,tp,false,false)
-		and not c:IsForbidden()
-end
 function c31531170.pendcon(e,c,og)
 	if c==nil then return true end
 	local tp=e:GetOwnerPlayer()
@@ -51,9 +45,9 @@ function c31531170.pendcon(e,c,og)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft<=0 then return false end
 	if og then
-		return og:IsExists(c31531170.filter,1,nil,e,tp,lscale,rscale)
+		return og:IsExists(aux.PConditionFilter,1,nil,e,tp,lscale,rscale)
 	else
-		return Duel.IsExistingMatchingCard(c31531170.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,lscale,rscale)
+		return Duel.IsExistingMatchingCard(aux.PConditionFilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,lscale,rscale)
 	end
 end
 function c31531170.pendop(e,tp,eg,ep,ev,re,r,rp,c,sg,og)
@@ -65,11 +59,11 @@ function c31531170.pendop(e,tp,eg,ep,ev,re,r,rp,c,sg,og)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if og then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local g=og:FilterSelect(tp,c31531170.filter,1,ft,nil,e,tp,lscale,rscale)
+		local g=og:FilterSelect(tp,aux.PConditionFilter,1,ft,nil,e,tp,lscale,rscale)
 		sg:Merge(g)
 	else
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local g=Duel.SelectMatchingCard(tp,c31531170.filter,tp,LOCATION_EXTRA,0,1,ft,nil,e,tp,lscale,rscale)
+		local g=Duel.SelectMatchingCard(tp,aux.PConditionFilter,tp,LOCATION_EXTRA,0,1,ft,nil,e,tp,lscale,rscale)
 		sg:Merge(g)
 	end
 end


### PR DESCRIPTION
这里并不需要一个额外的filter，只需要用全局里的灵摆filter即可。
况且，霸王黑龙的额外灵摆等级出现后，全局里的灵摆filter得到了所必须的改写，然而这张卡的filter被遗忘了。
霸王黑龙的灵摆等级的写法随时可能变动，到时候这张卡的filter说不定又会被遗忘了。
不如就这样用全局的filter，免得今后再出什么变数，又忘了这张奇葩无比的卡。