### PR TITLE
fix Transforming Sphere

### DIFF
--- a/script/c66094973.lua
+++ b/script/c66094973.lua
@@ -111,6 +111,7 @@ end
 function c66094973.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
+		if not Duel.IsPlayerCanSpecialSummon(tp) then return end
 		if Duel.SpecialSummon(tc,0,tp,1-tp,false,false,POS_FACEUP_DEFENCE)==0 then
 			Duel.SendtoGrave(tc,REASON_EFFECT)
 		end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9621&keyword=&tag=-1
また、「虚無魔人」の効果が適用され、特殊召喚する事ができない場合でも、エンドフェイズ時に「トランスフォーム・スフィア」の効果が発動しますが、装備モンスターを特殊召喚する事ができず、モンスターは装備されたままとなります。