### PR TITLE
fix Triangle Ecstasy Spark

### DIFF
--- a/script/c12181376.lua
+++ b/script/c12181376.lua
@@ -16,10 +16,11 @@ function c12181376.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c12181376.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 end
 function c12181376.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
 	local g=Duel.GetMatchingGroup(c12181376.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	local tc=g:GetFirst()
 	while tc do
-		local e1=Effect.CreateEffect(e:GetHandler())
+		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
 		e1:SetValue(2700)
@@ -27,14 +28,13 @@ function c12181376.activate(e,tp,eg,ep,ev,re,r,rp)
 		tc:RegisterEffect(e1)
 		tc=g:GetNext()
 	end
-	local c=e:GetHandler()
-	--cannot trigger
+	--cannot activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_CANNOT_TRIGGER)
-	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
-	e1:SetTargetRange(0,LOCATION_SZONE)
-	e1:SetTarget(c12181376.distg)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e1:SetTargetRange(0,1)
+	e1:SetValue(c12181376.aclimit)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
 	--disable
@@ -53,6 +53,9 @@ function c12181376.activate(e,tp,eg,ep,ev,re,r,rp)
 	e3:SetTarget(c12181376.distg)
 	e3:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e3,tp)
+end
+function c12181376.aclimit(e,re,tp)
+	return re:IsActiveType(TYPE_TRAP)
 end
 function c12181376.distg(e,c)
 	return c:IsType(TYPE_TRAP)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6267&keyword=&tag=0
 Q.自分の発動した「トライアングル・X・スパーク」の『このターンのエンドフェイズまで、「ハーピィ・レディ三姉妹」の攻撃力は２７００になり、相手プレイヤーは罠カードを発動できず、相手フィールド上の罠カードの効果は無効になる』効果が適用されているターン、相手は「死霊の巣」等の魔法＆罠ゾーンに既に表側表示で存在している永続罠カードの効果や、墓地に存在する「ブレイクスルー・スキル」の効果を発動する事はできますか？
A.自分の発動した「トライアングル・X・スパーク」の効果が適用されているターン、相手は罠カードのカードの発動を行う事はできませんが、罠カードの効果の発動を行う事はできます。

魔法＆罠ゾーンに既に表側表示で存在している「死霊の巣」等の永続罠カードの場合、効果の発動は行えますが、その効果は「トライアングル・X・スパーク」の『相手フィールド上の罠カードの効果は無効になる』効果によって無効になります。

また、墓地にて発動する「ブレイクスルー・スキル」等の効果の場合、効果の発動は行えます。また、その効果も通常通り適用される事になります。 