### PR TITLE
fix Marshalling Field (2)

### DIFF
--- a/script/c63881033.lua
+++ b/script/c63881033.lua
@@ -82,7 +82,7 @@ function c63881033.lvop(e,tp,eg,ep,ev,re,r,rp)
 	while tc do
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
-		e1:SetCode(EFFECT_CHANGE_LEVEL)
+		e1:SetCode(EFFECT_CHANGE_LEVEL_FINAL)
 		e1:SetValue(e:GetLabel())
 		e1:SetReset(RESET_EVENT+0x1fe0000)
 		tc:RegisterEffect(e1)


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%A5%DE%A1%BC%A5%B7%A5%E3%A5%EA%A5%F3%A5%B0%A1%A6%A5%D5%A5%A3%A1%BC%A5%EB%A5%C9%A1%D5#faq
Ｑ：幻獣機トークン１体と自身の効果でレベル７になっている《幻獣機テザーウルフ》１体が存在する場合にこのカードの(2)の効果でレベル５と宣言しました。
この場合、《幻獣機テザーウルフ》のレベルはどうなりますか？
Ａ：《幻獣機テザーウルフ》のレベルは５になります。(15/02/25)