### PR TITLE
fix Arcana Force XXI - The World

### DIFF
--- a/script/c23846921.lua
+++ b/script/c23846921.lua
@@ -61,7 +61,8 @@ function c23846921.skipcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and e:GetHandler():GetFlagEffectLabel(36690018)==1
 end
 function c23846921.skipcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGraveAsCost,tp,LOCATION_MZONE,0,2,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGraveAsCost,tp,LOCATION_MZONE,0,2,nil)
+		and c:GetFlagEffect(23846921)==0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToGraveAsCost,tp,LOCATION_MZONE,0,2,2,nil)
 	Duel.SendtoGrave(g,REASON_COST)
@@ -74,6 +75,7 @@ function c23846921.skipop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetTargetRange(0,1)
 	e1:SetReset(RESET_PHASE+PHASE_END+RESET_OPPO_TURN)
 	Duel.RegisterEffect(e1,tp)
+	e:GetHandler():RegisterFlagEffect(23846921,RESET_PHASE+PHASE_END,0,1)
 end
 function c23846921.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep~=tp and e:GetHandler():GetFlagEffectLabel(36690018)==0

--- a/script/c23846921.lua
+++ b/script/c23846921.lua
@@ -62,7 +62,7 @@ function c23846921.skipcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c23846921.skipcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGraveAsCost,tp,LOCATION_MZONE,0,2,nil)
-		and c:GetFlagEffect(23846921)==0 end
+		and e:GetHandler():GetFlagEffect(23846921)==0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToGraveAsCost,tp,LOCATION_MZONE,0,2,2,nil)
 	Duel.SendtoGrave(g,REASON_COST)


### PR DESCRIPTION
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
《アルカナフォースＸＸＩ－ＴＨＥ ＷＯＲＬＤ》の『●表』の効果を使用した後に別の《アルカナフォースＸＸＩ－ＴＨＥ ＷＯＲＬＤ》の『●表』の効果を発動できますか？ 
A. 
自身の『●表』の効果を得ている「アルカナフォースⅩⅩⅠ－THE WORLD」が2体存在する際、エンドフェイズにてまず1体目の「アルカナフォースⅩⅩⅠ－THE WORLD」の効果を適用した時点で『次の相手ターンをスキップする』事になるため、同じエンドフェイズ中にて2体目の「アルカナフォースⅩⅩⅠ－THE WORLD 」の効果を発動する事はできません。 


これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。