### PR TITLE
Update Many Synchro Cards

### DIFF
--- a/script/c17377751.lua
+++ b/script/c17377751.lua
@@ -9,6 +9,7 @@ function c17377751.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetRange(LOCATION_EXTRA)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(c17377751.sumlimit)
 	c:RegisterEffect(e1)
 	--Special Summon
 	local e2=Effect.CreateEffect(c)
@@ -20,6 +21,9 @@ function c17377751.initial_effect(c)
 	e2:SetTarget(c17377751.sptg)
 	e2:SetOperation(c17377751.spop)
 	c:RegisterEffect(e2)
+end
+function c17377751.sumlimit(e,se,sp,st)
+	return bit.band(st,SUMMON_TYPE_SYNCHRO)==SUMMON_TYPE_SYNCHRO
 end
 function c17377751.spcon(e,tp,eg,ep,ev,re,r,rp,chk)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SYNCHRO

--- a/script/c26268488.lua
+++ b/script/c26268488.lua
@@ -8,6 +8,7 @@ function c26268488.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(c26268488.sumlimit)
 	c:RegisterEffect(e1)
 	--indes
 	local e2=Effect.CreateEffect(c)
@@ -43,6 +44,9 @@ function c26268488.initial_effect(c)
 	e4:SetTarget(c26268488.sptg)
 	e4:SetOperation(c26268488.spop)
 	c:RegisterEffect(e4)
+end
+function c26268488.sumlimit(e,se,sp,st)
+	return bit.band(st,SUMMON_TYPE_SYNCHRO)==SUMMON_TYPE_SYNCHRO
 end
 function c26268488.repfilter(c,tp)
 	return c:IsControler(tp) and c:IsOnField() and c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:GetFlagEffect(26268488)==0

--- a/script/c35952884.lua
+++ b/script/c35952884.lua
@@ -8,6 +8,7 @@ function c35952884.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(c35952884.sumlimit)
 	c:RegisterEffect(e1)
 	--multi attack
 	local e2=Effect.CreateEffect(c)
@@ -52,6 +53,9 @@ function c35952884.initial_effect(c)
 	local e6=e4:Clone()
 	e6:SetCode(EVENT_TO_DECK)
 	c:RegisterEffect(e6)
+end
+function c35952884.sumlimit(e,se,sp,st)
+	return bit.band(st,SUMMON_TYPE_SYNCHRO)==SUMMON_TYPE_SYNCHRO
 end
 function c35952884.mfilter(c)
 	return not c:IsType(TYPE_TUNER)

--- a/script/c39402797.lua
+++ b/script/c39402797.lua
@@ -8,6 +8,7 @@ function c39402797.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(c39402797.sumlimit)
 	c:RegisterEffect(e1)
 	--destroy
 	local e2=Effect.CreateEffect(c)
@@ -20,6 +21,9 @@ function c39402797.initial_effect(c)
 	e2:SetTarget(c39402797.destg)
 	e2:SetOperation(c39402797.desop)
 	c:RegisterEffect(e2)
+end
+function c39402797.sumlimit(e,se,sp,st)
+	return bit.band(st,SUMMON_TYPE_SYNCHRO)==SUMMON_TYPE_SYNCHRO
 end
 function c39402797.descon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SYNCHRO

--- a/script/c41517789.lua
+++ b/script/c41517789.lua
@@ -8,6 +8,7 @@ function c41517789.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(c41517789.sumlimit)
 	c:RegisterEffect(e1)
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
@@ -26,6 +27,9 @@ function c41517789.initial_effect(c)
 	e4:SetCode(EVENT_ATTACK_ANNOUNCE)
 	e4:SetOperation(c41517789.atkop)
 	c:RegisterEffect(e4)
+end
+function c17377751.sumlimit(e,se,sp,st)
+	return bit.band(st,SUMMON_TYPE_SYNCHRO)==SUMMON_TYPE_SYNCHRO
 end
 function c41517789.sumsuc(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():GetSummonType()~=SUMMON_TYPE_SYNCHRO then return end

--- a/script/c89474727.lua
+++ b/script/c89474727.lua
@@ -8,6 +8,7 @@ function c89474727.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetValue(c89474727.sumlimit)
 	c:RegisterEffect(e1)
 	--immune
 	local e2=Effect.CreateEffect(c)
@@ -30,6 +31,9 @@ function c89474727.initial_effect(c)
 	e3:SetTarget(c89474727.sptg)
 	e3:SetOperation(c89474727.spop)
 	c:RegisterEffect(e3)
+end
+function c89474727.sumlimit(e,se,sp,st)
+	return bit.band(st,SUMMON_TYPE_SYNCHRO)==SUMMON_TYPE_SYNCHRO
 end
 function c89474727.cfilter(c)
 	return c:IsType(TYPE_SYNCHRO) and c:IsAbleToRemoveAsCost()

--- a/script/c97836203.lua
+++ b/script/c97836203.lua
@@ -8,7 +8,7 @@ function c97836203.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e1:SetValue(aux.FALSE)
+	e1:SetValue(c97836203.sumlimit)
 	c:RegisterEffect(e1)
 	--Negate summon
 	local e2=Effect.CreateEffect(c)
@@ -41,6 +41,9 @@ function c97836203.initial_effect(c)
 	e5:SetTarget(c97836203.sptg)
 	e5:SetOperation(c97836203.spop)
 	c:RegisterEffect(e5)
+end
+function c97836203.sumlimit(e,se,sp,st)
+	return bit.band(st,SUMMON_TYPE_SYNCHRO)==SUMMON_TYPE_SYNCHRO
 end
 function c97836203.discon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentChain()==0


### PR DESCRIPTION
现在已经有“当作同调召唤特殊召唤”的效果了。这些具有“用同调召唤才能特殊召唤”的召唤限制的卡也应该增加一个value，免得出现问题。