### PR TITLE
fix event player of Pendulum summon

### DIFF
--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -2323,7 +2323,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card * target, ui
 			(*cit)->set_status(STATUS_SUMMONING, TRUE);
 		}
 		if(cset.size())
-			raise_event(&cset, EVENT_SPSUMMON, core.units.begin()->peffect, 0, sumplayer, PLAYER_NONE, 0);
+			raise_event(&cset, EVENT_SPSUMMON, core.units.begin()->peffect, 0, sumplayer, sumplayer, 0);
 		process_single_event();
 		process_instant_event();
 		add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, 0x101, TRUE);


### PR DESCRIPTION
The event player of Pendulum summon should be summon player or the Stardust Warrior can disable Pendulum summon of both player