### PR TITLE
fix Rider of the Storm Winds

### DIFF
--- a/script/c14235211.lua
+++ b/script/c14235211.lua
@@ -47,6 +47,10 @@ function c14235211.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_EQUIP_LIMIT)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
-	e1:SetValue(1)
+	e1:SetValue(c14235211.eqlimit)
+	e1:SetLabelObject(tc)
 	c:RegisterEffect(e1)
+end
+function c14235211.eqlimit(e,c)
+	return c==e:GetLabelObject()
 end


### PR DESCRIPTION
Fix this: Rider of the Storm Winds become Equip Card, You can Switch 1 Equip Card equipped to Rider of the Storm Winds to another correct target in Tailor of the Fickle's effect.

遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
自身の効果によって装備された「暴風竜の防人」を、「移り気な仕立屋」の効果で他のモンスターに移し替えられますか？ 
A. 
自身の効果で装備カードになった「暴風竜の防人」を、「移り気な仕立屋」の効果で移し替える事はできません。 

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。