### PR TITLE
Update c85087012.lua

### DIFF
--- a/script/c83531441.lua
+++ b/script/c83531441.lua
@@ -44,8 +44,8 @@ function c83531441.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	else
 		local ac=0
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(83531441,2))
-		if ct==2 then ac=Duel.AnnounceNumber(tp,1,2)
-		else ac=Duel.AnnounceNumber(tp,1,2,3) end
+		if ct==2 then ac=Duel.AnnounceNumber(tp,2,1)
+		else ac=Duel.AnnounceNumber(tp,3,2,1) end
 		Duel.DiscardDeck(tp,ac,REASON_COST)
 		e:SetLabel(ac)
 	end

--- a/script/c85087012.lua
+++ b/script/c85087012.lua
@@ -30,8 +30,8 @@ function c85087012.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	else
 		local ac=0
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(85087012,2))
-		if ct==2 then ac=Duel.AnnounceNumber(tp,1,2)
-		else ac=Duel.AnnounceNumber(tp,1,2,3) end
+		if ct==2 then ac=Duel.AnnounceNumber(tp,2,1)
+		else ac=Duel.AnnounceNumber(tp,3,2,1) end
 		Duel.DiscardDeck(tp,ac,REASON_COST)
 		e:SetLabel(ac)
 	end


### PR DESCRIPTION
玩家既然要堆墓，多数情况当然是希望堆越多越好。我认为这种可以把数字以从大到小的顺序排列，这样玩家可以不需要点击下拉菜单也可直接选出目前可以堆墓的最大卡数，可以省去一个操作步骤。