### PR TITLE
Update c69176131.lua

### DIFF
--- a/script/c69176131.lua
+++ b/script/c69176131.lua
@@ -12,5 +12,11 @@ function c69176131.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckRemoveOverlayCard(tp,1,1,1,REASON_EFFECT) end
 end
 function c69176131.activate(e,tp,eg,ep,ev,re,r,rp)
-	Duel.RemoveOverlayCard(tp,1,1,1,1,REASON_EFFECT)
+	local sg=Duel.GetMatchingGroup(Card.CheckRemoveOverlayCard,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp,1,REASON_EFFECT)
+	local rg=nil
+	if sg:GetCount()==1 then rg=sg else
+		rg=sg:Select(tp,1,1,nil)
+		Duel.HintSelection(rg)
+	end
+	rg:GetFirst():RemoveOverlayCard(tp,1,1,REASON_EFFECT)
 end


### PR DESCRIPTION
太空旋风的写法容易造成误操作。一下子就把所有的超量素材摆在你面前，很容易分不清哪个是谁的素材。

举个例子：对方超量召唤了「鸟铳士 卡斯泰尔」，现发动「太空旋风」，准备去除「鸟铳士 卡斯泰尔」的1个超量素材，却错误地去除了「精怪王」的超量素材。

我认为如果有多只可去除素材的怪兽，应该由玩家先选1只，然后从那只怪兽去除1个素材，这样可以减少误操作率。