### PR TITLE
multiple EFFECT_MAX_ZONE effects

### DIFF
--- a/ocgcore/field.cpp
+++ b/ocgcore/field.cpp
@@ -476,7 +476,11 @@ int32 field::get_useable_count(uint8 playerid, uint8 location, uint8 uplayer, ui
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(uplayer, PARAM_TYPE_INT);
 		pduel->lua->add_param(reason, PARAM_TYPE_INT);
-		int32 max = eset.get_last()->get_value(3);
+		int32 max = eset[0]->get_value(3);
+		for (int32 i = 1; i < eset.size(); ++i) {
+			if (max > eset[i]->get_value(3))
+				max = eset[i]->get_value(3);
+		}
 		int32 block = 5 - field_used_count[flag];
 		int32 limit = max - field_used_count[used_flag];
 		return block < limit ? block : limit;


### PR DESCRIPTION
if multiple EFFECT_MAX_ZONE effects are active, 
shouldn't the most restrictive one be used?