### PR TITLE
fix White-Horned Dragon,Amulet Dragon

### DIFF
--- a/script/c73891874.lua
+++ b/script/c73891874.lua
@@ -19,7 +19,7 @@ function c73891874.filter(c)
 end
 function c73891874.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and c73891874.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c73891874.filter,tp,0,LOCATION_GRAVE,1,nil) end
+	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectTarget(tp,c73891874.filter,tp,0,LOCATION_GRAVE,1,5,nil)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)

--- a/script/c75380687.lua
+++ b/script/c75380687.lua
@@ -39,7 +39,7 @@ function c75380687.filter(c)
 end
 function c75380687.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and c75380687.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c75380687.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil) end
+	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectTarget(tp,c75380687.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,120,nil)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13170&keyword=&tag=-1
 Q.「ホワイト・ホーンズ・ドラゴン」の召喚・特殊召喚に成功した際、相手の墓地に魔法カードが無い場合、効果は発動しますか？
A.「ホワイト・ホーンズ・ドラゴン」の効果は、「ホワイト・ホーンズ・ドラゴン」自身が召喚・特殊召喚に成功した際に必ず発動する効果になります。

「ホワイト・ホーンズ・ドラゴン」の効果が発動する際に、相手の墓地に魔法カードが1枚もない場合でも効果は発動し、チェーンブロックが作られます。しかし、対象となるカードが存在しないため、効果の処理を行う事はできず、処理は適用されません。 