### PR TITLE
fix Dark End Dragon

### DIFF
--- a/script/c88643579.lua
+++ b/script/c88643579.lua
@@ -28,9 +28,6 @@ function c88643579.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and c:IsFaceup() and c:GetAttack()>=500 and c:GetDefence()>=500 then
-		if tc and tc:IsRelateToEffect(e) then
-			Duel.SendtoGrave(tc,REASON_EFFECT)
-		end
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetProperty(EFFECT_FLAG_COPY_INHERIT)
@@ -41,5 +38,8 @@ function c88643579.operation(e,tp,eg,ep,ev,re,r,rp)
 		local e2=e1:Clone()
 		e2:SetCode(EFFECT_UPDATE_DEFENCE)
 		c:RegisterEffect(e2)
+		if tc and tc:IsControler(1-tp) and tc:IsRelateToEffect(e) and not c:IsHasEffect(EFFECT_REVERSE_UPDATE) then
+			Duel.SendtoGrave(tc,REASON_EFFECT)
+		end
 	end
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7676&keyword=&tag=-1
 Q.「ダークエンド・ドラゴン」の効果にチェーンをして発動した「エネミーコントローラー」等の効果によって、「ダークエンド・ドラゴン」の効果の対象に選択した相手モンスターのコントロールが自分フィールド上に移っている場合、「ダークエンド・ドラゴン」の効果処理時に、対象のモンスターは墓地に送られますか？
A.「ダークエンド・ドラゴン」の効果処理を行う時に、対象に選択した相手モンスターのコントロールが、自分フィールド上に移っている場合、墓地へ送る効果は適用されません。 

http://yugioh-wiki.net/index.php?%A1%D4%A5%C0%A1%BC%A5%AF%A5%A8%A5%F3%A5%C9%A1%A6%A5%C9%A5%E9%A5%B4%A5%F3%A1%D5#faq
Ｑ：《あまのじゃくの呪い》の効果が適用されている時に自身の効果でこのカードの攻撃力・守備力がダウンする代わりにアップした場合、墓地へ送る処理は行われますか？
Ａ：いいえ、このカードの効果で攻撃力・守備力がダウンする処理ができなかった場合、墓地へ送る処理は行われません。(14/10/24)