### PR TITLE
fix Gandora the Dragon of Destruction

### DIFF
--- a/script/c64681432.lua
+++ b/script/c64681432.lua
@@ -11,10 +11,11 @@ function c64681432.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
-	e2:SetOperation(c64681432.tgreg)
+	e2:SetOperation(c64681432.tgreg1)
 	c:RegisterEffect(e2)
 	local e3=e2:Clone()
 	e3:SetCode(EVENT_FLIP_SUMMON_SUCCESS)
+	e3:SetOperation(c64681432.tgreg2)
 	c:RegisterEffect(e3)
 	--destroy
 	local e4=Effect.CreateEffect(c)
@@ -26,6 +27,18 @@ function c64681432.initial_effect(c)
 	e4:SetTarget(c64681432.destg)
 	e4:SetOperation(c64681432.desop)
 	c:RegisterEffect(e4)
+	--to grave
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e5:SetDescription(aux.Stringid(64681432,1))
+	e5:SetCategory(CATEGORY_TOGRAVE)
+	e5:SetCode(EVENT_PHASE+PHASE_END)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetCountLimit(1)
+	e5:SetCondition(c64681432.tgcon)
+	e5:SetTarget(c64681432.tgtg)
+	e5:SetOperation(c64681432.tgop)
+	c:RegisterEffect(e5)
 end
 function c64681432.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
@@ -50,20 +63,14 @@ function c64681432.desop(e,tp,eg,ep,ev,re,r,rp)
 		e:GetHandler():RegisterEffect(e1)
 	end
 end
-function c64681432.tgreg(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	--to grave
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e1:SetDescription(aux.Stringid(64681432,1))
-	e1:SetCategory(CATEGORY_TOGRAVE)
-	e1:SetCode(EVENT_PHASE+PHASE_END)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetCountLimit(1)
-	e1:SetReset(RESET_EVENT+0x1ee0000+RESET_PHASE+PHASE_END)
-	e1:SetTarget(c64681432.tgtg)
-	e1:SetOperation(c64681432.tgop)
-	c:RegisterEffect(e1)
+function c64681432.tgreg1(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(64681432,RESET_EVENT+0x16e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c64681432.tgreg2(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(64681432,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c64681432.tgcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(64681432)~=0
 end
 function c64681432.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9992&keyword=&tag=-1
Q.「破壊竜ガンドラ」が召喚・反転召喚されたターンに「亜空間物質転送装置」の効果によって除外され、エンドフェイズにフィールドに戻りました。

この場合、「破壊竜ガンドラ」の『このカードが召喚・反転召喚したターンのエンドフェイズ時、このカードを墓地へ送る』効果は発動しますか？
A.「破壊竜ガンドラ」が召喚されたターンに「亜空間物質転送装置」の効果にて除外され、エンドフェイズにフィールドに戻っている場合には、エンドフェイズに「破壊竜ガンドラ」の効果は通常通り発動し、「破壊竜ガンドラ」自身が墓地へ送られる事になります。

また、「破壊竜ガンドラ」が反転召喚されたターンに「亜空間物質転送装置」の効果にて除外され、エンドフェイズにフィールドに戻っている場合には、フィールドに戻った「破壊竜ガンドラ」は、このターンに反転召喚したカードの扱いではなくなりますので、エンドフェイズに「破壊竜ガンドラ」の効果は発動せず、フィールドに残る事になります。