### PR TITLE
fix Helios Trice Megistus

### DIFF
--- a/script/c17286057.lua
+++ b/script/c17286057.lua
@@ -80,6 +80,6 @@ function c17286057.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 	Duel.SpecialSummonComplete()
 end
-function c17286057.atcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0
+function c17286057.atcon(e)
+	return Duel.GetFieldGroupCount(e:GetHandlerPlayer(),0,LOCATION_MZONE)>0
 end


### PR DESCRIPTION
Fix this: If your opponent controls no monsters, Helios Trice Megistus can make a second attack in a row.