### PR TITLE
fix Dewloren, Tiger King of the Ice Barrier

### DIFF
--- a/script/c70583986.lua
+++ b/script/c70583986.lua
@@ -19,10 +19,10 @@ function c70583986.filter(c)
 	return c:IsFaceup() and c:IsAbleToHand()
 end
 function c70583986.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() and chkc:IsControler(tp) and c70583986.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c70583986.filter,tp,LOCATION_ONFIELD,0,1,nil) end
+	if chkc then return chkc:IsOnField() and chkc:IsControler(tp) and c70583986.filter(chkc) and chkc~=e:GetHandler() end
+	if chk==0 then return Duel.IsExistingTarget(c70583986.filter,tp,LOCATION_ONFIELD,0,1,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local g=Duel.SelectTarget(tp,c70583986.filter,tp,LOCATION_ONFIELD,0,1,11,nil)
+	local g=Duel.SelectTarget(tp,c70583986.filter,tp,LOCATION_ONFIELD,0,1,11,e:GetHandler())
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
 end
 function c70583986.operation(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7790&keyword=&tag=-1
Q.「氷結界の虎王ドゥローレン」の『１ターンに１度、自分フィールド上に表側表示で存在するカードを任意の枚数選択して持ち主の手札に戻す事ができる。このカードの攻撃力はエンドフェイズ時まで、この効果で手札に戻したカードの数×５００ポイントアップする』の対象として、効果を発動した「氷結界の虎王ドゥローレン」自身を選択する事はできますか？
A.「氷結界の虎王ドゥローレン」の効果は自身の攻撃力をアップする効果ですので、持ち主の手札に戻す対象として、効果を発動した「氷結界の虎王ドゥローレン」自身を選択する事はできません。