### PR TITLE
Update c75141056.lua

### DIFF
--- a/script/c75141056.lua
+++ b/script/c75141056.lua
@@ -9,22 +9,27 @@ function c75141056.initial_effect(c)
 	e1:SetOperation(c75141056.activate)
 	c:RegisterEffect(e1)
 end
-function c75141056.cfilter(c)
-	return c:IsSetCard(0x3008) and c:IsAbleToGrave()
+function c75141056.tgfilter(c)
+	return c:IsFaceup() and Duel.GetMatchingGroup(c75141056.cfilter,tp,LOCATION_DECK,0,nil,c:GetCode()):FilterCount(Card.IsAbleToGrave,nil)>0
+end
+function c75141056.cfilter(c,code)
+	return c:IsSetCard(0x3008) and c:GetCode()~=code
 end
 function c75141056.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingMatchingCard(c75141056.cfilter,tp,LOCATION_DECK,0,1,nil)
-		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(c75141056.tgfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SelectTarget(tp,c75141056.tgfilter,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function c75141056.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-		local g=Duel.SelectMatchingCard(tp,c75141056.cfilter,tp,LOCATION_DECK,0,1,1,nil)
-		if g:GetCount()>0 then
+		local g=Duel.GetMatchingGroup(c75141056.cfilter,tp,LOCATION_DECK,0,nil,tc:GetCode())
+		if g:GetCount()~=0 then
+			g=g:Filter(Card.IsAbleToGrave,nil)
+			if g:GetCount()==0 then return end
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g=g:Select(tp,1,1,nil)
 			Duel.SendtoGrave(g,REASON_EFFECT)
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)
@@ -32,6 +37,11 @@ function c75141056.activate(e,tp,eg,ep,ev,re,r,rp)
 			e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+RESET_END)
 			e1:SetValue(g:GetFirst():GetCode())
 			tc:RegisterEffect(e1)
+		else
+			local cg=Duel.GetFieldGroup(tp,LOCATION_DECK,0)
+			Duel.ConfirmCards(1-tp,cg)
+			Duel.ConfirmCards(tp,cg)
+			Duel.ShuffleDeck(tp)
 		end
 	end
 end


### PR DESCRIPTION
英雄假面并不能把同一个怪兽反复变成同一个卡名-。-此外，也不能把已经是某个卡名的变成相同的卡名。

Ｑ：《Ｅ・ＨＥＲＯ ネオス》のみがフィールドにいる時、このカードで《Ｅ・ＨＥＲＯ ネオス》を墓地に送れますか？
Ａ：いいえ、墓地に送れません。（14/01/18)
Q：场上只有「元素英雄 新宇侠」的场合，这张卡能不能把「元素英雄 新宇侠」送去墓地？（能不能用这张卡的效果把「元素英雄 新宇侠」重命名为「元素英雄 新宇侠」？）
A：不能。