### PR TITLE
Temperance of Prophecy & Spellbook of Life 

### DIFF
--- a/script/c87608852.lua
+++ b/script/c87608852.lua
@@ -14,7 +14,7 @@ function c87608852.initial_effect(c)
 	Duel.AddCustomActivityCounter(87608852,ACTIVITY_CHAIN,c87608852.chainfilter)
 end
 function c87608852.counterfilter(c)
-	return not c:IsLevelAbove(5)
+	return not c:IsLevelAbove(5) or (c:GetReasonEffect():GetHandler():IsCode(52628687) and c:GetOriginalLevel()<5)
 end
 function c87608852.chainfilter(re,tp,cid)
 	return not (re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_SPELL) and re:GetHandler():IsSetCard(0x106e))


### PR DESCRIPTION
Ｑ：《ネクロの魔導書》を発動し元々のレベルが４以下の魔法使い族を選択して特殊召喚しそのモンスターのレベルが５以上になった場合、このターン中にこのカードの効果を発動することは可能ですか？
Ａ：はい、可能です。(12/05/02)