### PR TITLE
fix Instant Neo Space

### DIFF
--- a/script/c11913700.lua
+++ b/script/c11913700.lua
@@ -54,7 +54,7 @@ function c11913700.operation(e,tp,eg,ep,ev,re,r,rp)
 end
 function c11913700.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetPreviousEquipTarget()
-	return e:GetHandler():IsReason(REASON_LOST_TARGET) and not ec:IsOnField()
+	return e:GetHandler():IsReason(REASON_LOST_TARGET) and not ec:IsLocation(LOCATION_ONFIELD+LOCATION_OVERLAY)
 end
 function c11913700.spfilter(c,e,tp)
 	return c:IsCode(89943723) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and not c:IsHasEffect(EFFECT_NECRO_VALLEY)


### PR DESCRIPTION
Fix this: If the equipped monster was used as an Xyz Material, Instant Neo Space can activate.