### PR TITLE
Update c16195942.lua

### DIFF
--- a/script/c16195942.lua
+++ b/script/c16195942.lua
@@ -41,7 +41,7 @@ function c16195942.operation(e,tp,eg,ep,ev,re,r,rp)
 			e2:SetCode(EFFECT_UPDATE_ATTACK)
 			e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 			e2:SetReset(RESET_EVENT+0x1fe0000)
-			e2:SetValue(math.floor(atk/2))
+			e2:SetValue(math.ceil(atk/2))
 			c:RegisterEffect(e2)
 		end
 	end


### PR DESCRIPTION
这东西增加攻击力的逻辑是“对方变成多少，自己就提升多少”。
比方说，攻击力2500的「黑魔导」连吃两发「黑羽-疾风之盖尔」的效果，攻击力变成625，然后再用这东西的效果去点他，之后黑魔导的攻击力会下降至313，下巴龙的攻击力会提升313。

原文也是比较模糊的，“その数値分”到底是指啥，是指所减去的数值，还是指最终变成的数值。最近的一个FAQ回答了我这个疑问。