### PR TITLE
fix Artifacts Unleashed, Number F0: Utopic Future

### DIFF
--- a/script/c56611470.lua
+++ b/script/c56611470.lua
@@ -34,6 +34,9 @@ end
 function c56611470.mfilter2(c,mc)
 	return c.xyz_filter(mc)
 end
+function c56611470.mfilter3(c,mc,exg)
+	return exg:IsExists(Card.IsXyzSummonable,1,nil,Group.FromCards(c,mc))
+end
 function c56611470.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	local mg=Duel.GetMatchingGroup(c56611470.filter,tp,LOCATION_MZONE,0,nil,e)
@@ -43,9 +46,8 @@ function c56611470.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	local sg1=mg:FilterSelect(tp,c56611470.mfilter1,1,1,nil,exg)
 	local tc1=sg1:GetFirst()
-	local exg2=exg:Filter(c56611470.mfilter2,nil,tc1)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	local sg2=mg:FilterSelect(tp,c56611470.mfilter1,1,1,tc1,exg2)
+	local sg2=mg:FilterSelect(tp,c56611470.mfilter3,1,1,tc1,tc1,exg)
 	sg1:Merge(sg2)
 	Duel.SetTargetCard(sg1)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)

--- a/script/c65305468.lua
+++ b/script/c65305468.lua
@@ -44,8 +44,12 @@ function c65305468.initial_effect(c)
 	e7:SetRange(LOCATION_MZONE)
 	e7:SetTarget(c65305468.reptg)
 	c:RegisterEffect(e7)
+	if not c65305468.xyz_filter then
+		c65305468.xyz_filter=function(mc) return mc:IsType(TYPE_XYZ) and not mc:IsSetCard(0x48) and mc:IsCanBeXyzMaterial(c) end
+	end
 end
 c65305468.xyz_number=0
+c65305468.xyz_count=2
 function c65305468.mfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ) and not c:IsSetCard(0x48)
 end
@@ -59,24 +63,36 @@ function c65305468.xyzcon(e,c,og)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil)
+	if og then mg=og end
 	return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
 		and mg:IsExists(c65305468.xyzfilter1,1,nil,mg)
 end
 function c65305468.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og)
-	local mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-	local g1=mg:FilterSelect(tp,c65305468.xyzfilter1,1,1,nil,mg)
-	local tc1=g1:GetFirst()
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-	local g2=mg:FilterSelect(tp,c65305468.xyzfilter2,1,1,tc1,tc1:GetRank())
-	local tc2=g2:GetFirst()
-	g1:Merge(g2)
-	local sg1=tc1:GetOverlayGroup()
-	local sg2=tc2:GetOverlayGroup()
-	sg1:Merge(sg2)
-	Duel.SendtoGrave(sg1,REASON_RULE)
-	c:SetMaterial(g1)
-	Duel.Overlay(c,g1)
+	local g=Group.CreateGroup()
+	local sg=Group.CreateGroup()
+	if og then
+		local tc=og:GetFirst()
+		while tc do
+			g:AddCard(tc)
+			sg:Merge(tc:GetOverlayGroup())
+			tc=og:GetNext()
+		end
+	else
+		local mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+		local g1=mg:FilterSelect(tp,c65305468.xyzfilter1,1,1,nil,mg)
+		local tc1=g1:GetFirst()
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+		local g2=mg:FilterSelect(tp,c65305468.xyzfilter2,1,1,tc1,tc1:GetRank())
+		local tc2=g2:GetFirst()
+		g:AddCard(tc1)
+		g:AddCard(tc2)
+		sg:Merge(tc1:GetOverlayGroup())
+		sg:Merge(tc2:GetOverlayGroup())
+	end
+	Duel.SendtoGrave(sg,REASON_RULE)
+	c:SetMaterial(g)
+	Duel.Overlay(c,g)
 end
 function c65305468.cttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=e:GetHandler():GetBattleTarget()


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9111&keyword=&tag=0
 Q.「アーティファクトの解放」の『自分フィールド上の「アーティファクト」と名のついたモンスター２体を選択して発動できる。選択したモンスター２体のみを素材としてエクシーズモンスター１体をエクシーズ召喚する』効果の対象として、「アーティファクト－デュランダル」2体を選択する事はできますか？
A.「アーティファクトの解放」のカードの発動を行う際に、対象として選択する2体のモンスターは、『選択したモンスター２体のみを素材としてエクシーズモンスター１体をエクシーズ召喚する』事ができるモンスターである必要があります。

例えば、「FNo.0 未来皇ホープ」は『「No.」モンスター以外の同じランクのXモンスター×２』をエクシーズ素材としてエクシーズ召喚されるモンスターです。「アーティファクト－デュランダル」2体によってエクシーズ召喚を行う事ができますので、自分のエクストラデッキに「FNo.0 未来皇ホープ」が存在するのであれば、「アーティファクト－デュランダル」2体を対象として「アーティファクトの解放」を発動する事ができます。 