### PR TITLE
fix Ring of Magnetism

### DIFF
--- a/script/c20436034.lua
+++ b/script/c20436034.lua
@@ -28,7 +28,7 @@ function c20436034.initial_effect(c)
 	e5:SetType(EFFECT_TYPE_SINGLE)
 	e5:SetCode(EFFECT_EQUIP_LIMIT)
 	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e5:SetValue(1)
+	e5:SetValue(c20436034.eqlimit)
 	c:RegisterEffect(e5)
 end
 function c20436034.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
@@ -40,7 +40,10 @@ function c20436034.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c20436034.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if e:GetHandler():IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if e:GetHandler():IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) then
 		Duel.Equip(tp,e:GetHandler(),tc)
 	end
+end
+function c20436034.eqlimit(e,c)
+	return e:GetHandlerPlayer()==c:GetControler()
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6218&keyword=&tag=-1
 Q.「心変わり」等の効果によって、コントロールを得た相手モンスターに、自分フィールド上のモンスターにのみ装備できる「磁力の指輪」を装備する事はできますか？
A.「心変わり」等の効果によって、コントロールを得た相手のモンスターでも、自分フィールド上に存在する場合であれば、「磁力の指輪」を装備する事ができます。
しかしながら、「心変わり」等の効果が適用されなくなり、モンスターが相手のフィールド上に戻った場合、「磁力の指輪」を装備する対象として正しくない為、「磁力の指輪」は破壊されます。 