### PR TITLE
fix act hint

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -13,12 +13,13 @@ ClientField::ClientField() {
 	hovered_card = 0;
 	clicked_card = 0;
 	highlighting_card = 0;
-	deck_act = false;
-	grave_act = false;
-	remove_act = false;
-	extra_act = false;
-	pzone_act[0] = false;
-	pzone_act[1] = false;
+	for(int p = 0; p < 2; ++p) {
+		deck_act[p] = false;
+		grave_act[p] = false;
+		remove_act[p] = false;
+		extra_act[p] = false;
+		pzone_act[p] = false;
+	}
 	deck_reversed = false;
 	for(int p = 0; p < 2; ++p) {
 		for(int i = 0; i < 5; ++i)
@@ -60,12 +61,13 @@ void ClientField::Clear() {
 	overlay_cards.clear();
 	chains.clear();
 	disabled_field = 0;
-	deck_act = false;
-	grave_act = false;
-	remove_act = false;
-	extra_act = false;
-	pzone_act[0] = false;
-	pzone_act[1] = false;
+	for(int p = 0; p < 2; ++p) {
+		deck_act[p] = false;
+		grave_act[p] = false;
+		remove_act[p] = false;
+		extra_act[p] = false;
+		pzone_act[p] = false;
+	}
 	deck_reversed = false;
 }
 void ClientField::Initial(int player, int deckc, int extrac) {
@@ -315,12 +317,13 @@ void ClientField::ClearCommandFlag() {
 		(*cit)->cmdFlag = 0;
 	for(cit = attackable_cards.begin(); cit != attackable_cards.end(); ++cit)
 		(*cit)->cmdFlag = 0;
-	deck_act = false;
-	extra_act = false;
-	grave_act = false;
-	remove_act = false;
-	pzone_act[0] = false;
-	pzone_act[1] = false;
+	for(int p = 0; p < 2; ++p) {
+		deck_act[p] = false;
+		grave_act[p] = false;
+		remove_act[p] = false;
+		extra_act[p] = false;
+		pzone_act[p] = false;
+	}
 }
 void ClientField::ClearSelect() {
 	std::vector<ClientCard*>::iterator cit;
@@ -336,8 +339,10 @@ void ClientField::ClearChainSelect() {
 		(*cit)->is_selectable = false;
 		(*cit)->is_selected = false;
 	}
-	grave_act = false;
-	remove_act = false;
+	for(int p = 0; p < 2; ++p) {
+		grave_act[p] = false;
+		remove_act[p] = false;
+	}
 }
 void ClientField::ShowSelectCard(bool buttonok) {
 	if(selectable_cards.size() <= 5) {

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -60,10 +60,10 @@ public:
 	std::set<ClientCard*> selectsum_cards;
 	std::vector<ClientCard*> selectsum_all;
 	std::vector<int> sort_list;
-	bool grave_act;
-	bool remove_act;
-	bool deck_act;
-	bool extra_act;
+	bool grave_act[2];
+	bool remove_act[2];
+	bool deck_act[2];
+	bool extra_act[2];
 	bool pzone_act[2];
 	bool chain_forced;
 	ChainInfo current_chain;

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -247,27 +247,51 @@ void Game::DrawMisc() {
 	im.setRotationRadians(act_rot);
 	matManager.mTexture.setTexture(0, imageManager.tAct);
 	driver->setMaterial(matManager.mTexture);
-	if(dField.deck_act) {
+	if(dField.deck_act[0]) {
 		im.setTranslation(vector3df(matManager.vFields[0].Pos.X - (matManager.vFields[0].Pos.X - matManager.vFields[1].Pos.X)/2,
 			matManager.vFields[0].Pos.Y - (matManager.vFields[0].Pos.Y - matManager.vFields[3].Pos.Y)/2, dField.deck[0].size() * 0.01f + 0.02f));
 		driver->setTransform(irr::video::ETS_WORLD, im);
 		driver->drawVertexPrimitiveList(matManager.vActivate, 4, matManager.iRectangle, 2);
 	}
-	if(dField.grave_act) {
+	if(dField.deck_act[1]) {
+		im.setTranslation(vector3df(matManager.vFields[68].Pos.X - (matManager.vFields[68].Pos.X - matManager.vFields[69].Pos.X)/2,
+			matManager.vFields[68].Pos.Y - (matManager.vFields[68].Pos.Y - matManager.vFields[71].Pos.Y)/2, dField.deck[1].size() * 0.01f + 0.02f));
+		driver->setTransform(irr::video::ETS_WORLD, im);
+		driver->drawVertexPrimitiveList(matManager.vActivate, 4, matManager.iRectangle, 2);
+	}
+	if(dField.grave_act[0]) {
 		im.setTranslation(vector3df(matManager.vFields[4].Pos.X - (matManager.vFields[4].Pos.X - matManager.vFields[5].Pos.X)/2,
 			matManager.vFields[4].Pos.Y - (matManager.vFields[4].Pos.Y - matManager.vFields[6].Pos.Y)/2, dField.grave[0].size() * 0.01f + 0.02f));
 		driver->setTransform(irr::video::ETS_WORLD, im);
 		driver->drawVertexPrimitiveList(matManager.vActivate, 4, matManager.iRectangle, 2);
 	}
-	if(dField.remove_act) {
+	if(dField.grave_act[1]) {
+		im.setTranslation(vector3df(matManager.vFields[72].Pos.X - (matManager.vFields[72].Pos.X - matManager.vFields[73].Pos.X)/2,
+			matManager.vFields[72].Pos.Y - (matManager.vFields[72].Pos.Y - matManager.vFields[74].Pos.Y)/2, dField.grave[1].size() * 0.01f + 0.02f));
+		driver->setTransform(irr::video::ETS_WORLD, im);
+		driver->drawVertexPrimitiveList(matManager.vActivate, 4, matManager.iRectangle, 2);
+	}
+	if(dField.remove_act[0]) {
 		im.setTranslation(vector3df(matManager.vFields[12].Pos.X - (matManager.vFields[12].Pos.X - matManager.vFields[13].Pos.X)/2,
 			matManager.vFields[12].Pos.Y - (matManager.vFields[12].Pos.Y - matManager.vFields[14].Pos.Y)/2, dField.remove[0].size() * 0.01f + 0.02f));
 		driver->setTransform(irr::video::ETS_WORLD, im);
 		driver->drawVertexPrimitiveList(matManager.vActivate, 4, matManager.iRectangle, 2);
 	}
-	if(dField.extra_act) {
+	if(dField.remove_act[1]) {
+		im.setTranslation(vector3df(matManager.vFields[80].Pos.X - (matManager.vFields[80].Pos.X - matManager.vFields[81].Pos.X)/2,
+			matManager.vFields[80].Pos.Y - (matManager.vFields[80].Pos.Y - matManager.vFields[82].Pos.Y)/2, dField.remove[1].size() * 0.01f + 0.02f));
+		driver->setTransform(irr::video::ETS_WORLD, im);
+		driver->drawVertexPrimitiveList(matManager.vActivate, 4, matManager.iRectangle, 2);
+	}
+	if(dField.extra_act[0]) {
 		im.setTranslation(vector3df(matManager.vFields[8].Pos.X - (matManager.vFields[8].Pos.X - matManager.vFields[9].Pos.X)/2,
 			matManager.vFields[8].Pos.Y - (matManager.vFields[8].Pos.Y - matManager.vFields[10].Pos.Y)/2, dField.extra[0].size() * 0.01f + 0.02f));
+		driver->setTransform(irr::video::ETS_WORLD, im);
+		driver->drawVertexPrimitiveList(matManager.vActivate, 4, matManager.iRectangle, 2);
+	}
+	if(dField.extra_act[1]) {
+		im.setTranslation(vector3df(matManager.vFields[76].Pos.X - (matManager.vFields[76].Pos.X - matManager.vFields[77].Pos.X)/2,
+			matManager.vFields[76].Pos.Y - (matManager.vFields[76].Pos.Y - matManager.vFields[78].Pos.Y)/2, dField.extra[1].size() * 0.01f + 0.02f));
 		driver->setTransform(irr::video::ETS_WORLD, im);
 		driver->drawVertexPrimitiveList(matManager.vActivate, 4, matManager.iRectangle, 2);
 	}

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -915,9 +915,9 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 			mainGame->dField.activatable_descs.push_back(desc);
 			pcard->cmdFlag |= COMMAND_ACTIVATE;
 			if (pcard->location == LOCATION_GRAVE)
-				mainGame->dField.grave_act = true;
+				mainGame->dField.grave_act[pcard->controler] = true;
 			if (pcard->location == LOCATION_REMOVED)
-				mainGame->dField.remove_act = true;
+				mainGame->dField.remove_act[pcard->controler] = true;
 		}
 		mainGame->dField.attackable_cards.clear();
 		count = BufferIO::ReadInt8(pbuf);
@@ -972,14 +972,14 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 			pcard->cmdFlag |= COMMAND_SPSUMMON;
 			if (pcard->location == LOCATION_DECK) {
 				pcard->SetCode(code);
-				mainGame->dField.deck_act = true;
+				mainGame->dField.deck_act[pcard->controler] = true;
 			}
 			if (pcard->location == LOCATION_GRAVE)
-				mainGame->dField.grave_act = true;
+				mainGame->dField.grave_act[pcard->controler] = true;
 			if (pcard->location == LOCATION_REMOVED)
-				mainGame->dField.remove_act = true;
+				mainGame->dField.remove_act[pcard->controler] = true;
 			if (pcard->location == LOCATION_EXTRA)
-				mainGame->dField.extra_act = true;
+				mainGame->dField.extra_act[pcard->controler] = true;
 			if (pcard->location == LOCATION_SZONE && pcard->sequence == 6)
 				mainGame->dField.pzone_act[pcard->controler] = true;
 		}
@@ -1030,9 +1030,9 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 			mainGame->dField.activatable_descs.push_back(desc);
 			pcard->cmdFlag |= COMMAND_ACTIVATE;
 			if (pcard->location == LOCATION_GRAVE)
-				mainGame->dField.grave_act = true;
+				mainGame->dField.grave_act[pcard->controler] = true;
 			if (pcard->location == LOCATION_REMOVED)
-				mainGame->dField.remove_act = true;
+				mainGame->dField.remove_act[pcard->controler] = true;
 		}
 		if(BufferIO::ReadInt8(pbuf)) {
 			mainGame->btnBP->setVisible(true);
@@ -1180,9 +1180,9 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 			pcard->is_selected = false;
 			pcard->cmdFlag |= COMMAND_ACTIVATE;
 			if(l == LOCATION_GRAVE)
-				mainGame->dField.grave_act = true;
+				mainGame->dField.grave_act[pcard->controler] = true;
 			if(l == LOCATION_REMOVED)
-				mainGame->dField.remove_act = true;
+				mainGame->dField.remove_act[pcard->controler] = true;
 			if(l & 0xc1)
 				panelmode = true;
 		}


### PR DESCRIPTION
It is possible to "activate" opponent's cards.
For example, if one uses opponent's Rescue Rabbit, the operation that destroy monsters at end phase is needed to "activated" manually sometimes but the act hint is not on the opponent's LOCATION_REMOVE.