### PR TITLE
Update c45627618.lua

### DIFF
--- a/script/c45627618.lua
+++ b/script/c45627618.lua
@@ -99,6 +99,7 @@ function c45627618.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c45627618.penop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local lsc=Duel.GetFieldCard(tp,LOCATION_SZONE,6)
 	local rsc=Duel.GetFieldCard(tp,LOCATION_SZONE,7)
 	local g=Group.FromCards(lsc,rsc)


### PR DESCRIPTION
霸王黑龙用两个普通的L7龙族叠放吃奈落，并发动进灵摆区的效果。这时，在C2用异次元埋葬把被除外的霸王黑龙送进墓地。那之后霸王黑龙还能从墓地继续处理效果，这是不正确的。