### PR TITLE
fix Tyrant Burst Dragon

### DIFF
--- a/script/c58293343.lua
+++ b/script/c58293343.lua
@@ -35,7 +35,7 @@ function c58293343.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) or c:IsLocation(LOCATION_SZONE) or c:IsFacedown() then return end
 	local tc=Duel.GetFirstTarget()
-	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 or tc:IsFacedown() or not tc:IsRelateToEffect(e) then
+	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 or tc:GetControler()~=tp or tc:IsFacedown() or not tc:IsRelateToEffect(e) then
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=16014&keyword=&tag=-1
 Q.「タイラント・バースト・ドラゴン」の『②：自分フィールドのモンスター１体を対象として発動できる。このカードを攻撃力・守備力４００アップの装備カード扱いとしてその自分のモンスターに装備する。この効果で装備した場合、装備モンスターは１度のバトルフェイズ中に３回攻撃できる』効果の対象として、「青眼の白龍」を選択しました。

その発動にチェーンして「月の書」が発動し「青眼の白龍」が裏側守備表示になった場合や、チェーンして発動した「エネミーコントローラー」によって「青眼の白龍」のコントロールが相手に移った場合、「タイラント・バースト・ドラゴン」の効果処理はどうなりますか？
A.「タイラント・バースト・ドラゴン」のモンスターへ装備する効果の処理時に、「月の書」や「エネミーコントローラー」の効果が適用される事によって、対象のモンスターが効果処理時に自分のモンスターゾーンに表側表示で存在しなくなった場合には、装備させる事はできず、「タイラント・バースト・ドラゴン」は墓地へ送られる事になります。
（「タイラント・バースト・ドラゴン」は破壊された扱いにはなりません。） 