### PR TITLE
Update c18511384.lua

### DIFF
--- a/script/c18511384.lua
+++ b/script/c18511384.lua
@@ -14,7 +14,9 @@ function c18511384.filter1(c)
 	return c:IsCode(24094653) and c:IsAbleToHand()
 end
 function c18511384.filter2(c)
-	return bit.band(c:GetReason(),0x40008)==0x40008 and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+	return c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+		and bit.band(c:GetReason(),REASON_MATERIAL+REASON_COST)~=0
+		and bit.band(c:GetReasonCard():GetOriginalType(),TYPE_FUSION)~=0
 end
 function c18511384.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end


### PR DESCRIPTION
Q. 「融合回収」は、「ビーストアイズ・ペンデュラム・ドラゴン」の固有召喚方法『●自分フィールドの上記カードをリリースした場合にエクストラデッキから特殊召喚できる。』の為にリリースしたモンスターを対象とする事ができますか？ 
A. 「ビーストアイズ・ペンデュラム・ドラゴン」を『●』の手順で特殊召喚した際にリリースしたモンスターは、"融合素材"として扱いますので、「融合回収」の効果によって手札に加える事ができます。
————————————————————————————————————————
Q：「融合回收」可以选择被「野兽眼灵摆龙」的●手续而解放的怪兽为对象吗？
A：因为被「野兽眼灵摆龙」的●手续而解放的怪兽是算作融合素材的，所以可以用「融合回收」的效果加入手卡。

根据这个逻辑，这融合回收的所谓“融合使用的融合素材”大概是指“融合怪兽的特殊召唤使用的融合素材”。修改一下原因判定大概就能解决这个问题。