### PR TITLE
fix

### DIFF
--- a/script/c40737112.lua
+++ b/script/c40737112.lua
@@ -78,7 +78,7 @@ end
 function c40737112.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local bc=e:GetLabelObject()
 	if bc:IsRelateToBattle() then
-		Duel.Remove(bc,POS_FACEUP,REASON_EFFECT)
+		Duel.Remove(bc,POS_FACEUP,REASON_EFFECT+REASON_BATTLE)
 	end
 end
 function c40737112.recon(e)


### PR DESCRIPTION
When Dark Magician of Chaos applied by the effect of Spellbook of Power remove the battle destroyed monster, the effect of Spellbook of Power that add a Spellbook from deck to hand still can be activated.
Q.
「ヒュグロの魔導書」自分フィールド上の「混沌の黒魔術師」を選択して発動できる、この「混沌の黒魔術師」の『②』効果を発動する場合、「ヒュグロの魔導書」の『戦闘によって相手モンスターを破壊した場合、デッキから「魔導書」と名のついた魔法カード１枚を手札に加える事ができる』効果は発動しますか？
A.
「混沌の黒魔術師」が戦闘によって破壊したモンスターは墓地に送られずにゲームから除外しますが、戦闘によって破壊した扱いではあるため、「ヒュグロの魔導書」の『戦闘によって相手モンスターを破壊した場合』の効果を発動する事はできます。