### PR TITLE
fix Timaeus the Knight of Destiny

### DIFF
--- a/script/c53315891.lua
+++ b/script/c53315891.lua
@@ -103,7 +103,7 @@ function c53315891.atkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c53315891.spfilter(c,e,tp)
-	return c:IsSetCard(0xa0) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:IsSetCard(0xa0) and c:IsCanBeSpecialSummoned(e,0,tp,true,true)
 		and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c53315891.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -116,6 +116,6 @@ function c53315891.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c53315891.spfilter,tp,0x13,0,3,3,nil,e,tp)
 	if g:GetCount()>0 then
-		Duel.SpecialSummon(g,0,tp,tp,true,false,POS_FACEUP)
+		Duel.SpecialSummon(g,0,tp,tp,true,true,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=16041&keyword=&tag=-1
 Q.「合神竜ティマイオス」の『③：このカードが戦闘で破壊された時に発動できる。自分の手札・デッキ・墓地の「伝説の騎士」モンスター３体を選び、召喚条件を無視して特殊召喚する』効果によって特殊召喚する「伝説の騎士」と名のついたモンスターを選ぶ場合、「合神竜ティマイオス」を特殊召喚する際に墓地へ送ったモンスターのみを選ぶ事になりますか？
A.「合神竜ティマイオス」の効果で特殊召喚するモンスター3体は、「合神竜ティマイオス」を特殊召喚するために墓地へ送った「伝説の騎士」と名のついたモンスターである必要はありません。

特殊召喚されずに手札やデッキから墓地へ送られている「伝説の騎士」と名のついたモンスターも、「合神竜ティマイオス」の効果で特殊召喚するモンスターに含める事ができます。 