### PR TITLE
fix Chaos Chimera Dragon, Survival of the Fittest

### DIFF
--- a/script/c58272005.lua
+++ b/script/c58272005.lua
@@ -54,6 +54,7 @@ function c58272005.operation(e,tp,eg,ep,ev,re,r,rp)
 		e3:SetRange(LOCATION_SZONE)
 		e3:SetCode(EVENT_BATTLE_DESTROYING)
 		e3:SetCondition(c58272005.atcon)
+		e3:SetTarget(c58272005.attg)
 		e3:SetOperation(c58272005.atop)
 		e3:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e3)
@@ -67,6 +68,9 @@ function c58272005.atcon(e,tp,eg,ep,ev,re,r,rp)
 	if not eg:IsContains(ec) then return false end
 	local bc=ec:GetBattleTarget()
 	return bc:IsLocation(LOCATION_GRAVE) and bc:IsType(TYPE_MONSTER) and ec:IsChainAttackable(2,true) and ec:IsStatus(STATUS_OPPO_BATTLE)
+end
+function c58272005.attg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0 end
 end
 function c58272005.atop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/script/c69757518.lua
+++ b/script/c69757518.lua
@@ -18,6 +18,7 @@ function c69757518.initial_effect(c)
 	e2:SetCode(EVENT_DAMAGE_STEP_END)
 	e2:SetCondition(c69757518.atcon)
 	e2:SetCost(c69757518.atcost)
+	e2:SetTarget(c69757518.attg)
 	e2:SetOperation(c69757518.atop)
 	c:RegisterEffect(e2)
 	local e3=Effect.CreateEffect(c)
@@ -43,6 +44,9 @@ end
 function c69757518.atcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function c69757518.attg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0 end
 end
 function c69757518.atop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
「生存競争」を装備したモンスターが戦闘によって相手モンスターを破壊し墓地へ送った時に相手フィールド上にモンスターが存在しない場合でも「生存競争」の『装備モンスターは相手フィールド上のモンスターにもう１度だけ続けて攻撃できる』効果を発動できますか？
A.
ご質問の状況の場合、「生存競争」の『装備モンスターは相手フィールド上のモンスターにもう１度だけ続けて攻撃できる』効果を発動する事はできません。

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。

遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
「CNo.5 亡朧龍 カオス・キマイラ・ドラゴン」が攻撃を行ったダメージステップ終了時に相手フィールドにモンスターが存在しない場合でも「CNo.5 亡朧龍 カオス・キマイラ・ドラゴン」の②の効果を発動できますか？
A.
ご質問の状況の場合、「CNo.5 亡朧龍 カオス・キマイラ・ドラゴン」の『②』の効果を発動する事はできません。

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。