### PR TITLE
Negate Pendulum Summon Bug Fix

### DIFF
--- a/ocgcore/card.cpp
+++ b/ocgcore/card.cpp
@@ -2092,7 +2092,7 @@ int32 card::is_setable_szone(uint8 playerid, uint8 ignore_fd) {
 	return TRUE;
 }
 int32 card::is_affect_by_effect(effect* peffect) {
-	if(is_status(STATUS_SUMMONING))
+	if(!(!peffect || (peffect->flag & EFFECT_FLAG_IGNORE_RANGE)) & is_status(STATUS_SUMMONING))
 		return FALSE;
 	if(!peffect || (peffect->flag & EFFECT_FLAG_IGNORE_IMMUNE))
 		return TRUE;


### PR DESCRIPTION
自己左右灵摆区域有「闪光之骑士」、「傅科魔炮石」。现在发动魔法卡「魔力隔壁」，选择“这个回合自己的魔法使族怪兽的特殊召唤不可无效”，并对「黑魔术少女」进行灵摆召唤。对方依然可以对应此灵摆召唤发动「神之警告」来无效「黑魔术少女」的灵摆召唤，一如其根本没有受到「魔力隔壁」的影响。同样的情况，解放两只「黑魔术少女」来特殊召唤「黑魔法神官」，对方却反而不能发动「神之警告」了。

通过此修改就可以修复此偏门的BUG，并且带来的变化是最小幅度的。