### PR TITLE
fix

### DIFF
--- a/script/c41855169.lua
+++ b/script/c41855169.lua
@@ -19,8 +19,11 @@ function c41855169.initial_effect(c)
 	e2:SetOperation(c41855169.operation)
 	c:RegisterEffect(e2)
 end
+function c41855169.cfilter(c)
+	return c:IsDiscardable() and c:IsAbleToGraveAsCost() and not c:IsHasEffect(81674782)
+end
 function c41855169.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c41855169.cfilter,tp,LOCATION_HAND,0,1,nil) end
 	local g=Duel.GetFieldGroup(tp,LOCATION_HAND,0)
 	local sg=g:RandomSelect(tp,1)
 	Duel.SendtoGrave(sg,REASON_COST+REASON_DISCARD)

--- a/script/c81674782.lua
+++ b/script/c81674782.lua
@@ -15,7 +15,19 @@ function c81674782.initial_effect(c)
 	e2:SetTargetRange(0xff,0xff)
 	e2:SetValue(LOCATION_REMOVED)
 	c:RegisterEffect(e2)
+	--
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(81674782)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e3:SetTargetRange(0xff,0xff)
+	e3:SetTarget(c81674782.checktg)
+	c:RegisterEffect(e3)
 end
 function c81674782.rmtarget(e,c)
 	return not c:IsLocation(0x80) and not c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c81674782.checktg(e,c)
+	return not c:IsPublic()
 end


### PR DESCRIPTION
昇霊術師 ジョウゲン/Jowgen the Spiritualist cannot activate its effect when 次元の裂け目/Dimensional Fissure on field
http://yugioh-wiki.net/index.php?%A1%D4%BE%BA%CE%EE%BD%D1%BB%D5%20%A5%B8%A5%E7%A5%A6%A5%B2%A5%F3%A1%D5=
Ｑ：《次元の裂け目》がフィールド上に表側表示で存在する時、《昇霊術師 ジョウゲン》の起動効果を発動できますか?（モンスターのみコストで墓地へ送ることができない時、「手札をランダムに墓地に捨てる」コストを払えますか?）
Ａ：発動できません。(11/12/14)