### PR TITLE
fix

### DIFF
--- a/script/c13945283.lua
+++ b/script/c13945283.lua
@@ -12,7 +12,7 @@ function c13945283.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c13945283.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetAttackTarget()==e:GetHandler()
+	return Duel.GetAttackTarget()==e:GetHandler() and not Duel.GetAttacker():IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c13945283.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/script/c32542011.lua
+++ b/script/c32542011.lua
@@ -44,6 +44,7 @@ function c32542011.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if Duel.IsExistingMatchingCard(c32542011.cfilter2,tp,LOCATION_MZONE,0,1,nil,ATTRIBUTE_WATER) then
 		local g=Duel.GetMatchingGroup(c32542011.spfilter,tp,LOCATION_GRAVE,0,nil,Duel.GetTurnCount(),e,tp)
 		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,Duel.GetLocationCount(tp,LOCATION_MZONE),0,0)
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,nil,1,0,LOCATION_MZONE)
 	end
 end
 function c32542011.activate(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c73872164.lua
+++ b/script/c73872164.lua
@@ -32,12 +32,13 @@ end
 function c73872164.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		Duel.BreakEffect()
 		local code=tc:GetCode()
 		local g=Duel.GetMatchingGroup(Card.IsCode,tp,0,LOCATION_HAND,nil,code)
 		local hg=Duel.GetFieldGroup(tp,0,LOCATION_HAND)
 		Duel.ConfirmCards(tp,hg)
 		if g:GetCount()>0 then
-			Duel.SendtoGrave(g,REASON_EFFECT+REASON_DISCARD)
+			Duel.SendtoGrave(g,REASON_EFFECT)
 		end
 		Duel.ShuffleHand(1-tp)
 	end


### PR DESCRIPTION
幻影の壁かべ/Wall of Illusion
Similar to ケルベク/Kelbek, it cannot send monster that is battle destroy comfirmed to hand.

燃え上がる大海/High Tide on Fire Island
Stardust Dragon can negate the activation of this card when "● WATER" effect applies.
http://yugioh-wiki.net/index.php?%A1%D4%C7%B3%A4%A8%BE%E5%A4%AC%A4%EB%C2%E7%B3%A4%A1%D5#d93bce9b
Ｑ：水属性モンスターが存在している場合《スターダスト・ドラゴン》でこのカードの発動を無効にできますか？
Ａ：はい、無効にできます。(13/03/14)

お家おとりつぶし
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7008
Destroying selected card and sending card in hand to grave is not treated simultaneously, and the latter is not discarding card
■『選択して破壊する』処理と『さらに相手の手札を確認し、破壊したカードと同名のカードを全て墓地へ送る』 処理は同時に行われる扱いではありません。