### PR TITLE
fix Chaos Atlandis(2)

### DIFF
--- a/script/c6387204.lua
+++ b/script/c6387204.lua
@@ -72,7 +72,7 @@ function c6387204.lpcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetLP(1-tp)~=100 and e:GetHandler():GetOverlayGroup():IsExists(Card.IsCode,1,nil,9161357)
 end
 function c6387204.filter(c)
-	return c:GetFlagEffect(6387204)~=0 and c:IsSetCard(0x48) and c:IsAbleToGraveAsCost()
+	return c:GetFlagEffect(6387204)~=0 and c:IsSetCard(0x48) and c:IsFaceup() and c:IsAbleToGraveAsCost()
 end
 function c6387204.lpcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,3,REASON_COST)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7268&keyword=&tag=-1
Q.「CNo.6 先史遺産カオス・アトランタル」の『１ターンに１度、相手フィールド上のモンスター１体を選択し、攻撃力１０００ポイントアップの装備カード扱いとしてこのカードに装備できる』効果の対象として、裏側守備表示のモンスターを選択する事はできますか？
A.「CNo.6 先史遺産カオス・アトランタル」の効果の対象として、相手フィールドの裏側守備表示のモンスターを選択する事はできます。

なお、その裏側守備表示のモンスターが、「No.」と名のついたモンスターだった場合でも、そのカードを「CNo.6 先史遺産カオス・アトランタル」の『●このカードのエクシーズ素材を３つ取り除き、このカードの効果で装備した「No.」と名のついたモンスターを全て墓地へ送って発動できる。相手のライフポイントを１００にする』の効果を発動する際に墓地へ送る事はできません。
（効果を発動するためには、「CNo.6 先史遺産カオス・アトランタル」が「No.」と名のついたモンスターを表側表示で装備している必要があります。）