### PR TITLE
fix Ambulanceroid

### DIFF
--- a/script/c36378213.lua
+++ b/script/c36378213.lua
@@ -30,9 +30,9 @@ function c36378213.activate(e,tp,eg,ep,ev,re,r,rp)
 	if ft<=0 then return end
 	local g=eg:Filter(c36378213.spfilter,nil,e,tp)
 	if g:GetCount()==0 then return end
-	if g:GetCount()>1 then
+	if g:GetCount()>ft then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		g=g:Select(tp,1,ft,nil)
+		g=g:Select(tp,ft,ft,nil)
 	end
 	Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7725&keyword=&tag=0
 Q.「サルベージ」の効果によって、自分の墓地の「サブマリンロイド」2体が手札に加わった時、自分は「キューキューロイド」の『「ロイド」と名のついたモンスターが自分の墓地から手札に加わった時、そのモンスターを特殊召喚する事ができる』効果を発動する事はできますか？
A.質問の状況の場合でも、「キューキューロイド」の効果を発動する事はできます。

その場合、同時に墓地から手札に加わった「サブマリンロイド」2体を全て特殊召喚する事になります。
（加えたモンスターの中から1体のみを選んで特殊召喚する、というような事はできません。） 