### PR TITLE
fix Heat Wave

### DIFF
--- a/script/c45141013.lua
+++ b/script/c45141013.lua
@@ -25,5 +25,5 @@ function c45141013.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e2,tp)
 end
 function c45141013.sumlimit(e,c,sump,sumtype,sumpos,targetp)
-	return c:IsLocation(LOCATION_MZONE) or c:IsType(TYPE_EFFECT)
+	return c:IsType(TYPE_EFFECT)
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10210&keyword=&tag=-1
また、モンスターゾーンに表側表示で存在するデュアルモンスターは通常モンスターの状態の時、もう1度召喚を行う事ができるモンスターです。
「大熱波」の効果適用中に、モンスターゾーンに通常モンスター扱いで存在する表側表示のデュアルモンスターをもう1度召喚する事はできます。（もう1度召喚されたそのデュアルモンスターは効果モンスターの扱いとなります。） 