### PR TITLE
fix Rampart Blaster

### DIFF
--- a/script/c47737087.lua
+++ b/script/c47737087.lua
@@ -13,27 +13,44 @@ function c47737087.initial_effect(c)
 	--
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_DEFENCE_ATTACK)
+	e2:SetCode(EFFECT_DIRECT_ATTACK)
 	e2:SetCondition(c47737087.dacon)
 	c:RegisterEffect(e2)
-	--atkdown
 	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e3:SetCode(EVENT_PRE_DAMAGE_CALCULATE)
-	e3:SetCondition(c47737087.rdcon)
-	e3:SetOperation(c47737087.rdop)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_DEFENCE_ATTACK)
+	e3:SetCondition(c47737087.dacon)
 	c:RegisterEffect(e3)
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTargetRange(0,LOCATION_MZONE)
+	e4:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e4:SetCode(EFFECT_CANNOT_BE_BATTLE_TARGET)
+	e4:SetCondition(c47737087.dacon)
+	e4:SetValue(c47737087.val)
+	c:RegisterEffect(e4)
+	--atkdown
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e5:SetCode(EVENT_PRE_DAMAGE_CALCULATE)
+	e5:SetCondition(c47737087.rdcon)
+	e5:SetOperation(c47737087.rdop)
+	c:RegisterEffect(e5)
 end
 function c47737087.splimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
 end
 function c47737087.dacon(e)
-	return Duel.GetFieldGroupCount(e:GetHandlerPlayer(),0,LOCATION_MZONE)==0
-		or e:GetHandler():IsHasEffect(EFFECT_DIRECT_ATTACK)
+	return e:GetHandler():IsDefencePos()
+end
+function c47737087.val(e,c)
+	return c==e:GetHandler()
 end
 function c47737087.rdcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c==Duel.GetAttacker() and c:IsDefencePos() and Duel.GetAttackTarget()==nil
+	return ep~=tp and c==Duel.GetAttacker() and Duel.GetAttackTarget()==nil and c:IsDefencePos()
+		and c:GetEffectCount(EFFECT_DIRECT_ATTACK)<2 and Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0
 end
 function c47737087.rdop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9224&keyword=&tag=-1
Q.相手フィールドにモンスターが存在する場合、表側守備表示の「E・HERO ランパートガンナー」は、自身の『このカードが表側守備表示の場合、守備表示の状態で相手プレイヤーを直接攻撃する事ができる。その場合、このカードの攻撃力はダメージ計算時のみ半分になる』効果によって直接攻撃を行う事ができますか？
A.できます。