### PR TITLE
fix Powerful Rebirth

### DIFF
--- a/script/c84298614.lua
+++ b/script/c84298614.lua
@@ -53,7 +53,7 @@ function c84298614.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c84298614.rcon(e)
-	return e:GetOwner():IsHasCardTarget(e:GetHandler())
+	return e:GetOwner():IsHasCardTarget(e:GetHandler()) and not e:GetHandler():IsImmuneToEffect(e)
 end
 function c84298614.descon(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetHandler():GetFirstCardTarget()


### PR DESCRIPTION
If monster that Special Summoned by Powerful Rebirth's effect was affected by Forbidden Lance, that monster doesn't change it level, ATK and DEF.