### PR TITLE
fix Soaring Eagle Above the Searing Land

### DIFF
--- a/script/c26381750.lua
+++ b/script/c26381750.lua
@@ -21,6 +21,7 @@ function c26381750.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end
 function c26381750.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetMatchingGroup(Card.IsSetCard,tp,LOCATION_GRAVE,0,nil,0x39):GetClassCount(Card.GetCode)<3 then return end
 	local c=e:GetHandler()
 	if c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)~=0 then
 		local e1=Effect.CreateEffect(c)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6389&keyword=&tag=0
 Q.「紅蓮地帯を飛ぶ鷹」の『このカードがシンクロモンスターのシンクロ召喚に使用され墓地へ送られた場合に自分の墓地の「ラヴァル」と名のついたモンスターが３種類以上の場合、このカードを墓地から特殊召喚できる』効果の発動にチェーンして、相手が「D.D.クロウ」の効果を発動し、効果処理時に自分の墓地に存在する「ラヴァル」と名のついたモンスターが2種類以下になる場合、効果処理はどうなりますか？
A.「紅蓮地帯を飛ぶ鷹」の効果処理時に自分の墓地に存在する「ラヴァル」と名のついたモンスターが2種類以下になる場合には、自身を特殊召喚する効果は適用されません。（「紅蓮地帯を飛ぶ鷹」は墓地に残ります。） 