### PR TITLE
fix Arcana Force XXI - The World, Tellarknight Ptolemaeus

### DIFF
--- a/script/c18326736.lua
+++ b/script/c18326736.lua
@@ -69,7 +69,7 @@ function c18326736.spop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c18326736.skipcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:CheckRemoveOverlayCard(tp,7,REASON_COST) and c:GetFlagEffect(18326737)==0 end
+	if chk==0 then return c:CheckRemoveOverlayCard(tp,7,REASON_COST) and not Duel.IsPlayerAffectedByEffect(1-tp,EFFECT_SKIP_TURN) end
 	c:RemoveOverlayCard(tp,7,7,REASON_COST)
 end
 function c18326736.skipop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c23846921.lua
+++ b/script/c23846921.lua
@@ -61,7 +61,8 @@ function c23846921.skipcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and e:GetHandler():GetFlagEffectLabel(36690018)==1
 end
 function c23846921.skipcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGraveAsCost,tp,LOCATION_MZONE,0,2,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGraveAsCost,tp,LOCATION_MZONE,0,2,nil)
+		and not Duel.IsPlayerAffectedByEffect(1-tp,EFFECT_SKIP_TURN) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToGraveAsCost,tp,LOCATION_MZONE,0,2,2,nil)
 	Duel.SendtoGrave(g,REASON_COST)


### PR DESCRIPTION
Fix this: If you have been applied turn skip effect, The World and Ptolemaeus can activate.
http://yugioh-wiki.net/index.php?%A1%D4%A5%A2%A5%EB%A5%AB%A5%CA%A5%D5%A5%A9%A1%BC%A5%B9%A3%D8%A3%D8%A3%C9%A1%DD%A3%D4%A3%C8%A3%C5%20%A3%D7%A3%CF%A3%D2%A3%CC%A3%C4%A1%D5#faq
Ｑ：《アルカナフォースＸＸＩ－ＴＨＥ ＷＯＲＬＤ》の表の効果を使用した後に別の《アルカナフォースＸＸＩ－ＴＨＥ ＷＯＲＬＤ》の表の効果を発動できますか？
Ａ：いいえ、できません。(15/06/18)
Ｑ：《星守の騎士 プトレマイオス》の「●７つ」の効果を適用したターンのエンドフェイズにこのカードの表の効果を発動できますか？
Ａ：いいえ、できません。(15/06/28)

http://yugioh-wiki.net/index.php?%A1%D4%C0%B1%BC%E9%A4%CE%B5%B3%BB%CE%20%A5%D7%A5%C8%A5%EC%A5%DE%A5%A4%A5%AA%A5%B9%A1%D5#faq1
Ｑ：「●７つ」の効果が適用された後、同一ターン中にもう一度「●７つ」の効果を適用することはできますか？
Ａ：いいえ、できません。(15/03/21)