### PR TITLE
fix Comic Hand

### DIFF
--- a/script/c33453260.lua
+++ b/script/c33453260.lua
@@ -81,5 +81,5 @@ function c33453260.dircon(e)
 	return not Duel.IsExistingMatchingCard(c33453260.dirfilter,e:GetHandlerPlayer(),0,LOCATION_MZONE,1,nil)
 end
 function c33453260.descon(e)
-	return not Duel.IsExistingMatchingCard(c33453260.cfilter,e:GetHandlerPlayer(),LOCATION_ONFIELD,0,1,nil)
+	return not Duel.IsExistingMatchingCard(c33453260.cfilter,e:GetHandlerPlayer(),LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
 end


### PR DESCRIPTION
Fix this: If your opponent do not control Toon World, destroy Comic Hand.