### PR TITLE
fix Magical Hats

### DIFF
--- a/script/c81210420.lua
+++ b/script/c81210420.lua
@@ -97,5 +97,5 @@ function c81210420.desop(e,tp,eg,ep,ev,re,r,rp)
 	local fid=e:GetLabel()
 	local tg=g:Filter(c81210420.desfilter,nil,fid)
 	g:DeleteGroup()
-	Duel.Destroy(tg,REASON_EFFECT)
+	Duel.Destroy(tg,REASON_RULE)
 end


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%A5%DE%A5%B8%A5%AB%A5%EB%A5%B7%A5%EB%A5%AF%A5%CF%A5%C3%A5%C8%A1%D5#g3375fb3
Ｑ：特殊召喚したカードが何らかのカードの効果で破壊される場合、表側表示（＋アンデット族）になっていたら《宮廷のしきたり》や《アンデット・スカル・デーモン》の効果で破壊を阻むことができますか？
Ａ：このカードの効果によって永続罠カードをモンスターとしてセットした場合、《宮廷のしきたり》が発動していても、バトルフェイズ終了時に破壊されます。(09/11/14)
　　《アンデット・スカル・デーモン》の場合も同様です。(15/01/05)

Ｑ：このカードの効果でモンスターカードとしてにフィールド出した魔法・罠カードに対して、《攻撃の無敵化》の一つ目の効果を選択して破壊耐性を持たせた場合、バトルフェイズ終了時にその魔法・罠カードは自壊しますか？
　　自壊せずにそれ以降もフィールドに残り続ける場合、次のバトルフェイズ終了時に自壊しますか？
Ａ：自壊します。(14/10/22)

Ｑ：《聖なる輝き》が存在する状態で《マジカルシルクハット》を発動し、その後モンスター扱いの魔法・罠カードに《ヴァイロン・テトラ》を装備しました。
　　バトルフェイズ終了時、《ヴァイロン・テトラ》を破壊してモンスター扱いの魔法・罠カードをフィールドに維持することができますか？
　　維持できる場合、以後のバトルフェイズが終了する度に自壊する処理は行われますか？
Ａ：《マジカルシルクハット》の効果で特殊召喚したカードは、自壊効果が適用されているため、バトルフェイズ終了後もフィールド上に残り続ける事はできません。
　　したがって、バトルフェイズ終了時に《ヴァイロン・テトラ》を破壊したとしても、ただちにモンスター扱いの魔法・罠カードも破壊されます。(14/12/24)

Ｑ：《マジカルシルクハット》の効果でモンスターとして扱われている魔法・罠カードの自壊を《禁じられた聖槍》や《暴君の威圧》で阻止することは可能ですか？
Ａ：いいえ、自壊します。(14/10/22)

Ｑ：《マジカルシルクハット》の効果でモンスターとして扱われている魔法・罠カードの自壊を《禁じられた聖衣》や《攻撃の無敵化》、《ゴーストリック・アウト》で阻止することは可能ですか？
Ａ：いいえ、自壊します。(14/12/18)

Ｑ：《マジカルシルクハット》の効果でモンスターとして扱われている魔法・罠カードが存在する時、モンスターがいても直接攻撃できるモンスターに直接攻撃されたので《閃光弾》を発動しました。
　　モンスターとして扱われている魔法・罠カードはフィールドに残り続けますか？
Ａ：エンドフェイズに入る前に《マジカルシルクハット》の効果が適用され、モンスター扱いとして特殊召喚した魔法・罠カードが破壊され、その後エンドフェイズになります(14/12/18)

Ｑ：《ＤＮＡ改造手術》で魔法使い族と宣言されている場合、このカードの効果で特殊召喚したモンスター扱いの魔法・罠カードが自壊する代わりに《魔導騎士 ディフェンダー》の効果で魔力カウンターを取り除く事はできますか？
Ａ：《マジカルシルクハット》の効果で特殊召喚したカードは、自壊効果が適用されているため、《魔導騎士 ディフェンダー》の効果により魔力カウンターを取り除く事はできますが、その後、ただちにモンスター扱いの魔法・罠カードは破壊されます。(14/12/24)