### PR TITLE
card::is_set_card

### DIFF
--- a/ocgcore/card.cpp
+++ b/ocgcore/card.cpp
@@ -270,6 +270,23 @@ int32 card::is_set_card(uint32 set_code) {
 			return TRUE;
 		setcode = setcode >> 16;
 	}
+	//another code
+	uint32 code2 = get_another_code();
+	uint64 setcode2;
+	if (code2 != 0) {
+		card_data dat;
+		::read_card(code2, &dat);
+		setcode2 = dat.setcode;
+	} else {
+		return FALSE;
+	}
+	uint32 settype2 = setcode2 & 0xfff;
+	uint32 setsubtype2 = setcode2 & 0xf000;
+	while(setcode2) {
+		if ((setcode2 & 0xfff) == settype2 && (setcode2 & 0xf000 & setsubtype2) == setsubtype2)
+			return TRUE;
+		setcode2 = setcode2 >> 16;
+	}
 	return FALSE;
 }
 uint32 card::get_type() {


### PR DESCRIPTION
我觉得这个函数最好追加判断一下EFFECT_ADD_CODE所添加的别名的字段。
虽然目前使用EFFECT_ADD_CODE的卡片基本上本名已经具备了别名的所有字段，但是这不代表以后不会出现那种本名不具备别名的某些字段的卡。比如「古代科技结晶」①：这张卡在墓地存在的场合也当作「古代的机械巨人」使用。这张卡的本名就不具备别名的字段“古代的机械”。
这只是举个例子。追加判断一下以防万一。