### PR TITLE
fix Graydle

### DIFF
--- a/script/c29834183.lua
+++ b/script/c29834183.lua
@@ -60,7 +60,7 @@ function c29834183.eqop(e,tp,eg,ep,ev,re,r,rp)
 		e4:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
 		e4:SetCode(EVENT_LEAVE_FIELD)
 		e4:SetOperation(c29834183.desop)
-		e4:SetReset(RESET_EVENT+0x1fe0000)
+		e4:SetReset(RESET_EVENT+0x17e0000)
 		e4:SetLabelObject(e3)
 		c:RegisterEffect(e4)
 	end

--- a/script/c66451379.lua
+++ b/script/c66451379.lua
@@ -60,7 +60,7 @@ function c66451379.eqop(e,tp,eg,ep,ev,re,r,rp)
 		e4:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
 		e4:SetCode(EVENT_LEAVE_FIELD)
 		e4:SetOperation(c66451379.desop)
-		e4:SetReset(RESET_EVENT+0x1fe0000)
+		e4:SetReset(RESET_EVENT+0x17e0000)
 		e4:SetLabelObject(e3)
 		c:RegisterEffect(e4)
 	end

--- a/script/c93445074.lua
+++ b/script/c93445074.lua
@@ -60,7 +60,7 @@ function c93445074.eqop(e,tp,eg,ep,ev,re,r,rp)
 		e4:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
 		e4:SetCode(EVENT_LEAVE_FIELD)
 		e4:SetOperation(c93445074.desop)
-		e4:SetReset(RESET_EVENT+0x1fe0000)
+		e4:SetReset(RESET_EVENT+0x17e0000)
 		e4:SetLabelObject(e3)
 		c:RegisterEffect(e4)
 	end


### PR DESCRIPTION
Fix: When these three Graydle monsters leaves field as equip cards, the equip target will not be destroyed.