### PR TITLE
fix

### DIFF
--- a/script/c5609226.lua
+++ b/script/c5609226.lua
@@ -20,7 +20,7 @@ function c5609226.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c5609226.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)

--- a/script/c94973028.lua
+++ b/script/c94973028.lua
@@ -67,6 +67,7 @@ function c94973028.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,0,0)
 end
 function c94973028.spop(e,tp,eg,ep,ev,re,r,rp)
+	if not c94973028.spcon(e,tp,eg,ep,ev,re,r,rp) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=1 then return end
 	if Duel.IsPlayerCanSpecialSummonMonster(tp,31533705,0x101b,0x4011,0,0,3,RACE_MACHINE,ATTRIBUTE_WIND) then
 		local token=Duel.CreateToken(tp,94973029)


### PR DESCRIPTION
幻獣機コルトウィング/Mecha Phantom Beast Hamstrat(94973028)
If there are no other Mecha Phantom Beast monster on field when resolving effect, the effect will not apply.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8174&keyword=&tag=-1

チューナーズ・バリア/Tuner’s Barrier(5609226)
It will also apply to face down monsters when resolving effect.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9097&keyword=&tag=-1