### PR TITLE
switch equip card

### DIFF
--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -1038,6 +1038,7 @@ int32 field::equip(uint16 step, uint8 equip_player, card * equip_card, card * ta
 			return TRUE;
 		if(equip_card->equiping_target) {
 			equip_card->unequip();
+			equip_card->enable_field_effect(FALSE);
 			return FALSE;
 		}
 		if(equip_card->current.location == LOCATION_SZONE) {


### PR DESCRIPTION
When switching equip card, its effect should re-apply. The result of following two cases should be the same.
Activate リミッター解除/Limiter Removal(23171610), the atk of Cyber End Dragon becomes 8000, then use 移り気な仕立屋/Tailor of the Fickle(43641473) switch デーモンの斧/Axe of Despair(40619825) that activated before activation of Limiter Removal to this Cyber End Dragon, its atk is still 8000.
If first activate Limiter Removal, the atk of Cyber End Dragon becomes 8000, then activate Axe of Despair equipping to another monster. After that, use Tailor of the Fickle switch this Axe of Despair to Cyber End Dragon, its atk increase to 9000.