### PR TITLE
fix

### DIFF
--- a/script/c15978426.lua
+++ b/script/c15978426.lua
@@ -15,7 +15,8 @@ function c15978426.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c15978426.filter(c,tohand)
-	return c:IsSetCard(0x9f) and c:IsType(TYPE_MONSTER) and (c:IsAbleToGrave() or (tohand and c:IsAbleToHand()))
+	return c:IsSetCard(0x9f) and not c:IsCode(15978426) and c:IsType(TYPE_MONSTER)
+		and (c:IsAbleToGrave() or (tohand and c:IsAbleToHand()))
 end
 function c15978426.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/script/c41141943.lua
+++ b/script/c41141943.lua
@@ -20,7 +20,7 @@ function c41141943.initial_effect(c)
 	c:RegisterEffect(e2)
 	--special summon
 	local e3=Effect.CreateEffect(c)
-	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_DRAW)
 	e3:SetType(EFFECT_TYPE_IGNITION)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetCountLimit(1,41141943)

--- a/script/c48144509.lua
+++ b/script/c48144509.lua
@@ -27,10 +27,12 @@ function c48144509.filter2(c,e,tp,m,f,chkf)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
 function c48144509.filter3(c,e,tp,m,f,chkf)
+	local mg=m:Clone()
+	mg:RemoveCard(c)
 	if c:IsType(TYPE_FUSION) and c:IsRace(RACE_DRAGON) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) then
-		if c.check_fusion_material_48144509 then return c.check_fusion_material_48144509(m,chkf) end
-		return c:CheckFusionMaterial(m,nil,chkf)
+		if c.check_fusion_material_48144509 then return c.check_fusion_material_48144509(mg,chkf) end
+		return c:CheckFusionMaterial(mg,nil,chkf)
 	else return false end
 end
 function c48144509.target(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -78,6 +80,7 @@ function c48144509.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
+		mg1:RemoveCard(tc)
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
 			local mat1=nil
 			if tc.select_fusion_material_48144509 then


### PR DESCRIPTION
Odd Eyes Fusion
fix special summoned monster can be used as fusion material itself.

Performapal Secondonkey
cannot select Performapal Secondonkey