### PR TITLE
fix The Black Stone of Legend

### DIFF
--- a/script/c66574418.lua
+++ b/script/c66574418.lua
@@ -57,7 +57,7 @@ function c66574418.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	local c=e:GetHandler()
 	if tc:IsRelateToEffect(e) and Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)~=0
-		and tc:IsLocation(LOCATION_DECK) and c:IsRelateToEffect(e) then
+		and tc:IsLocation(LOCATION_DECK+LOCATION_EXTRA) and c:IsRelateToEffect(e) then
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%C5%C1%C0%E2%A4%CE%B9%F5%C0%D0%A1%D5#faq
Ｑ：(2)の効果で《真紅眼の黒竜剣》を選択して、そのモンスターがデッキに戻る代わりにエクストラデッキに戻った場合でも、手札に加わる処理は行われますか？
Ａ：はい、行われます。(15/05/23)