### PR TITLE
fix Odd-Eyes Saber Dragon

### DIFF
--- a/script/c19221310.lua
+++ b/script/c19221310.lua
@@ -41,7 +41,7 @@ function c19221310.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g=Duel.SelectMatchingCard(tp,c19221310.filter,tp,LOCATION_ONFIELD+LOCATION_HAND+LOCATION_DECK,0,1,1,nil)
 	if Duel.SendtoGrave(g,REASON_EFFECT)~=0 then
-		if c:IsRelateToEffect(e) then
+		if c:IsRelateToEffect(e) and g:GetFirst():IsLocation(LOCATION_GRAVE) then
 			Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 		end
 	end


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%A5%AA%A5%C3%A5%C9%A5%A2%A5%A4%A5%BA%A1%A6%A5%BB%A5%A4%A5%D0%A1%BC%A1%A6%A5%C9%A5%E9%A5%B4%A5%F3%A1%D5#faq
Ｑ：《マクロコスモス》がフィールドに存在する時に(1)の効果で《オッドアイズ・ドラゴン》を墓地へ送る代わりに除外された場合、このカードは特殊召喚されますか？
Ａ：いいえ、特殊召喚されません。(15/03/21)