### PR TITLE
Maintain cross-platform compatibility

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -8,9 +8,10 @@
 #include "duelclient.h"
 #include "netserver.h"
 #include "single_mode.h"
-#include <io.h>
 
-#ifndef WIN32
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <sys/types.h>
 #include <dirent.h>
 #endif
@@ -22,9 +23,12 @@ namespace ygo {
 Game* mainGame;
 
 bool Game::Initialize() {
+#ifdef _WIN32
 	_finddata_t fdata;
 	long fhandle;
 	char fpath[1000] = "./expansions/";
+	char fpath[1000] = "expansions\\";
+#endif
 	srand(time(0));
 	LoadConfig();
 	irr::SIrrlichtCreationParameters params = irr::SIrrlichtCreationParameters();
@@ -60,6 +64,7 @@ bool Game::Initialize() {
 		return false;
 	if(!dataManager.LoadStrings("strings.conf"))
 		return false;
+#ifdef _WIN32
 	fhandle = _findfirst("./expansions/*.cdb", &fdata);
 	if(fhandle != -1) {
 		strcat(fpath, fdata.name);
@@ -71,6 +76,7 @@ bool Game::Initialize() {
 		}
 		_findclose(fhandle);
 	}
+#endif
 	env = device->getGUIEnvironment();
 	numFont = irr::gui::CGUITTFont::createTTFont(env, gameConf.numfont, 16);
 	adFont = irr::gui::CGUITTFont::createTTFont(env, gameConf.numfont, 12);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -27,7 +27,6 @@ bool Game::Initialize() {
 	_finddata_t fdata;
 	long fhandle;
 	char fpath[1000] = "./expansions/";
-	char fpath[1000] = "expansions\\";
 #endif
 	srand(time(0));
 	LoadConfig();
@@ -76,6 +75,25 @@ bool Game::Initialize() {
 		}
 		_findclose(fhandle);
 	}
+#else
+        DIR * dir;
+        struct dirent * dirp;
+        const char *foldername = "./expansions/";
+        if((dir = opendir(foldername)) != NULL) {
+	        while((dirp = readdir(dir)) != NULL) {
+		        size_t len = strlen(dirp->d_name);
+		        if(len < 5 || strcasecmp(dirp->d_name + len - 4, ".cdb") != 0)
+			        continue;
+                        char *filepath = (char *)malloc(sizeof(char)*(len + strlen(foldername)));
+                        strncpy(filepath, foldername, strlen(foldername)+1);
+                        strncat(filepath, dirp->d_name, len);
+                        std::cout << "Found file " << filepath << std::endl;
+                        if (!dataManager.LoadDB(filepath))
+	                        std::cout << "Error loading file" << std::endl;
+                        free(filepath);
+	        }
+	        closedir(dir);
+        }
 #endif
 	env = device->getGUIEnvironment();
 	numFont = irr::gui::CGUITTFont::createTTFont(env, gameConf.numfont, 16);


### PR DESCRIPTION
io.h include provides platform specific directory functions for windows. To maintain compatibility with Linux distros, this code has been moved to ifdefs and replacement code using dirent provided.

Fixes #1399 