### PR TITLE
Read Resource From Expansions

### DIFF
--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -1,4 +1,5 @@
 #include "image_manager.h"
+#include <io.h>
 
 namespace ygo {
 
@@ -57,6 +58,27 @@ irr::video::ITexture* ImageManager::GetTexture(int code) {
 		char file[256];
 		sprintf(file, "pics/%d.jpg", code);
 		irr::video::ITexture* img = driver->getTexture(file);
+		//expansions
+		if(img == NULL) {
+			_finddata_t fdata;
+			long fhandle;
+			char fpath[1000];
+			char file2[256];
+			fhandle = _findfirst("expansions\\*.cdb", &fdata);
+			if(fhandle != -1) {
+				strcpy(fpath, fdata.name);
+				fpath[strlen(fpath)-4]='\0';
+				sprintf(file2, "./expansions/%s/%s",fpath,file);
+				img = driver->getTexture(file2);
+				while(_findnext(fhandle, &fdata) != -1 && img == NULL) {
+					strcpy(fpath, fdata.name);
+					fpath[strlen(fpath)-4]='\0';
+					sprintf(file2, "./expansions/%s/%s",fpath,file);
+					img = driver->getTexture(file2);
+				}
+				_findclose(fhandle);
+			}
+		}
 		if(img == NULL) {
 			tMap[code] = NULL;
 			return GetTextureThumb(code);
@@ -78,6 +100,27 @@ irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 		char file[256];
 		sprintf(file, "pics/thumbnail/%d.jpg", code);
 		irr::video::ITexture* img = driver->getTexture(file);
+		//expansions
+		if(img == NULL) {
+			_finddata_t fdata;
+			long fhandle;
+			char fpath[1000];
+			char file2[256];
+			fhandle = _findfirst("expansions\\*.cdb", &fdata);
+			if(fhandle != -1) {
+				strcpy(fpath, fdata.name);
+				fpath[strlen(fpath)-4]='\0';
+				sprintf(file2, "./expansions/%s/%s",fpath,file);
+				img = driver->getTexture(file2);
+				while(_findnext(fhandle, &fdata) != -1 && img == NULL) {
+					strcpy(fpath, fdata.name);
+					fpath[strlen(fpath)-4]='\0';
+					sprintf(file2, "./expansions/%s/%s",fpath,file);
+					img = driver->getTexture(file2);
+				}
+				_findclose(fhandle);
+			}
+		}
 		if(img == NULL) {
 			tThumb[code] = NULL;
 			return tUnknown;

--- a/ocgcore/interpreter.cpp
+++ b/ocgcore/interpreter.cpp
@@ -678,13 +678,23 @@ int32 interpreter::load_card_script(uint32 code) {
 		lua_rawset(current_state, -3);
 		//load extra scripts
 		sprintf(script_name, "./script/c%d.lua", code);
+		if (load_script(script_name)) {
+			return OPERATION_SUCCESS;
+		}
 		//expansions
-		if (!load_script(script_name)) {
-			_finddata_t fdata;
-			long fhandle;
-			char fpath[1000];
-			fhandle = _findfirst("expansions\\*.cdb", &fdata);
-			if(fhandle != -1) {
+		_finddata_t fdata;
+		long fhandle;
+		char fpath[1000];
+		fhandle = _findfirst("expansions\\*.cdb", &fdata);
+		if(fhandle != -1) {
+			strcpy(fpath, fdata.name);
+			fpath[strlen(fpath)-4]='\0';
+			sprintf(script_name, "./expansions/%s/script/c%d.lua",fpath,code);
+			if (load_script(script_name)) {
+				_findclose(fhandle);
+				return OPERATION_SUCCESS;
+			}
+			while(_findnext(fhandle, &fdata) != -1) {
 				strcpy(fpath, fdata.name);
 				fpath[strlen(fpath)-4]='\0';
 				sprintf(script_name, "./expansions/%s/script/c%d.lua",fpath,code);
@@ -692,19 +702,10 @@ int32 interpreter::load_card_script(uint32 code) {
 					_findclose(fhandle);
 					return OPERATION_SUCCESS;
 				}
-				while(_findnext(fhandle, &fdata) != -1) {
-					strcpy(fpath, fdata.name);
-					fpath[strlen(fpath)-4]='\0';
-					sprintf(script_name, "./expansions/%s/script/c%d.lua",fpath,code);
-					if (load_script(script_name)) {
-						_findclose(fhandle);
-						return OPERATION_SUCCESS;
-					}
-				}
-				_findclose(fhandle);
 			}
-			return OPERATION_FAIL;
+			_findclose(fhandle);
 		}
+		return OPERATION_FAIL;
 	}
 	return OPERATION_SUCCESS;
 }


### PR DESCRIPTION
此修改允许根据expansions中的cdb而读取expansions中的资源。

例：
若存在expansions/1.cdb，则可以读取expansions/1/pics/的图片以及expansions/1/script/的脚本。若pics和script本来就有所需资源，则无视expansions的资源。
此外，也允许读取expansions/1.lua，其优先度次于constant.lua和utility.lua。

仅当存在expansions/1.cdb才会去找expansions/1/pics/等。若没有1.cdb则1/pics/无效。