### PR TITLE
fix Heart-eartH

### DIFF
--- a/script/c23998625.lua
+++ b/script/c23998625.lua
@@ -80,5 +80,10 @@ function c23998625.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Overlay(tc,cg)
 		Duel.SpecialSummon(tc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
 		tc:CompleteProcedure()
+	else
+		local cg=Duel.GetFieldGroup(tp,LOCATION_EXTRA,0)
+		if cg:IsExists(Card.IsFacedown,1,nil) and Duel.IsPlayerCanSpecialSummon(tp) then
+			Duel.ConfirmCards(1-tp,cg)
+		end
 	end
 end


### PR DESCRIPTION
http://yugioh-wiki.net/?%A1%D4%A3%CE%A3%EF.%A3%B5%A3%B3%20%B5%B6%B3%BC%BF%C0%20%A3%C8%A3%E5%A3%E1%A3%F2%A3%F4%A1%DD%A3%E5%A3%E1%A3%F2%A3%F4%A3%C8%A1%D5
逆に効果が発動してエクストラデッキに《Ｎｏ.９２ 偽骸神龍 Ｈｅａｒｔ－ｅａｒｔＨ Ｄｒａｇｏｎ》がない場合は、相手にエクストラデッキを公開する必要がある。