### PR TITLE
fix Abyssgaios, Crystalzero Lancer

### DIFF
--- a/script/c74371660.lua
+++ b/script/c74371660.lua
@@ -33,7 +33,7 @@ function c74371660.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c74371660.filter(c,atk)
-	return c:IsFaceup() and c:GetAttack()<atk
+	return aux.disfilter1(c) and c:GetAttack()<atk
 end
 function c74371660.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c74371660.filter,tp,0,LOCATION_MZONE,1,nil,e:GetHandler():GetAttack()) end

--- a/script/c99469936.lua
+++ b/script/c99469936.lua
@@ -49,11 +49,11 @@ function c99469936.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c99469936.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(aux.disfilter1,tp,0,LOCATION_MZONE,1,nil) end
 end
 function c99469936.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
+	local g=Duel.GetMatchingGroup(aux.disfilter1,tp,0,LOCATION_MZONE,nil)
 	local tc=g:GetFirst()
 	while tc do
 		local e1=Effect.CreateEffect(c)


### PR DESCRIPTION
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
相手フィールドのモンスターが既に効果が無効化されているモンスターや通常モンスターのみの場合、「ＦＡ－クリスタル・ゼロ・ランサー」や「水精鱗－ガイオアビス」の効果を発動できますか？ 
A. 
ご質問の状況の場合、「FA－クリスタル・ゼロ・ランサー」や「水精鱗－ガイオアビス」の効果を発動する事はできません。 



これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。