### PR TITLE
fix Performapal Lacoodown

### DIFF
--- a/script/c44481227.lua
+++ b/script/c44481227.lua
@@ -45,7 +45,6 @@ function c44481227.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
-	if not tc:IsRelateToEffect(e) then return end
 	if g:GetCount()==0 then return end
 	local gc=g:GetFirst()
 	while gc do
@@ -57,11 +56,13 @@ function c44481227.operation(e,tp,eg,ep,ev,re,r,rp)
 		gc:RegisterEffect(e1)
 		gc=g:GetNext()
 	end
-	local e2=Effect.CreateEffect(e:GetHandler())
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_PIERCE)
-	e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+RESET_END)
-	tc:RegisterEffect(e2)
+	if tc:IsRelateToEffect(e) then
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_PIERCE)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+RESET_END)
+		tc:RegisterEffect(e2)
+	end
 end
 function c44481227.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local rc=e:GetHandler():GetReasonCard()


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=15697&keyword=&tag=-1
 Q.「EMラクダウン」の『①：１ターンに１度、自分フィールドの表側表示モンスター１体を対象として発動できる。相手フィールドの全てのモンスターの守備力はターン終了時まで８００ダウンし、このターン対象のモンスターが守備表示モンスターを攻撃した場合、その守備力を攻撃力が超えた分だけ相手に戦闘ダメージを与える』ペンデュラム効果の発動にチェーンして「強制脱出装置」が発動し、対象のモンスターがフィールドを離れている場合、処理はどうなりますか？
A.「EMラクダウン」のペンデュラム効果の処理時に、対象のモンスターがフィールドを離れている場合には、『相手フィールドの全てのモンスターの守備力はターン終了時まで８００ダウンし』の処理のみが適用される事になります。 