### PR TITLE
fix attacked count

### DIFF
--- a/ocgcore/processor.cpp
+++ b/ocgcore/processor.cpp
@@ -3831,10 +3831,14 @@ int32 field::process_damage_step(uint16 step) {
 		infos.phase = PHASE_DAMAGE;
 		pduel->write_buffer8(MSG_DAMAGE_STEP_START);
 		core.pre_field[0] = core.attacker->fieldid_r;
-		if(core.attack_target)
+		if(core.attack_target) {
 			core.pre_field[1] = core.attack_target->fieldid_r;
-		else
+			core.attacker->attacked_cards[core.attack_target->fieldid_r] = core.attack_target;
+		} else {
 			core.pre_field[1] = 0;
+			core.attacker->attacked_cards[0] = 0;
+		}
+		core.attacker->attacked_count++;
 		if(core.attack_target->is_position(POS_FACEDOWN)) {
 			change_position(core.attack_target, 0, PLAYER_NONE, core.attack_target->current.position >> 1, 0, TRUE);
 			adjust_all();


### PR DESCRIPTION
The attacker is viewed attacked if it has entered damage step.
Q.
自分の「RR－インペイル・レイニアス」の直接攻撃宣言時に、相手が手札の「工作列車シグナル・レッド」の効果を発動し、その効果によって戦闘ダメージ計算を行いました。そのターンのメインフェイズ２にて、その「RR－インペイル・レイニアス」の『②：このカードが攻撃したターンの自分メインフェイズ２に、自分の墓地の「RR」モンスター１体を対象として発動できる。そのモンスターを特殊召喚する』効果を発動する事はできますか？
A.
手札から特殊召喚した「工作列車シグナル・レッド」の効果によって攻撃対象が入れ替わり、「工作列車シグナル・レッド」と戦闘を行ったとしても、その「RR－インペイル・レイニアス」は攻撃を行っていますので、『②』の効果をメインフェイズ2にて発動する事ができます。

Q.
「No.52 ダイヤモンド・クラブ・キング」の直接攻撃宣言時に、相手が手札の「工作列車シグナル・レッド」の効果を発動し、その効果によって戦闘ダメージ計算を行いました。 
その戦闘が行われた後、「No.52 ダイヤモンド・クラブ・キング」の『このカードは攻撃した場合、バトルフェイズ終了時に守備表示になる』効果を適用する事はできますか？
A.
「工作列車シグナル・レッド」の効果により戦闘ダメージ計算を行ったとしても、攻撃宣言を行った「No.52 ダイヤモンド・クラブ・キング」は攻撃を行ったモンスターとして扱いますので、バトルフェイズ終了時には守備表示となります。