### PR TITLE
fix Cyber Dragon Drei

### DIFF
--- a/script/c59281922.lua
+++ b/script/c59281922.lua
@@ -73,7 +73,7 @@ function c59281922.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c59281922.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6099&keyword=&tag=-1
 Q.「サイバー・ドラゴン・ドライ」の『このカードが除外された場合、自分フィールド上の「サイバー・ドラゴン」１体を選択して発動できる。選択したモンスターはこのターン、戦闘及びカードの効果では破壊されない』効果の発動にチェーンして「月の書」が発動し、対象のモンスターが効果処理時に裏側守備表示になっている場合、効果は適用されますか？
A.質問の状況の場合でも、対象のモンスターは『このターン、戦闘及びカードの効果では破壊されない』効果が通常通り適用されます。

なお、そのターンにて、その後にそのモンスターが表側表示になった場合でも、『このターン、戦闘及びカードの効果では破壊されない』効果は適用されたままです。 