### PR TITLE
fix Necro Gardna

### DIFF
--- a/script/c4906301.lua
+++ b/script/c4906301.lua
@@ -13,8 +13,7 @@ function c4906301.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c4906301.condition(e,tp,eg,ep,ev,re,r,rp)
-	local ph=Duel.GetCurrentPhase()
-	return Duel.GetTurnPlayer()~=tp and ph~=PHASE_MAIN2 and ph~=PHASE_END
+	return Duel.GetTurnPlayer()~=tp and (Duel.IsAbleToEnterBP() or Duel.GetCurrentPhase()==PHASE_BATTLE)
 end
 function c4906301.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
@@ -33,5 +32,6 @@ function c4906301.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c4906301.disop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,4906301)
 	Duel.NegateAttack()
 end


### PR DESCRIPTION
Fix this: When you cannot conduct your Battle Phase the turn, Necro Gardna can activate.
http://yugioh-wiki.net/index.php?%A1%D4%A5%CD%A5%AF%A5%ED%A1%A6%A5%AC%A1%BC%A5%C9%A5%CA%A1%BC%A1%D5#occ2a70d
Ｑ：相手が《ソウル・チャージ》を発動したなど、バトルフェイズが行えない事が確定している相手ターンに《ネクロ・ガードナー》の効果を発動することはできますか？
Ａ：ご質問のように、バトルフェイズが行えないターン中にて、《ネクロ・ガードナー》の効果を発動する事はできません。(15/05/23)