### PR TITLE
fix Odd-Eyes Rebellion Dragon

### DIFF
--- a/script/c45627618.lua
+++ b/script/c45627618.lua
@@ -119,5 +119,5 @@ function c45627618.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsFaceup()
 end
 function c45627618.splimit(e,se,sp,st)
-	return e:GetHandler():IsStatus(STATUS_PROC_COMPLETE) and bit.band(st,SUMMON_TYPE_PENDULUM)==SUMMON_TYPE_PENDULUM
+	return e:GetHandler():IsStatus(STATUS_PROC_COMPLETE) and bit.band(st,SUMMON_TYPE_XYZ)~=SUMMON_TYPE_XYZ
 end


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%C7%C6%B2%A6%B9%F5%CE%B5%A5%AA%A5%C3%A5%C9%A5%A2%A5%A4%A5%BA%A1%A6%A5%EA%A5%D9%A5%EA%A5%AA%A5%F3%A1%A6%A5%C9%A5%E9%A5%B4%A5%F3%A1%D5#faq3
Ｑ：エクシーズ召喚された後エクストラデッキに表側表示で加わったこのカードを、《エクシーズ・シフト》や《エクシーズ・ユニバース》、《ＤＤプラウド・オーガ》の効果で特殊召喚できますか？
Ａ：正規の手順でエクシーズ召喚した後、エクストラデッキに表側表示で加わったこのカードを、《エクシーズ・シフト》や《エクシーズ・ユニバース》、《ＤＤプラウド・オーガ》の効果によって特殊召喚する事はできます。(15/04/30)