### PR TITLE
fix A Wild Monster Appears!

### DIFF
--- a/script/c23587624.lua
+++ b/script/c23587624.lua
@@ -36,6 +36,7 @@ function c23587624.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_IMMUNE_EFFECT)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
 		e1:SetValue(c23587624.efilter)
+		e1:SetOwnerPlayer(tp)
 		tc:RegisterEffect(e1,true)
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
@@ -72,7 +73,7 @@ function c23587624.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e4,tp)
 end
 function c23587624.efilter(e,re)
-	return e:GetHandlerPlayer()==re:GetHandlerPlayer() and e:GetHandler()~=re:GetHandler()
+	return e:GetOwnerPlayer()==re:GetHandlerPlayer() and e:GetHandler()~=re:GetHandler()
 end
 function c23587624.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp


### PR DESCRIPTION
遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
「エネミーコントローラー」の効果で相手が「青天の霹靂」の効果で特殊召喚した「インフェルノイド・ネヘモス」のコントロールを得ました。この場合、「インフェルノイド・ネヘモス」は自分のカードの効果を受けますか？
A.
「エネミーコントローラー」の効果によってコントロールを得た「インフェルノイド・ネヘモス」は、コントロールを得たプレイヤーの効果は受けますが、「青天の霹靂」を発動したプレイヤーの効果は受けません。

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。