### PR TITLE
fix Galaxy-Eyes Full Armor Photon Dragon

### DIFF
--- a/script/c39030163.lua
+++ b/script/c39030163.lua
@@ -70,7 +70,7 @@ function c39030163.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c39030163.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) then
 		Duel.Destroy(tc,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13486&keyword=&tag=-1
Q.相手フィールドの表側表示モンスターを対象として、「ギャラクシーアイズ FA・フォトン・ドラゴン」の『②：１ターンに１度、このカードのX素材を１つ取り除き、相手フィールドの表側表示のカード１枚を対象として発動できる。そのカードを破壊する』効果を発動しました。

その発動にチェーンした「月の書」によって、その対象のモンスターが裏側守備表示になっている場合、そのモンスターは破壊されますか？
A.「ギャラクシーアイズ FA・フォトン・ドラゴン」の『②：１ターンに１度、このカードのX素材を１つ取り除き、相手フィールドの表側表示のカード１枚を対象として発動できる。そのカードを破壊する』効果の対象となった、相手フィールドの表側表示モンスターが、チェーンにて発動した「月の書」によって、効果処理時に裏側守備表示になっている場合でも、その対象のモンスターは通常通り破壊されます。