### PR TITLE
fix Summon Limit Activate

### DIFF
--- a/script/c23536866.lua
+++ b/script/c23536866.lua
@@ -52,7 +52,6 @@ function c23536866.filter2(c,e,tp)
 end
 function c23536866.operation(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
-	if not Duel.IsPlayerCanSpecialSummonCount(tp,2) then return end
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c23536866.filter2,nil,e,tp)
 	if g:GetCount()<2 then return end
 	local tc1=g:GetFirst()

--- a/script/c25148255.lua
+++ b/script/c25148255.lua
@@ -42,7 +42,6 @@ function c25148255.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c25148255.scop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<1 then return end
-	if not Duel.IsPlayerCanSpecialSummonCount(tp,2) then return end
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) or Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)==0 then return end

--- a/script/c57734012.lua
+++ b/script/c57734012.lua
@@ -56,7 +56,7 @@ end
 function c57734012.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetFlagEffect(tp,57734012)~=0 then return end
 	Duel.RegisterFlagEffect(tp,57734012,0,0,0)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 or not Duel.IsPlayerCanSpecialSummonCount(tp,2) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g1=Duel.SelectMatchingCard(tp,c57734012.filter1,tp,LOCATION_GRAVE+LOCATION_EXTRA,0,1,1,nil,e,tp)
 	local tc1=g1:GetFirst()

--- a/script/c61314842.lua
+++ b/script/c61314842.lua
@@ -45,7 +45,6 @@ function c61314842.filter2(c,e,tp)
 end
 function c61314842.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
-	if not Duel.IsPlayerCanSpecialSummonCount(tp,2) then return end
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c61314842.filter2,nil,e,tp)
 	if g:GetCount()<2 then return end
 	Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12510
Q.既に通常召喚を1度行っているターンに「高等紋章術」を発動し、それにチェーンして「サモンリミッター」が発動された場合、どのように処理を行いますか？
A.既に1度通常召喚を行っているターン中に「高等紋章術」を発動し、それにチェーンして「サモンリミッター」が発動された場合には、「高等紋章術」の『選択したモンスター2体を特殊召喚』する効果処理は行いますが、『その2体のみを素材としてエクシーズモンスター1体をエクシーズ召喚する』を行う事はできません。