### PR TITLE
fix Arcana Force EX - The Light Ruler

### DIFF
--- a/script/c5861892.lua
+++ b/script/c5861892.lua
@@ -104,7 +104,11 @@ function c5861892.negcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:GetFlagEffectLabel(36690018)==0 and (re:IsHasType(EFFECT_TYPE_ACTIVATE) or re:IsActiveType(TYPE_MONSTER))
 end
 function c5861892.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	local c=e:GetHandler()
+	if chk==0 then return c:GetFlagEffect(5861892)==0 end
+	if c:IsHasEffect(EFFECT_REVERSE_UPDATE) then
+		c:RegisterFlagEffect(5861892,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+	end
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 	if re:GetHandler():IsRelateToEffect(re) and re:GetHandler():IsDestructable() then
 		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%A5%A2%A5%EB%A5%AB%A5%CA%A5%D5%A5%A9%A1%BC%A5%B9%A3%C5%A3%D8%A1%DD%A3%D4%A3%C8%A3%C5%20%A3%CC%A3%C9%A3%C7%A3%C8%A3%D4%20%A3%D2%A3%D5%A3%CC%A3%C5%A3%D2%A1%D5#faq
Ｑ：《光と闇の竜》のように、《あまのじゃくの呪い》の効果適用中は｢裏｣の効果を１ターンに１度しか発動しなくなりますか？
Ａ：はい、《あまのじゃくの呪い》が適用されている場合、１度のみしか発動しません。(14/07/14)