### PR TITLE
fix Necro Gardna

### DIFF
--- a/script/c4906301.lua
+++ b/script/c4906301.lua
@@ -15,7 +15,6 @@ end
 function c4906301.condition(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	return Duel.GetTurnPlayer()~=tp and ph~=PHASE_MAIN2 and ph~=PHASE_END
-		and Duel.IsExistingMatchingCard(Card.IsAttackable,tp,0,LOCATION_MZONE,1,nil)
 end
 function c4906301.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%A5%CD%A5%AF%A5%ED%A1%A6%A5%AC%A1%BC%A5%C9%A5%CA%A1%BC%A1%D5#occ2a70d
Ｑ：相手フィールドにモンスターが存在しない、または《威嚇する咆哮》でモンスターの攻撃宣言が行えない状況で《ネクロ・ガードナー》の効果は発動できますか？
Ａ：ご質問の場合でも、相手ターンのバトルフェイズ以前のタイミングであり、なおかつダメージステップ以外であれば《ネクロ・ガードナー》は発動できます。(15/04/15)