### PR TITLE
fix Mist Valley Apex Avian

### DIFF
--- a/script/c29587993.lua
+++ b/script/c29587993.lua
@@ -33,7 +33,7 @@ function c29587993.distg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c29587993.disop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) then return end
+	if tc:IsFacedown() or not tc:IsRelateToEffect(e) then return end
 	Duel.SendtoHand(tc,nil,REASON_EFFECT)
 	if not tc:IsLocation(LOCATION_HAND) then return end
 	Duel.NegateActivation(ev)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8121
（なお、「ミスト・バレー」と名のついたモンスターを対象として発動した際に、対象のモンスターがフィールドに裏側守備表示で存在しているような場合でも、持ち主の手札に戻す処理も行われません。） 