### PR TITLE
fix Toy Vendor

### DIFF
--- a/script/c70245411.lua
+++ b/script/c70245411.lua
@@ -44,16 +44,17 @@ function c70245411.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.Draw(tp,1,REASON_EFFECT)==0 then return end
 	local tc=Duel.GetOperatedGroup():GetFirst()
 	Duel.ConfirmCards(1-tp,tc)
-	Duel.BreakEffect()
 	if tc:IsSetCard(0xa9) and tc:IsType(TYPE_MONSTER) then
 		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 		local g=Duel.GetMatchingGroup(c70245411.spfilter,tp,LOCATION_HAND,0,nil,e,tp)
 		if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(70245411,2)) then
+			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 			local sc=g:Select(tp,1,1,nil)
 			Duel.SpecialSummon(sc,0,tp,tp,false,false,POS_FACEUP)
 		end
 	else
+		Duel.BreakEffect()
 		Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)
 	end
 	Duel.ShuffleHand(tp)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8035&keyword=&tag=0
 （なお、ドローした「ファーニマル」と名のついたモンスターを「トイポット」の効果によって特殊召喚せずに処理を完了するのであれば、「光神テテュス」の効果を発動する事ができます。） 