### PR TITLE
fix Utopic Future, Artifacts Unleashed

### DIFF
--- a/script/c56611470.lua
+++ b/script/c56611470.lua
@@ -34,6 +34,9 @@ end
 function c56611470.mfilter2(c,mc)
 	return c.xyz_filter(mc)
 end
+function c56611470.mfilter3(c,mc,exg)
+	return exg:IsExists(Card.IsXyzSummonable,1,nil,Group.FromCards(c,mc))
+end
 function c56611470.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	local mg=Duel.GetMatchingGroup(c56611470.filter,tp,LOCATION_MZONE,0,nil,e)
@@ -45,7 +48,7 @@ function c56611470.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tc1=sg1:GetFirst()
 	local exg2=exg:Filter(c56611470.mfilter2,nil,tc1)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	local sg2=mg:FilterSelect(tp,c56611470.mfilter1,1,1,tc1,exg2)
+	local sg2=mg:FilterSelect(tp,c56611470.mfilter3,1,1,tc1,tc1,exg2)
 	sg1:Merge(sg2)
 	Duel.SetTargetCard(sg1)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)

--- a/script/c65305468.lua
+++ b/script/c65305468.lua
@@ -44,8 +44,12 @@ function c65305468.initial_effect(c)
 	e7:SetRange(LOCATION_MZONE)
 	e7:SetTarget(c65305468.reptg)
 	c:RegisterEffect(e7)
+	if c65305468.xyz_filter==nil then
+		c65305468.xyz_filter=function(mc) return mc:IsType(TYPE_XYZ) and not mc:IsSetCard(0x48) and mc:IsCanBeXyzMaterial(c) end
+	end
 end
 c65305468.xyz_number=0
+c65305468.xyz_count=2
 function c65305468.mfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ) and not c:IsSetCard(0x48)
 end
@@ -59,24 +63,36 @@ function c65305468.xyzcon(e,c,og)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil)
+	if og then mg=og end
 	return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
 		and mg:IsExists(c65305468.xyzfilter1,1,nil,mg)
 end
 function c65305468.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og)
-	local mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-	local g1=mg:FilterSelect(tp,c65305468.xyzfilter1,1,1,nil,mg)
-	local tc1=g1:GetFirst()
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-	local g2=mg:FilterSelect(tp,c65305468.xyzfilter2,1,1,tc1,tc1:GetRank())
-	local tc2=g2:GetFirst()
-	g1:Merge(g2)
-	local sg1=tc1:GetOverlayGroup()
-	local sg2=tc2:GetOverlayGroup()
-	sg1:Merge(sg2)
-	Duel.SendtoGrave(sg1,REASON_RULE)
-	c:SetMaterial(g1)
-	Duel.Overlay(c,g1)
+	local g=Group.CreateGroup()
+	local sg=Group.CreateGroup()
+	if og then
+		local tc=og:GetFirst()
+		while tc do
+			g:AddCard(tc)
+			sg:Merge(tc:GetOverlayGroup())
+			tc=og:GetNext()
+		end
+	else
+		local mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+		local g1=mg:FilterSelect(tp,c65305468.xyzfilter1,1,1,nil,mg)
+		local tc1=g1:GetFirst()
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+		local g2=mg:FilterSelect(tp,c65305468.xyzfilter2,1,1,tc1,tc1:GetRank())
+		local tc2=g2:GetFirst()
+		g:AddCard(tc1)
+		g:AddCard(tc2)
+		sg:Merge(tc1:GetOverlayGroup())
+		sg:Merge(tc2:GetOverlayGroup())
+	end
+	Duel.SendtoGrave(sg,REASON_RULE)
+	c:SetMaterial(g)
+	Duel.Overlay(c,g)
 end
 function c65305468.cttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=e:GetHandler():GetBattleTarget()


### PR DESCRIPTION
Fix this: You cannot Xyz Summon Number F0: Utopic Future using 2 Artifact Durendals by Artifacts Unleashed effect.
http://yugioh-wiki.net/index.php?%A1%D4%A5%A2%A1%BC%A5%C6%A5%A3%A5%D5%A5%A1%A5%AF%A5%C8%A4%CE%B2%F2%CA%FC%A1%D5#faq
Ｑ：《アーティファクトの解放》の対象に《アーティファクト－デュランダル》２体を選択し、《ＦＮｏ.０ 未来皇ホープ》をエクシーズ召喚する事はできますか？
Ａ：自分フィールド上に、ランク５の《アーティファクト－デュランダル》が２体存在するのであれば、《アーティファクトの解放》を発動し、《アーティファクト－デュランダル》２体を選択して《ＦＮｏ.０ 未来皇ホープ》をエクシーズ召喚する事ができます。(15/05/18)