### PR TITLE
fix Fusion Recovery

### DIFF
--- a/script/c18511384.lua
+++ b/script/c18511384.lua
@@ -14,7 +14,7 @@ function c18511384.filter1(c)
 	return c:IsCode(24094653) and c:IsAbleToHand()
 end
 function c18511384.filter2(c)
-	return bit.band(c:GetReason(),0x40008)==0x40008 and c:IsAbleToHand()
+	return bit.band(c:GetReason(),0x40008)==0x40008 and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
 end
 function c18511384.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end


### PR DESCRIPTION
遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
モンスター扱いの「影依の原核」を融合素材に使用しました。このカードは「融合回収」で手札に加える事はできますか？

A.
墓地に送られた「影依の原核」は、モンスターカードとしては扱われず永続罠カードとしての扱いのみとなります。
したがって、融合召喚の素材として使用したモンスターカードを対象に選択する必要がある「融合回収」で選ぶことはできません。

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。