### PR TITLE
Pendulum Recycle Fixup

### DIFF
--- a/script/c12822541.lua
+++ b/script/c12822541.lua
@@ -16,6 +16,8 @@ function c12822541.initial_effect(c)
 end
 function c12822541.filter1(c)
 	return c:IsSetCard(0xaf) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+		and (c:IsLocation(LOCATION_GRAVE) or c:IsFaceup()
+		and bit.band(c:GetOriginalType(),TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)==0)
 end
 function c12822541.filter2(c)
 	return c:IsFaceup() and c:IsSetCard(0xaf) and c:IsType(TYPE_PENDULUM) and c:IsAbleToHand()

--- a/script/c12822541.lua
+++ b/script/c12822541.lua
@@ -16,8 +16,7 @@ function c12822541.initial_effect(c)
 end
 function c12822541.filter1(c)
 	return c:IsSetCard(0xaf) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
-		and (c:IsLocation(LOCATION_GRAVE) or c:IsFaceup()
-		and bit.band(c:GetOriginalType(),TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)==0)
+		and bit.band(c:GetOriginalType(),TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)==0
 end
 function c12822541.filter2(c)
 	return c:IsFaceup() and c:IsSetCard(0xaf) and c:IsType(TYPE_PENDULUM) and c:IsAbleToHand()

--- a/script/c17979378.lua
+++ b/script/c17979378.lua
@@ -67,6 +67,7 @@ function c17979378.sccon(e)
 end
 function c17979378.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_PENDULUM) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
+		and bit.band(c:GetOriginalType(),TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)==0
 end
 function c17979378.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c17979378.filter,tp,LOCATION_EXTRA,0,1,nil) end

--- a/script/c50485594.lua
+++ b/script/c50485594.lua
@@ -42,6 +42,7 @@ function c50485594.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c50485594.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_PENDULUM) and c:IsAbleToHand()
+		and bit.band(c:GetOriginalType(),TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)==0
 end
 function c50485594.filter2(c,g)
 	return g:IsExists(Card.IsCode,1,c,c:GetCode())


### PR DESCRIPTION
因为金满之壶对超量灵摆的裁定确认，有必要修改所有的有关把额外卡组的灵摆加入手卡或者送回卡组的效果的卡。好在目前这类效果并不多。