### PR TITLE
fix Skreech

### DIFF
--- a/script/c27655513.lua
+++ b/script/c27655513.lua
@@ -27,5 +27,10 @@ function c27655513.operation(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local sg=g:Select(tp,2,2,nil)
 		Duel.SendtoGrave(sg,REASON_EFFECT)
+	else
+		local cg=Duel.GetFieldGroup(tp,LOCATION_DECK,0)
+		Duel.ConfirmCards(1-tp,cg)
+		Duel.ConfirmCards(tp,cg)
+		Duel.ShuffleDeck(tp)
 	end
 end


### PR DESCRIPTION
http://yugioh-wiki.net/?%A1%D4%A5%B9%A5%AF%A5%EA%A1%BC%A5%C1%A1%D5
必ず２体選択するので、デッキ内に水属性モンスターが１体以下しかいない場合、効果は不発となる。
さらに強制効果であるため、２体以上水属性モンスターがいない場合は相手にデッキを確認させる必要がある。