### PR TITLE
Fix for STATUS_PROC_COMPLETE

### DIFF
--- a/ocgcore/libduel.cpp
+++ b/ocgcore/libduel.cpp
@@ -1282,12 +1282,16 @@ int32 scriptlib::duel_disable_summon(lua_State *L) {
 	if(pcard) {
 		pcard->set_status(STATUS_SUMMONING, FALSE);
 		pcard->set_status(STATUS_SUMMON_DISABLED, TRUE);
-		pcard->set_status(STATUS_PROC_COMPLETE, FALSE);
+		if (!((pcard->summon_info) & 0xff00ffff) == SUMMON_TYPE_PENDULUM){
+			pcard->set_status(STATUS_PROC_COMPLETE, FALSE);
+		}
 	} else {
 		for(auto cit = pgroup->container.begin(); cit != pgroup->container.end(); ++cit) {
 			(*cit)->set_status(STATUS_SUMMONING, FALSE);
 			(*cit)->set_status(STATUS_SUMMON_DISABLED, TRUE);
-			(*cit)->set_status(STATUS_PROC_COMPLETE, FALSE);
+			if (!(((*cit)->summon_info) & 0xff00ffff) == SUMMON_TYPE_PENDULUM){
+				(*cit)->set_status(STATUS_PROC_COMPLETE, FALSE);
+			}
 		}
 	}
 	return 0;

--- a/ocgcore/libduel.cpp
+++ b/ocgcore/libduel.cpp
@@ -1282,14 +1282,14 @@ int32 scriptlib::duel_disable_summon(lua_State *L) {
 	if(pcard) {
 		pcard->set_status(STATUS_SUMMONING, FALSE);
 		pcard->set_status(STATUS_SUMMON_DISABLED, TRUE);
-		if (!((pcard->summon_info) & 0xff00ffff) == SUMMON_TYPE_PENDULUM){
+		if (!(((pcard->summon_info) & 0xff00ffff) == SUMMON_TYPE_PENDULUM)){
 			pcard->set_status(STATUS_PROC_COMPLETE, FALSE);
 		}
 	} else {
 		for(auto cit = pgroup->container.begin(); cit != pgroup->container.end(); ++cit) {
 			(*cit)->set_status(STATUS_SUMMONING, FALSE);
 			(*cit)->set_status(STATUS_SUMMON_DISABLED, TRUE);
-			if (!(((*cit)->summon_info) & 0xff00ffff) == SUMMON_TYPE_PENDULUM){
+			if (!((((*cit)->summon_info) & 0xff00ffff) == SUMMON_TYPE_PENDULUM)){
 				(*cit)->set_status(STATUS_PROC_COMPLETE, FALSE);
 			}
 		}


### PR DESCRIPTION
Q. 「覇王黒竜オッドアイズ·リベリオン·ドラゴン」のペンデュラム召喚が「神の警告」の効果により無効化されました。その後、「死者蘇生」の効果で「覇王黒竜オッドアイズ·リベリオン·ドラゴン」を墓地から蘇生することができますか？ 
A. 一度正規の手順でエクシーズ召喚され、その後表側表示でエクストラデッキに加わってからのペンデュラム召喚が無効になった「覇王黒竜オッドアイズ・リベリオン・ドラゴン」であれば、墓地から「死者蘇生」の効果で特殊召喚できます。 
——————————————————————————————
Q：「霸王黑龙 异色眼叛逆龙」的灵摆召唤被「神之警告」的效果无效化了。那之后，可不可以用「死者苏生」的效果把「霸王黑龙 异色眼叛逆龙」从墓地苏生？
A：一度以正规手续超量召唤，再以表侧表示加入额外卡组并进行被无效化的灵摆召唤的「霸王黑龙 异色眼叛逆龙」，可以用「死者苏生」的效果从墓地特殊召唤。

目前这个文件对于无效召唤，是不分青红皂白一律将其正规手续完成的状态拔掉的，所以现在霸王黑龙的灵摆召唤被无效后，会变成不能从墓地特殊召唤的状态。目前先用这种简单的判断召唤方式的办法。