### PR TITLE
fix Elemental Lords

### DIFF
--- a/script/c13959634.lua
+++ b/script/c13959634.lua
@@ -28,7 +28,7 @@ function c13959634.initial_effect(c)
 	--leave
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e4:SetCode(EVENT_LEAVE_FIELD)
+	e4:SetCode(EVENT_LEAVE_FIELD_P)
 	e4:SetOperation(c13959634.leaveop)
 	c:RegisterEffect(e4)
 end
@@ -46,7 +46,8 @@ function c13959634.hdop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SendtoGrave(g,REASON_EFFECT+REASON_DISCARD)
 end
 function c13959634.leaveop(e,tp,eg,ep,ev,re,r,rp)
-	local effp=e:GetHandler():GetPreviousControler()
+	if e:GetHandler():IsFacedown() then return end
+	local effp=e:GetHandler():GetControler()
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_SKIP_BP)

--- a/script/c35842855.lua
+++ b/script/c35842855.lua
@@ -29,7 +29,7 @@ function c35842855.initial_effect(c)
 	--leave
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e4:SetCode(EVENT_LEAVE_FIELD)
+	e4:SetCode(EVENT_LEAVE_FIELD_P)
 	e4:SetOperation(c35842855.leaveop)
 	c:RegisterEffect(e4)
 end
@@ -60,7 +60,8 @@ function c35842855.desop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c35842855.leaveop(e,tp,eg,ep,ev,re,r,rp)
-	local effp=e:GetHandler():GetPreviousControler()
+	if e:GetHandler():IsFacedown() then return end
+	local effp=e:GetHandler():GetControler()
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_SKIP_BP)

--- a/script/c53027855.lua
+++ b/script/c53027855.lua
@@ -28,7 +28,7 @@ function c53027855.initial_effect(c)
 	--leave
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e4:SetCode(EVENT_LEAVE_FIELD)
+	e4:SetCode(EVENT_LEAVE_FIELD_P)
 	e4:SetOperation(c53027855.leaveop)
 	c:RegisterEffect(e4)
 end
@@ -50,7 +50,8 @@ function c53027855.desop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Destroy(g,REASON_EFFECT)
 end
 function c53027855.leaveop(e,tp,eg,ep,ev,re,r,rp)
-	local effp=e:GetHandler():GetPreviousControler()
+	if e:GetHandler():IsFacedown() then return end
+	local effp=e:GetHandler():GetControler()
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_SKIP_BP)

--- a/script/c61468779.lua
+++ b/script/c61468779.lua
@@ -28,7 +28,7 @@ function c61468779.initial_effect(c)
 	--leave
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e4:SetCode(EVENT_LEAVE_FIELD)
+	e4:SetCode(EVENT_LEAVE_FIELD_P)
 	e4:SetOperation(c61468779.leaveop)
 	c:RegisterEffect(e4)
 end
@@ -55,7 +55,8 @@ function c61468779.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c61468779.leaveop(e,tp,eg,ep,ev,re,r,rp)
-	local effp=e:GetHandler():GetPreviousControler()
+	if e:GetHandler():IsFacedown() then return end
+	local effp=e:GetHandler():GetControler()
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_SKIP_BP)


### PR DESCRIPTION
If a face-down Grandsoil the Elemental Lord leaves the field, its effect of skipping the Battle Phase does not apply.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=11315&keyword=&tag=0
If Grandsoil the Elemental Lord leaves the field while its effects are negated by Skill Drain, the effect of skipping the Battle Phase does not apply.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12644&keyword=&tag=0