### PR TITLE
fix EFFECT_NECRO_VALLEY check

### DIFF
--- a/script/c12940613.lua
+++ b/script/c12940613.lua
@@ -30,7 +30,7 @@ function c12940613.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,1,0,0)
 end
 function c12940613.tdfilter2(c)
-	return c:IsType(TYPE_MONSTER) and c:IsAbleToDeck()
+	return c:IsType(TYPE_MONSTER) and c:IsAbleToDeck() and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c12940613.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/script/c20579538.lua
+++ b/script/c20579538.lua
@@ -31,7 +31,7 @@ function c20579538.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
 end
 function c20579538.tdfilter(c)
-	return c:IsSetCard(0xa6) and c:IsType(TYPE_MONSTER) and c:IsAbleToDeck()
+	return c:IsSetCard(0xa6) and c:IsType(TYPE_MONSTER) and c:IsAbleToDeck() and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c20579538.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end

--- a/script/c3429238.lua
+++ b/script/c3429238.lua
@@ -84,10 +84,9 @@ function c3429238.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():GetFlagEffect(3429238)~=0 end
 	e:GetHandler():ResetFlagEffect(3429238)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_GRAVE)
 end
 function c3429238.filter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+	return c:IsType(TYPE_MONSTER) and c:IsAbleToHand() and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c3429238.spop(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsRelateToEffect(e) and Duel.SpecialSummon(e:GetHandler(),0,tp,tp,false,false,POS_FACEUP)>0 then

--- a/script/c50920465.lua
+++ b/script/c50920465.lua
@@ -21,7 +21,7 @@ function c50920465.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c50920465.filter(c,e,tp)
 	return c:IsRace(RACE_WINDBEAST) and c:IsAttribute(ATTRIBUTE_WATER)
-		and not c:IsCode(50920465) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and not c:IsCode(50920465) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c50920465.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>1

--- a/script/c6459419.lua
+++ b/script/c6459419.lua
@@ -13,7 +13,7 @@ function c6459419.dfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x4) and c:IsDestructable()
 end
 function c6459419.spfilter(c,e,tp)
-	return c:IsLevelBelow(4) and c:IsSetCard(0x4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevelBelow(4) and c:IsSetCard(0x4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c6459419.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c6459419.dfilter,tp,LOCATION_MZONE,0,1,nil) end

--- a/script/c64726269.lua
+++ b/script/c64726269.lua
@@ -27,7 +27,7 @@ function c64726269.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
 end
 function c64726269.tdfilter(c)
-	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAbleToDeck()
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAbleToDeck() and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c64726269.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end

--- a/script/c66127916.lua
+++ b/script/c66127916.lua
@@ -22,9 +22,10 @@ function c66127916.filter2(c,fc)
 end
 function c66127916.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c66127916.filter1,tp,LOCATION_EXTRA,0,1,nil,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function c66127916.filter3(c)
-	return c:IsCode(24094653) and c:IsAbleToHand()
+	return c:IsCode(24094653) and c:IsAbleToHand() and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c66127916.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONFIRM)

--- a/script/c71921856.lua
+++ b/script/c71921856.lua
@@ -33,7 +33,7 @@ function c71921856.initial_effect(c)
 end
 c71921856.xyz_number=79
 function c71921856.filter(c)
-	return c:IsSetCard(0x84) and c:IsType(TYPE_MONSTER)
+	return c:IsSetCard(0x84) and c:IsType(TYPE_MONSTER) and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c71921856.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c71921856.filter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil) end

--- a/script/c72648577.lua
+++ b/script/c72648577.lua
@@ -17,7 +17,7 @@ function c72648577.filter(c)
 	return c:IsSetCard(0xaf) and c:IsAbleToDeck()
 end
 function c72648577.thfilter(c)
-	return c:IsSetCard(0xaf) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+	return c:IsSetCard(0xaf) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand() and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c72648577.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c72648577.filter,tp,LOCATION_ONFIELD+LOCATION_GRAVE+LOCATION_HAND,0,3,nil) end

--- a/script/c89397517.lua
+++ b/script/c89397517.lua
@@ -21,7 +21,7 @@ function c89397517.rmfilter(c)
 	return c:IsSetCard(0xa1) and c:IsType(TYPE_SPELL) and c:IsAbleToRemove()
 end
 function c89397517.spfilter(c,e,tp)
-	return c:IsSetCard(0xa0) and c:IsType(TYPE_MONSTER) and c:IsCanBeSpecialSummoned(e,0,tp,true,true)
+	return c:IsSetCard(0xa0) and c:IsType(TYPE_MONSTER) and c:IsCanBeSpecialSummoned(e,0,tp,true,true) and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c89397517.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0


### PR DESCRIPTION
While Necrovalley is active, you can still activate the effect that banishes Drill Warrior. (The effect is applied normally.) If Necrovalley is active during my next Standby Phase after resolving that effect, the effect of Drill Warrior that Special Summons it and adds a monster from the Graveyard to the hand will activate. In this case, Drill Warrior is Special Summoned, but the effect of adding a monster to your hand is not applied.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9791&keyword=&tag=0

|Card Name|Card Id|
|:------------|:----------|
|マドルチェ・マナー|[12940613](http://yugioh.wikia.com/wiki/12940613)|
森羅の姫芽君 スプラウト|[20579538](http://yugioh.wikia.com/wiki/20579538)
ドリル・ウォリアー|[3429238](http://yugioh.wikia.com/wiki/3429238)
ブリザード・サンダーバード|[50920465](http://yugioh.wikia.com/wiki/50920465)
アマゾネス転生術|[6459419](http://yugioh.wikia.com/wiki/6459419)
光天使スケール|[64726269](http://yugioh.wikia.com/wiki/64726269)
融合準備|[66127916](http://yugioh.wikia.com/wiki/66127916)
No.79 BK 新星のカイザー|[71921856](http://yugioh.wikia.com/wiki/71921856)
DDDの人事権|[72648577](http://yugioh.wikia.com/wiki/72648577)
レジェンド・オブ・ハート|[89397517](http://yugioh.wikia.com/wiki/89397517)