### PR TITLE
fix Magical Hats (2)

### DIFF
--- a/script/c81210420.lua
+++ b/script/c81210420.lua
@@ -97,5 +97,5 @@ function c81210420.desop(e,tp,eg,ep,ev,re,r,rp)
 	local fid=e:GetLabel()
 	local tg=g:Filter(c81210420.desfilter,nil,fid)
 	g:DeleteGroup()
-	Duel.Destroy(tg,REASON_RULE)
+	Duel.Destroy(tg,REASON_RULE+REASON_EFFECT)
 end


### PR DESCRIPTION
遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
「マジカルシルクハット」の効果で「神縛りの塚」を特殊召喚しました。バトルフェイズ終了時に「マジカルシルクハット」の効果で「神縛りの塚」が破壊された場合、「神縛りの塚」の③の効果は発動しますか？
A.
「神縛りの塚」が、「マジカルシルクハット」の効果で破壊されて墓地へ送られた場合、「神縛りの塚」の『③』の効果を発動する事ができます。

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。