### PR TITLE
fix Featherizer

### DIFF
--- a/script/c32271987.lua
+++ b/script/c32271987.lua
@@ -18,8 +18,10 @@ function c32271987.filter(c)
 	return c:IsType(TYPE_DUAL) and c:IsAbleToGrave()
 end
 function c32271987.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp,1)
-		and Duel.IsExistingMatchingCard(c32271987.filter,tp,LOCATION_DECK,0,1,nil) end
+	if chk==0 then
+		local ct=Duel.GetMatchingGroupCount(c32271987.filter,tp,LOCATION_DECK,0,nil)
+		if ct==1 and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==1 then return false end
+		return Duel.IsPlayerCanDraw(tp,1) and ct>=1 end
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8750&keyword=&tag=-1
Q.「フェデライザー」のデッキからデュアルモンスター1体を墓地へ送り、カードを1枚ドローする効果は、自分のデッキにデュアルモンスターが存在しない場合でも、発動する事ができますか？
また、デッキのカードがデュアルモンスター1体のみの場合に、「フェデライザー」の効果を発動して、デュアルモンスターを墓地に送る効果処理のみを適用する事ができますか？
A.自分のデッキにデュアルモンスターが存在しない場合、「フェデライザー」の効果を発動する事はできません。
また、デッキのカードがデュアルモンスター1枚のみの場合も、「フェデライザー」の効果を発動する事はできません。