### PR TITLE
Fix for Absorb Monster as Equip

### DIFF
--- a/script/c26211048.lua
+++ b/script/c26211048.lua
@@ -33,7 +33,7 @@ end
 function c26211048.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) then return end
+	if not tc:IsRelateToEffect(e) or not tc:IsLocation(LOCATION_GRAVE+LOCATION_MZONE) then return end
 	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 or c:IsFacedown() or not c:IsRelateToEffect(e) then
 		if tc:IsLocation(LOCATION_MZONE) then Duel.SendtoGrave(tc,REASON_EFFECT) end
 		return

--- a/script/c31930787.lua
+++ b/script/c31930787.lua
@@ -86,7 +86,7 @@ end
 function c31930787.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			local atk=tc:GetTextAttack()
 			if atk<0 then atk=0 end

--- a/script/c3897065.lua
+++ b/script/c3897065.lua
@@ -50,7 +50,7 @@ end
 function c3897065.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and not tc:IsRace(RACE_MACHINE) and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and not tc:IsRace(RACE_MACHINE) and tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			if not Duel.Equip(tp,tc,c,false) then return end
 			--equip limit

--- a/script/c39987164.lua
+++ b/script/c39987164.lua
@@ -47,7 +47,7 @@ end
 function c39987164.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsAttackPos() and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsAttackPos() and tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			if not Duel.Equip(tp,tc,c,false) then return end
 			--Add Equip limit

--- a/script/c4252828.lua
+++ b/script/c4252828.lua
@@ -45,7 +45,7 @@ end
 function c4252828.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			if not Duel.Equip(tp,tc,c,false) then return end
 			--Add Equip limit

--- a/script/c4545683.lua
+++ b/script/c4545683.lua
@@ -91,7 +91,7 @@ end
 function c4545683.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			local atk=tc:GetTextAttack()
 			if atk<0 then atk=0 end

--- a/script/c57784563.lua
+++ b/script/c57784563.lua
@@ -44,7 +44,7 @@ end
 function c57784563.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			if not Duel.Equip(tp,tc,c,false) then return end
 			--Add Equip limit

--- a/script/c63465535.lua
+++ b/script/c63465535.lua
@@ -67,7 +67,7 @@ end
 function c63465535.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			if not Duel.Equip(tp,tc,c,false) then return end
 			--Add Equip limit

--- a/script/c63468625.lua
+++ b/script/c63468625.lua
@@ -73,7 +73,7 @@ end
 function c63468625.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			local atk=tc:GetTextAttack()
 			if atk<0 then atk=0 end

--- a/script/c64631466.lua
+++ b/script/c64631466.lua
@@ -43,7 +43,7 @@ end
 function c64631466.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			local atk=tc:GetTextAttack()
 			local def=tc:GetTextDefence()

--- a/script/c68140974.lua
+++ b/script/c68140974.lua
@@ -90,7 +90,7 @@ end
 function c68140974.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			local atk=tc:GetTextAttack()
 			if atk<0 then atk=0 end


### PR DESCRIPTION
Q. 「影依の原核」を対象に、「サクリファイス」の効果を発動し、相手はチェーン２に「月の書」の効果で「影依の原核」を再びセットしました。この場合、「サクリファイス」の効果はどのような処理になりますか？ 
A. ご質問の状況の場合、チェーン2の「月の書」の効果で魔法＆罠ゾーンにセットされた「影依の原核」を、「サクリファイス」は装備できず処理を終えます。 
——————————————————————————————
Q：以「影依的原核」为对象发动「纳祭之魔」的效果，对方在连锁2用「月之书」的效果把「影依的原核」给盖了回去。这个场合，「纳祭之魔」的效果如何处理？
A：这个场合，因连锁2「月之书」的效果而覆盖在魔法&陷阱区域的「影依的原核」不会被「纳祭之魔」所装备，就这样结束处理。

现在程序里模拟同样的情况，其结果是以里侧守备表示放到对方的魔法区的陷阱怪兽，会就这样以在对方魔法区里侧表示的情况成为纳祭之魔的装备卡。不仅如此，下个回合那张被覆盖的陷阱怪兽还能够发动，然后通过特殊召唤自己解除装备状态。
看起来需要判断一下效果处理时对象怪兽还在不在怪兽区。

顺便一提，「吸血鬼妖女」这张卡早已判断是不是在怪兽区了。