### PR TITLE
fix Black-Winged Dragon

### DIFF
--- a/script/c9012916.lua
+++ b/script/c9012916.lua
@@ -1,5 +1,6 @@
 --ブラックフェザー・ドラゴン
 function c9012916.initial_effect(c)
+	c:EnableCounterPermit(0x3010)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
 	c:EnableReviveLimit()
@@ -34,25 +35,25 @@ function c9012916.initial_effect(c)
 end
 function c9012916.damval(e,re,val,r,rp,rc)
 	if bit.band(r,REASON_EFFECT)~=0 then
-		e:GetHandler():AddCounter(0x10,1)
+		e:GetHandler():AddCounter(0x3010,1)
 		return 0
 	end
 	return val
 end
 function c9012916.atkval(e,c)
-	return c:GetCounter(0x10)*-700
+	return c:GetCounter(0x3010)*-700
 end
 function c9012916.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetCounter(0x10)>0 end
-	local ct=e:GetHandler():GetCounter(0x10)
+	if chk==0 then return e:GetHandler():GetCounter(0x3010)>0 end
+	local ct=e:GetHandler():GetCounter(0x3010)
 	e:SetLabel(ct*700)
-	e:GetHandler():RemoveCounter(tp,0x10,ct,REASON_COST)
+	e:GetHandler():RemoveCounter(tp,0x3010,ct,REASON_COST)
 end
 function c9012916.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(aux.nzatk,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,aux.nzatk,tp,0,LOCATION_MZONE,1,1,nil)
 end
 function c9012916.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/strings.conf
+++ b/strings.conf
@@ -399,7 +399,7 @@
 !counter 0xd 强欲指示物
 !counter 0xe A指示物
 !counter 0xf 虫指示物
-!counter 0x10 黑羽指示物
+!counter 0x3010 黑羽指示物
 !counter 0x11 超毒指示物
 !counter 0x12 机巧指示物
 !counter 0x13 混沌指示物


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%A5%D6%A5%E9%A5%C3%A5%AF%A5%D5%A5%A7%A5%B6%A1%BC%A1%A6%A5%C9%A5%E9%A5%B4%A5%F3%A1%D5#faq
Ｑ：このカードに黒羽カウンターが乗っている場合に《スキルドレイン》の効果を発動した場合、このカードに乗っている黒羽カウンターを取り除きますか？
Ａ：はい。黒羽カウンターを取り除きます。(15/04/08)
Ｑ：このカードに黒羽カウンターが１つ乗っているときに相手の攻撃力700未満のモンスターを選択して発動できますか？
Ａ：はい、発動できます。ただし攻撃力が０のモンスターに対しては発動できません。（10/02/20）