### PR TITLE
fix returning control

### DIFF
--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -1022,7 +1022,7 @@ int32 field::control_adjust(uint16 step) {
 	};
 	case 5: {
 		if(core.destroy_set.size())
-			send_to(&core.destroy_set, 0, REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
+			destroy(&core.destroy_set, 0, REASON_RULE, PLAYER_NONE);
 		return TRUE;
 	}
 	}

--- a/script/c10000080.lua
+++ b/script/c10000080.lua
@@ -110,9 +110,13 @@ function c10000080.retcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c10000080.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetOwner()
-	if c:GetControler()~=c:GetOwner() then
-		Duel.GetControl(c,c:GetOwner())
-	end
+	c:ResetEffect(EFFECT_SET_CONTROL,RESET_CODE)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SET_CONTROL)
+	e1:SetValue(c:GetOwner())
+	e1:SetReset(RESET_EVENT+0xec0000)
+	c:RegisterEffect(e1)
 end
 function c10000080.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsReleasable() end

--- a/script/c93983867.lua
+++ b/script/c93983867.lua
@@ -58,7 +58,11 @@ function c93983867.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function c93983867.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:GetControler()~=c:GetOwner() then
-		Duel.GetControl(c,c:GetOwner())
-	end
+	c:ResetEffect(EFFECT_SET_CONTROL,RESET_CODE)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SET_CONTROL)
+	e1:SetValue(c:GetOwner())
+	e1:SetReset(RESET_EVENT+0xec0000)
+	c:RegisterEffect(e1)
 end


### PR DESCRIPTION
When returning control of a monster but there are no monster zone available, that monster shuold be destroyed.

Owner's Seal
Q. 
テキストに記載された方法によって相手フィールド上に特殊召喚された「溶岩魔神ラヴァ・ゴーレム」が、その後に発動した「所有者の刻印」の効果でコントロールが自分に移っている場合、自分のモンスターゾーンに空きがない場合、フィールドに戻った際のコントロールはどうなりますか？ 
A. 
元々の持ち主のモンスターゾーンに空きが無い場合、「溶岩魔神ラヴァ・ゴーレム」は破壊されます。  (2015/6/13)

The Winged Dragon of Ra - Sphere Mode
Q. 
「ラーの翼神竜－球体形」は『召喚したこのカードのコントロールは次のターンのエンドフェイズに元々の持ち主に戻る』と記されているモンスターとなりますが、相手のモンスターゾーンに「ラーの翼神竜－球体形」をアドバンス召喚された後に、自分のモンスターゾーンに空きがない場合、「ラーの翼神竜－球体形」は墓地へ送られる、このターン、相手他のモンスターが破壊していない場合、相手の「リュージョン・バルーン」を発動する事はできますか？ 
A. 
元々の持ち主のモンスターゾーンに空きが無く、「ラーの翼神竜－球体形」が相手フィールド上で破壊されたのであれば、相手は「イリュージョン・バルーン」を発動する事ができます。  (2015/6/13)

Trick Box
Q. 
「トリック・ボックス」は『このターンのエンドフェイズに、この効果で特殊召喚したモンスターのコントロールは元々の持ち主に戻る』、相手のモンスターゾーンに「Em」モンスターをこカードの効果で特殊召喚された後に、自分のモンスターゾーンに空きがない場合、フィールドに戻った際のコントロールはどうなりますか？ 
A. 
自分のモンスターゾーンに空きが無く、エンドフェイズ時に、「トリック・ボックス」の効果で相手フィールド上に特殊召喚した「Em」と名のついたモンスターのコントロールを戻す事ができない場合、その「Em」と名のついたモンスターは破壊され、元々の持ち主の墓地へ送られます。(2015/06/13)

Mind Control: returning control at the end phase
Q. 
フィールド上に表側表示で存在するモンスターを対象に「精神操作」や「エネミーコントローラー」を発動してコントロールを得た場合、エンドフェイズ時、相手のモンスターゾーンに空きがない場合、このモンスターは墓地へ送られる、このターン、自分他のモンスターが破壊していない場合、自分の「リュージョン・バルーン」を発動する事はできますか？ 
A. 
ご質問の状況の場合、相手にコントロールを戻せずにモンスターが破壊されたため、自分は「イリュージョン・バルーン」を発動できます。 (2015/7/1)