### PR TITLE
fix Remove Brainwashing

### DIFF
--- a/ocgcore/card.cpp
+++ b/ocgcore/card.cpp
@@ -1228,7 +1228,7 @@ void card::reset(uint32 id, uint32 reset_type) {
 			}
 		}
 		if(id & RESET_TURN_SET) {
-			effect* peffect = check_equip_control_effect();
+			effect* peffect = check_control_effect();
 			if(peffect) {
 				effect* new_effect = pduel->new_effect();
 				new_effect->id = peffect->id;
@@ -1715,7 +1715,7 @@ effect* card::is_affected_by_effect(int32 code, card* target) {
 	}
 	return 0;
 }
-effect* card::check_equip_control_effect() {
+effect* card::check_control_effect() {
 	effect* ret_effect = 0;
 	for (auto cit = equiping_cards.begin(); cit != equiping_cards.end(); ++cit) {
 		auto rg = (*cit)->equip_effect.equal_range(EFFECT_SET_CONTROL);
@@ -1724,6 +1724,14 @@ effect* card::check_equip_control_effect() {
 			if(!ret_effect || peffect->id > ret_effect->id)
 				ret_effect = peffect;
 		}
+	}
+	auto rg = single_effect.equal_range(EFFECT_SET_CONTROL);
+	for (; rg.first != rg.second; ++rg.first) {
+		effect* peffect = rg.first->second;
+		if(!(peffect->flag & EFFECT_FLAG_SINGLE_RANGE))
+			continue;
+		if(!ret_effect || peffect->id > ret_effect->id)
+			ret_effect = peffect;
 	}
 	return ret_effect;
 }

--- a/ocgcore/card.cpp
+++ b/ocgcore/card.cpp
@@ -1272,7 +1272,7 @@ int32 card::refresh_disable_status() {
 }
 uint8 card::refresh_control_status() {
 	uint8 final = owner;
-	if(pduel->game_field->core.remove_brainwashing)
+	if(pduel->game_field->core.remove_brainwashing && is_affected_by_effect(EFFECT_REMOVE_BRAINWASHING))
 		return final;
 	effect_set eset;
 	filter_effect(EFFECT_SET_CONTROL, &eset);
@@ -1468,6 +1468,17 @@ void card::filter_effect(int32 code, effect_set* eset, uint8 sort) {
 		peffect = rg.first->second;
 		if (!(peffect->flag & EFFECT_FLAG_PLAYER_TARGET) && peffect->is_available()
 		        && peffect->is_target(this) && is_affect_by_effect(peffect))
+			eset->add_item(peffect);
+	}
+	if(sort)
+		eset->sort();
+}
+void card::filter_single_effect(int32 code, effect_set* eset, uint8 sort) {
+	effect* peffect;
+	auto rg = single_effect.equal_range(code);
+	for (; rg.first != rg.second; ++rg.first) {
+		peffect = rg.first->second;
+		if (peffect->is_available() && !(peffect->flag & EFFECT_FLAG_SINGLE_RANGE))
 			eset->add_item(peffect);
 	}
 	if(sort)

--- a/ocgcore/card.h
+++ b/ocgcore/card.h
@@ -199,6 +199,7 @@ public:
 	void cancel_card_target(card* pcard);
 	
 	void filter_effect(int32 code, effect_set* eset, uint8 sort = TRUE);
+	void filter_single_effect(int32 code, effect_set* eset, uint8 sort = TRUE);
 	void filter_single_continuous_effect(int32 code, effect_set* eset, uint8 sort = TRUE);
 	void filter_immune_effect();
 	void filter_disable_related_cards();

--- a/ocgcore/card.h
+++ b/ocgcore/card.h
@@ -209,7 +209,7 @@ public:
 	void filter_spsummon_procedure_g(uint8 playerid, effect_set* eset);
 	effect* is_affected_by_effect(int32 code);
 	effect* is_affected_by_effect(int32 code, card* target);
-	effect* check_equip_control_effect();
+	effect* check_control_effect();
 	int32 fusion_check(group* fusion_m, card* cg, int32 chkf);
 	void fusion_select(uint8 playerid, group* fusion_m, card* cg, int32 chkf);
 	

--- a/ocgcore/field.cpp
+++ b/ocgcore/field.cpp
@@ -371,7 +371,7 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 	add_card(playerid, pcard, location, sequence);
 }
 void field::set_control(card* pcard, uint8 playerid, uint16 reset_phase, uint8 reset_count) {
-	if(core.remove_brainwashing || pcard->refresh_control_status() == playerid)
+	if((core.remove_brainwashing && pcard->is_affected_by_effect(EFFECT_REMOVE_BRAINWASHING)) || pcard->refresh_control_status() == playerid)
 		return;
 	effect* peffect = pduel->new_effect();
 	if(core.reason_effect)

--- a/ocgcore/processor.cpp
+++ b/ocgcore/processor.cpp
@@ -5221,6 +5221,34 @@ int32 field::adjust_step(uint16 step) {
 		return FALSE;
 	}
 	case 4: {
+		//remove brainwashing
+		effect_set eset;
+		uint32 res = 0;
+		if(core.global_flag & GLOBALFLAG_BRAINWASHING_CHECK) {
+			filter_field_effect(EFFECT_REMOVE_BRAINWASHING, &eset, FALSE);
+			res = eset.size() ? TRUE : FALSE;
+			if(res) {
+				card* pcard;
+				effect_set ctrleff;
+				for(uint8 p = 0; p < 2; ++p) {
+					for(uint8 i = 0; i < 5; ++i) {
+						pcard = player[p].list_mzone[i];
+						if(pcard && pcard->is_affected_by_effect(EFFECT_REMOVE_BRAINWASHING)) {
+							ctrleff.clear();
+							pcard->filter_single_effect(EFFECT_SET_CONTROL, &ctrleff, FALSE);
+							for(int32 i = 0; i < ctrleff.size(); ++i) {
+								pcard->remove_effect(ctrleff[i]);
+								core.re_adjust = TRUE;
+							}
+						}
+					}
+				}
+			}
+			core.remove_brainwashing = res;
+		}
+		return FALSE;
+	}
+	case 5: {
 		//1-4 control
 		card* pcard;
 		uint8 cur, ref;
@@ -5243,9 +5271,6 @@ int32 field::adjust_step(uint16 step) {
 			add_process(PROCESSOR_CONTROL_ADJUST, 0, 0, 0, 0, 0);
 		}
 		core.units.begin()->step = 7;
-		return FALSE;
-	}
-	case 5: {
 		return FALSE;
 	}
 	case 6: {
@@ -5346,7 +5371,7 @@ int32 field::adjust_step(uint16 step) {
 		return FALSE;
 	}
 	case 13: {
-		//reverse_deck && remove brainwashing
+		//reverse_deck
 		effect_set eset;
 		uint32 res = 0;
 		if(core.global_flag & GLOBALFLAG_DECK_REVERSE_CHECK) {
@@ -5380,25 +5405,6 @@ int32 field::adjust_step(uint16 step) {
 				}
 			}
 			core.deck_reversed = res;
-			eset.clear();
-		}
-		if(core.global_flag & GLOBALFLAG_BRAINWASHING_CHECK) {
-			filter_field_effect(EFFECT_REMOVE_BRAINWASHING, &eset, FALSE);
-			res = eset.size() ? TRUE : FALSE;
-			if(res && !core.remove_brainwashing) {
-				for(int i = 0; i < 5; ++i) {
-					card* pcard = player[0].list_mzone[i];
-					if(pcard)
-						pcard->reset(EFFECT_SET_CONTROL, RESET_CODE);
-				}
-				for(int i = 0; i < 5; ++i) {
-					card* pcard = player[1].list_mzone[i];
-					if(pcard)
-						pcard->reset(EFFECT_SET_CONTROL, RESET_CODE);
-				}
-				core.re_adjust = TRUE;
-			}
-			core.remove_brainwashing = res;
 		}
 		return FALSE;
 	}

--- a/ocgcore/processor.cpp
+++ b/ocgcore/processor.cpp
@@ -5236,8 +5236,8 @@ int32 field::adjust_step(uint16 step) {
 						if(pcard && pcard->is_affected_by_effect(EFFECT_REMOVE_BRAINWASHING)) {
 							ctrleff.clear();
 							pcard->filter_single_effect(EFFECT_SET_CONTROL, &ctrleff, FALSE);
-							for(int32 i = 0; i < ctrleff.size(); ++i) {
-								pcard->remove_effect(ctrleff[i]);
+							if(ctrleff.size()) {
+								pcard->reset(EFFECT_SET_CONTROL, RESET_CODE);
 								core.re_adjust = TRUE;
 							}
 						}

--- a/script/c19327348.lua
+++ b/script/c19327348.lua
@@ -26,42 +26,21 @@ function c19327348.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and c:IsFaceup() and tc and tc:IsRelateToEffect(e) and c19327348.filter(tc) then
-		c:CreateRelation(tc,RESET_EVENT+0x5fe0000)
+		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
-		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_CONTROL)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE+EFFECT_FLAG_SINGLE_RANGE)
+		e1:SetRange(LOCATION_MZONE)
 		e1:SetValue(tp)
 		e1:SetLabel(0)
 		e1:SetReset(RESET_EVENT+0x1fc0000)
 		e1:SetCondition(c19327348.ctcon)
 		tc:RegisterEffect(e1)
-		local e2=Effect.CreateEffect(c)
-		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-		e2:SetCode(EVENT_CHANGE_POS)
-		e2:SetReset(RESET_EVENT+0x1fc0000)
-		e2:SetOperation(c19327348.posop)
-		e2:SetLabelObject(e1)
-		tc:RegisterEffect(e2)
 	end
 end
 function c19327348.ctcon(e)
-	if e:GetLabel()==1 then return true end
-	if e:GetLabel()==2 then return false end
 	local c=e:GetOwner()
 	local h=e:GetHandler()
-	if h:IsAttribute(ATTRIBUTE_DARK) and not c:IsDisabled() and c:IsRelateToCard(h) then
-		return true
-	else
-		e:SetLabel(2)
-		return false
-	end
-end
-function c19327348.posop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetLabelObject():GetLabel()~=0 then return end
-	local h=e:GetHandler()
-	if h:IsPreviousPosition(POS_FACEUP) and h:IsFacedown() then
-		e:GetLabelObject():SetLabel(1)
-	end
+	return h:IsAttribute(ATTRIBUTE_DARK) and c:IsHasCardTarget(h)
 end

--- a/script/c37744402.lua
+++ b/script/c37744402.lua
@@ -26,42 +26,21 @@ function c37744402.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and c:IsFaceup() and tc and tc:IsRelateToEffect(e) and c37744402.filter(tc) then
-		c:CreateRelation(tc,RESET_EVENT+0x5fe0000)
+		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
-		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_CONTROL)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE+EFFECT_FLAG_SINGLE_RANGE)
+		e1:SetRange(LOCATION_MZONE)
 		e1:SetValue(tp)
 		e1:SetLabel(0)
 		e1:SetReset(RESET_EVENT+0x1fc0000)
 		e1:SetCondition(c37744402.ctcon)
 		tc:RegisterEffect(e1)
-		local e2=Effect.CreateEffect(c)
-		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-		e2:SetCode(EVENT_CHANGE_POS)
-		e2:SetReset(RESET_EVENT+0x1fc0000)
-		e2:SetOperation(c37744402.posop)
-		e2:SetLabelObject(e1)
-		tc:RegisterEffect(e2)
 	end
 end
 function c37744402.ctcon(e)
-	if e:GetLabel()==1 then return true end
-	if e:GetLabel()==2 then return false end
 	local c=e:GetOwner()
 	local h=e:GetHandler()
-	if h:IsAttribute(ATTRIBUTE_WIND) and not c:IsDisabled() and c:IsRelateToCard(h) then
-		return true
-	else
-		e:SetLabel(2)
-		return false
-	end
-end
-function c37744402.posop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetLabelObject():GetLabel()~=0 then return end
-	local h=e:GetHandler()
-	if h:IsPreviousPosition(POS_FACEUP) and h:IsFacedown() then
-		e:GetLabelObject():SetLabel(1)
-	end
+	return h:IsAttribute(ATTRIBUTE_FIRE) and c:IsHasCardTarget(h)
 end

--- a/script/c37970940.lua
+++ b/script/c37970940.lua
@@ -26,42 +26,21 @@ function c37970940.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and c:IsFaceup() and tc and tc:IsRelateToEffect(e) and c37970940.filter(tc) then
-		c:CreateRelation(tc,RESET_EVENT+0x5fe0000)
+		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
-		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_CONTROL)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE+EFFECT_FLAG_SINGLE_RANGE)
+		e1:SetRange(LOCATION_MZONE)
 		e1:SetValue(tp)
 		e1:SetLabel(0)
 		e1:SetReset(RESET_EVENT+0x1fc0000)
 		e1:SetCondition(c37970940.ctcon)
 		tc:RegisterEffect(e1)
-		local e2=Effect.CreateEffect(c)
-		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-		e2:SetCode(EVENT_CHANGE_POS)
-		e2:SetReset(RESET_EVENT+0x1fc0000)
-		e2:SetOperation(c37970940.posop)
-		e2:SetLabelObject(e1)
-		tc:RegisterEffect(e2)
 	end
 end
 function c37970940.ctcon(e)
-	if e:GetLabel()==1 then return true end
-	if e:GetLabel()==2 then return false end
 	local c=e:GetOwner()
 	local h=e:GetHandler()
-	if h:IsAttribute(ATTRIBUTE_EARTH) and not c:IsDisabled() and c:IsRelateToCard(h) then
-		return true
-	else
-		e:SetLabel(2)
-		return false
-	end
-end
-function c37970940.posop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetLabelObject():GetLabel()~=0 then return end
-	local h=e:GetHandler()
-	if h:IsPreviousPosition(POS_FACEUP) and h:IsFacedown() then
-		e:GetLabelObject():SetLabel(1)
-	end
+	return h:IsAttribute(ATTRIBUTE_FIRE) and c:IsHasCardTarget(h)
 end

--- a/script/c73318863.lua
+++ b/script/c73318863.lua
@@ -26,42 +26,21 @@ function c73318863.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and c:IsFaceup() and tc and tc:IsRelateToEffect(e) and c73318863.filter(tc) then
-		c:CreateRelation(tc,RESET_EVENT+0x5fe0000)
+		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
-		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_CONTROL)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE+EFFECT_FLAG_SINGLE_RANGE)
+		e1:SetRange(LOCATION_MZONE)
 		e1:SetValue(tp)
 		e1:SetLabel(0)
 		e1:SetReset(RESET_EVENT+0x1fc0000)
 		e1:SetCondition(c73318863.ctcon)
 		tc:RegisterEffect(e1)
-		local e2=Effect.CreateEffect(c)
-		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-		e2:SetCode(EVENT_CHANGE_POS)
-		e2:SetReset(RESET_EVENT+0x1fc0000)
-		e2:SetOperation(c73318863.posop)
-		e2:SetLabelObject(e1)
-		tc:RegisterEffect(e2)
 	end
 end
 function c73318863.ctcon(e)
-	if e:GetLabel()==1 then return true end
-	if e:GetLabel()==2 then return false end
 	local c=e:GetOwner()
 	local h=e:GetHandler()
-	if h:IsAttribute(ATTRIBUTE_LIGHT) and not c:IsDisabled() and c:IsRelateToCard(h) then
-		return true
-	else
-		e:SetLabel(2)
-		return false
-	end
-end
-function c73318863.posop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetLabelObject():GetLabel()~=0 then return end
-	local h=e:GetHandler()
-	if h:IsPreviousPosition(POS_FACEUP) and h:IsFacedown() then
-		e:GetLabelObject():SetLabel(1)
-	end
+	return h:IsAttribute(ATTRIBUTE_FIRE) and c:IsHasCardTarget(h)
 end

--- a/script/c74364659.lua
+++ b/script/c74364659.lua
@@ -26,42 +26,21 @@ function c74364659.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and c:IsFaceup() and tc and tc:IsRelateToEffect(e) and c74364659.filter(tc) then
-		c:CreateRelation(tc,RESET_EVENT+0x5fe0000)
+		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
-		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_CONTROL)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE+EFFECT_FLAG_SINGLE_RANGE)
+		e1:SetRange(LOCATION_MZONE)
 		e1:SetValue(tp)
 		e1:SetLabel(0)
 		e1:SetReset(RESET_EVENT+0x1fc0000)
 		e1:SetCondition(c74364659.ctcon)
 		tc:RegisterEffect(e1)
-		local e2=Effect.CreateEffect(c)
-		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-		e2:SetCode(EVENT_CHANGE_POS)
-		e2:SetReset(RESET_EVENT+0x1fc0000)
-		e2:SetOperation(c74364659.posop)
-		e2:SetLabelObject(e1)
-		tc:RegisterEffect(e2)
 	end
 end
 function c74364659.ctcon(e)
-	if e:GetLabel()==1 then return true end
-	if e:GetLabel()==2 then return false end
 	local c=e:GetOwner()
 	local h=e:GetHandler()
-	if h:IsAttribute(ATTRIBUTE_WATER) and not c:IsDisabled() and c:IsRelateToCard(h) then
-		return true
-	else
-		e:SetLabel(2)
-		return false
-	end
-end
-function c74364659.posop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetLabelObject():GetLabel()~=0 then return end
-	local h=e:GetHandler()
-	if h:IsPreviousPosition(POS_FACEUP) and h:IsFacedown() then
-		e:GetLabelObject():SetLabel(1)
-	end
+	return h:IsAttribute(ATTRIBUTE_FIRE) and c:IsHasCardTarget(h)
 end

--- a/script/c759393.lua
+++ b/script/c759393.lua
@@ -26,42 +26,21 @@ function c759393.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and c:IsFaceup() and tc and tc:IsRelateToEffect(e) and c759393.filter(tc) then
-		c:CreateRelation(tc,RESET_EVENT+0x5fe0000)
+		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
-		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_CONTROL)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE+EFFECT_FLAG_SINGLE_RANGE)
+		e1:SetRange(LOCATION_MZONE)
 		e1:SetValue(tp)
 		e1:SetLabel(0)
 		e1:SetReset(RESET_EVENT+0x1fc0000)
 		e1:SetCondition(c759393.ctcon)
 		tc:RegisterEffect(e1)
-		local e2=Effect.CreateEffect(c)
-		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-		e2:SetCode(EVENT_CHANGE_POS)
-		e2:SetReset(RESET_EVENT+0x1fc0000)
-		e2:SetOperation(c759393.posop)
-		e2:SetLabelObject(e1)
-		tc:RegisterEffect(e2)
 	end
 end
 function c759393.ctcon(e)
-	if e:GetLabel()==1 then return true end
-	if e:GetLabel()==2 then return false end
 	local c=e:GetOwner()
 	local h=e:GetHandler()
-	if h:IsAttribute(ATTRIBUTE_FIRE) and not c:IsDisabled() and c:IsRelateToCard(h) then
-		return true
-	else
-		e:SetLabel(2)
-		return false
-	end
-end
-function c759393.posop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetLabelObject():GetLabel()~=0 then return end
-	local h=e:GetHandler()
-	if h:IsPreviousPosition(POS_FACEUP) and h:IsFacedown() then
-		e:GetLabelObject():SetLabel(1)
-	end
+	return h:IsAttribute(ATTRIBUTE_FIRE) and c:IsHasCardTarget(h)
 end

--- a/script/c94739788.lua
+++ b/script/c94739788.lua
@@ -11,5 +11,6 @@ function c94739788.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
 	e2:SetCode(EFFECT_REMOVE_BRAINWASHING)
 	e2:SetRange(LOCATION_SZONE)
+	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
 	c:RegisterEffect(e2)
 end


### PR DESCRIPTION
fix https://github.com/Fluorohydride/ygopro/issues/1138 (immunity)

When the effect of Remove Brainwashing stops applying, the controler of Falling Down(equip card)/Tuner's Scheme(continuous target) should take control of opponent's monster again immediately.