### PR TITLE
fix Swords of Concealing Light, Book of Eclipse, Ghostrick Scare

### DIFF
--- a/script/c12923641.lua
+++ b/script/c12923641.lua
@@ -9,11 +9,14 @@ function c12923641.initial_effect(c)
 	e1:SetOperation(c12923641.activate)
 	c:RegisterEffect(e1)
 end
+function c12923641.filter(c)
+	return c:IsFaceup() and not c:IsType(TYPE_TOKEN)
+end
 function c12923641.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local c=e:GetHandler()
 	c:SetTurnCounter(0)
-	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
+	local g=Duel.GetMatchingGroup(c35480699.filter,tp,0,LOCATION_MZONE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,g:GetCount(),0,0)
 	--cannot change position
 	local e1=Effect.CreateEffect(c)

--- a/script/c35480699.lua
+++ b/script/c35480699.lua
@@ -10,16 +10,19 @@ function c35480699.initial_effect(c)
 	e1:SetOperation(c35480699.activate)
 	c:RegisterEffect(e1)
 end
-function c35480699.filter(c)
+function c35480699.filter1(c)
 	return c:IsFaceup() and c:IsCanTurnSet()
 end
 function c35480699.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c35480699.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
-	local g=Duel.GetMatchingGroup(c35480699.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	if chk==0 then return Duel.IsExistingMatchingCard(c35480699.filter1,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c35480699.filter1,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,g:GetCount(),0,0)
 end
+function c35480699.filter2(c)
+	return c:IsFaceup() and not c:IsType(TYPE_TOKEN)
+end
 function c35480699.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local g=Duel.GetMatchingGroup(c35480699.filter2,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	if g:GetCount()>0 then
 		Duel.ChangePosition(g,POS_FACEDOWN_DEFENCE)
 	end

--- a/script/c86516889.lua
+++ b/script/c86516889.lua
@@ -18,16 +18,19 @@ function c86516889.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.SelectTarget(tp,Card.IsFacedown,tp,LOCATION_MZONE,0,1,5,nil)
 	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,g:GetCount(),0,0)
 end
-function c86516889.filter(c,e)
+function c86516889.filter1(c,e)
 	return c:IsFacedown() and c:IsRelateToEffect(e)
 end
+function c86516889.filter2(c)
+	return c:IsFaceup() and not c:IsType(TYPE_TOKEN)
+end
 function c86516889.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c86516889.filter,nil,e)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c86516889.filter1,nil,e)
 	Duel.ChangePosition(g,POS_FACEUP_DEFENCE)
 	local ct=g:FilterCount(Card.IsSetCard,nil,0x8d)
 	if ct>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_POSCHANGE)
-		local sg=Duel.SelectMatchingCard(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,ct,nil)
+		local sg=Duel.SelectMatchingCard(tp,c86516889.filter2,tp,0,LOCATION_MZONE,1,ct,nil)
 		if sg:GetCount()>0 then
 			Duel.HintSelection(sg)
 			Duel.ChangePosition(sg,POS_FACEDOWN_DEFENCE)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7654&keyword=&tag=-1
また、質問の状況のように、モンスタートークンと「ニュート」がモンスターゾーンに表側攻撃表示で存在するような場合、「ニュート」は「皆既日蝕の書」の効果によって裏側守備表示になりますが、モンスタートークンの表示形式は表側攻撃表示のままとなります。

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7988&keyword=&tag=0
モンスタートークンは裏側表示になる事はありませんので、選択したモンスターを表側守備表示にする処理のみを行う事になります。