### PR TITLE
fix Zefraxi, Treasure of the Yang Zing

### DIFF
--- a/script/c21495657.lua
+++ b/script/c21495657.lua
@@ -39,7 +39,7 @@ function c21495657.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_PENDULUM or e:GetHandler():IsPreviousLocation(LOCATION_DECK)
 end
 function c21495657.filter(c)
-	return c:IsFaceup() and (c:IsSetCard(0x9e) or c:IsSetCard(0xc4)) and not c:IsCode(21495657)
+	return c:IsFaceup() and (c:IsSetCard(0x9e) or c:IsSetCard(0xc4)) and not c:IsType(TYPE_TUNER) and not c:IsCode(21495657)
 end
 function c21495657.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c21495657.filter(chkc) end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11699
■「宝竜星－セフィラフウシ」のモンスター効果の対象として、チューナーを選択する事はできません。