### PR TITLE
fix Hieratic Dragon

### DIFF
--- a/script/c31516413.lua
+++ b/script/c31516413.lua
@@ -83,5 +83,10 @@ function c31516413.spop(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetCode(EFFECT_SET_DEFENCE)
 		tc:RegisterEffect(e2)
 		Duel.SpecialSummonComplete()
+	else
+		local cg=Duel.GetFieldGroup(tp,0x13,0)
+		Duel.ConfirmCards(1-tp,cg)
+		Duel.ShuffleHand(tp)
+		Duel.ShuffleDeck(tp)
 	end
 end

--- a/script/c3300267.lua
+++ b/script/c3300267.lua
@@ -86,5 +86,10 @@ function c3300267.spop(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetCode(EFFECT_SET_DEFENCE)
 		tc:RegisterEffect(e2)
 		Duel.SpecialSummonComplete()
+	else
+		local cg=Duel.GetFieldGroup(tp,0x13,0)
+		Duel.ConfirmCards(1-tp,cg)
+		Duel.ShuffleHand(tp)
+		Duel.ShuffleDeck(tp)
 	end
 end

--- a/script/c4022819.lua
+++ b/script/c4022819.lua
@@ -96,5 +96,10 @@ function c4022819.spop(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetCode(EFFECT_SET_DEFENCE)
 		tc:RegisterEffect(e2)
 		Duel.SpecialSummonComplete()
+	else
+		local cg=Duel.GetFieldGroup(tp,0x13,0)
+		Duel.ConfirmCards(1-tp,cg)
+		Duel.ShuffleHand(tp)
+		Duel.ShuffleDeck(tp)
 	end
 end

--- a/script/c41639001.lua
+++ b/script/c41639001.lua
@@ -44,5 +44,10 @@ function c41639001.spop(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetCode(EFFECT_SET_DEFENCE)
 		tc:RegisterEffect(e2)
 		Duel.SpecialSummonComplete()
+	else
+		local cg=Duel.GetFieldGroup(tp,0x13,0)
+		Duel.ConfirmCards(1-tp,cg)
+		Duel.ShuffleHand(tp)
+		Duel.ShuffleDeck(tp)
 	end
 end

--- a/script/c77901552.lua
+++ b/script/c77901552.lua
@@ -57,5 +57,10 @@ function c77901552.spop(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetCode(EFFECT_SET_DEFENCE)
 		tc:RegisterEffect(e2)
 		Duel.SpecialSummonComplete()
+	else
+		local cg=Duel.GetFieldGroup(tp,0x13,0)
+		Duel.ConfirmCards(1-tp,cg)
+		Duel.ShuffleHand(tp)
+		Duel.ShuffleDeck(tp)
 	end
 end

--- a/script/c78033100.lua
+++ b/script/c78033100.lua
@@ -60,5 +60,10 @@ function c78033100.spop(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetCode(EFFECT_SET_DEFENCE)
 		tc:RegisterEffect(e2)
 		Duel.SpecialSummonComplete()
+	else
+		local cg=Duel.GetFieldGroup(tp,0x13,0)
+		Duel.ConfirmCards(1-tp,cg)
+		Duel.ShuffleHand(tp)
+		Duel.ShuffleDeck(tp)
 	end
 end


### PR DESCRIPTION
Fix this: If you don't have a monster that can be Special Summoned, you cannot confirm your opponent's hand and Deck.

遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
自分の手札・デッキ・墓地にドラゴン族の通常モンスターが１体も存在しない場合に「聖刻龍－トフェニドラゴン」がリリースされた場合どうなりますか？
A.
「聖刻龍－トフェニドラゴン」のこの効果は、必ず発動する効果です。
よって、リリースされた「聖刻龍－トフェニドラゴン」の効果は発動した結果、自分は相手に、特殊召喚できる通常モンスターが、手札・墓地・デッキに存在しない事を説明していただきます。

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。