### PR TITLE
fix Aromage

### DIFF
--- a/script/c22174866.lua
+++ b/script/c22174866.lua
@@ -18,7 +18,7 @@ function c22174866.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e3:SetCode(EVENT_RECOVER)
 	e3:SetRange(LOCATION_MZONE)
-	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_EVENT_PLAYER)
 	e3:SetCountLimit(1)
 	e3:SetCondition(c22174866.thcon)
 	e3:SetTarget(c22174866.thtg)
@@ -37,7 +37,7 @@ function c22174866.thfilter(c)
 end
 function c22174866.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) and c22174866.thfilter(chkc) end
-	if chk==0 then return true end
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
 	local g=Duel.SelectTarget(tp,c22174866.thfilter,tp,0,LOCATION_ONFIELD,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)

--- a/script/c58569561.lua
+++ b/script/c58569561.lua
@@ -14,7 +14,7 @@ function c58569561.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetCode(EVENT_RECOVER)
 	e2:SetRange(LOCATION_MZONE)
-	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_EVENT_PLAYER)
 	e2:SetCountLimit(1)
 	e2:SetCondition(c58569561.poscon)
 	e2:SetTarget(c58569561.postg)
@@ -50,7 +50,7 @@ function c58569561.poscon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c58569561.postg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return true end
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_POSCHANGE)
 	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,g:GetCount(),0,0)

--- a/script/c85967160.lua
+++ b/script/c85967160.lua
@@ -15,8 +15,10 @@ function c85967160.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetCode(EVENT_RECOVER)
 	e2:SetRange(LOCATION_MZONE)
+	e2:SetProperty(EFFECT_FLAG_EVENT_PLAYER)
 	e2:SetCountLimit(1)
 	e2:SetCondition(c85967160.adcon)
+	e2:SetTarget(c85967160.adtg)
 	e2:SetOperation(c85967160.adop)
 	c:RegisterEffect(e2)
 end
@@ -26,6 +28,9 @@ function c85967160.pccon(e)
 end
 function c85967160.adcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp
+end
+function c85967160.adtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) end
 end
 function c85967160.adop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/script/c96789758.lua
+++ b/script/c96789758.lua
@@ -15,7 +15,7 @@ function c96789758.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetCode(EVENT_RECOVER)
 	e2:SetRange(LOCATION_MZONE)
-	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_EVENT_PLAYER)
 	e2:SetCountLimit(1)
 	e2:SetCondition(c96789758.drcon)
 	e2:SetTarget(c96789758.drtg)
@@ -33,7 +33,7 @@ function c96789758.drcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp
 end
 function c96789758.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetTargetParam(1)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)


### PR DESCRIPTION
If the controler changed, the effect that cannot activate.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=15491&keyword=&tag=-1

If the Aromage monster is not on the field, the effect cannot activate.
遊戯王OCG事務局です。(2015/6/18)
Q. 
相手が自分のモンスターゾーンに表側表示で存在する「アロマージ－ジャスミン」を対象として発動した「サンダー・ブレイク」にチェーンして自分が「ご隠居の猛毒薬」を発動し、『●自分は１２００LP回復する』効果によって自分のライフポイントを回復しました。 
その一連のチェーン処理にて、「アロマージ－ジャスミン」で破壊された場合、「アロマージ－ジャスミン」の『②：１ターンに１度、自分のLPが回復した場合に発動する。自分はデッキから１枚ドローする』効果は発動しますか？ 
A. 
ご質問頂きました状況の場合、一連のチェーン処理を終えたタイミングでは、「アロマージ－ジャスミン」自身がフィールド上に表側表示で存在しない為、デッキからカード1枚ドローする効果を発動する事はできません。