### PR TITLE
fix Evigishki Levianima

### DIFF
--- a/script/c71203602.lua
+++ b/script/c71203602.lua
@@ -22,6 +22,7 @@ function c71203602.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.ConfirmCards(1-tp,tc)
 	Duel.ShuffleHand(tp)
 	if tc:IsSetCard(0x3a) and tc:IsType(TYPE_MONSTER) then
+		Duel.BreakEffect()
 		local g=Duel.GetFieldGroup(tp,0,LOCATION_HAND)
 		if g:GetCount()>0 then
 			local sg=g:RandomSelect(tp,1)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8761&keyword=&tag=0
Q.相手が、「イビリチュア・リヴァイアニマ」で攻撃宣言を行った際に、『このカードの攻撃宣言時、自分のデッキからカードを１枚ドローし、お互いに確認する。確認したカードが「リチュア」と名のついたモンスターだった場合、相手の手札をランダムに１枚確認する』効果が発動しました。

その効果処理によって相手がカードをドローした際に、自分は「強烈なはたき落とし」を発動する事はできますか？
A.相手の「イビリチュア・リヴァイアニマ」の効果処理によって確認したカードが「リチュア」と名のついたモンスターだった場合には、『相手の手札をランダムに１枚確認する』処理が行われる事になりますので、その場合には、自分は「強烈なはたき落とし」を発動する事はできません。

また、相手の「イビリチュア・リヴァイアニマ」の効果処理によって確認したカードが「リチュア」と名のついたモンスターではなかった場合には、デッキから『自分のデッキからカードを１枚ドローし、お互いに確認する』処理にて処理が完了する事になりますので、その場合には、自分は「強烈なはたき落とし」を発動する事ができます。 