### PR TITLE
fix disable pendulum summon

### DIFF
--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -2343,10 +2343,11 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card * target, ui
 		if(cset.size()) {
 			send_to(&cset, 0, REASON_RULE, sumplayer, sumplayer, LOCATION_GRAVE, 0, 0);
 			adjust_instant();
-			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, FALSE, 0);
 		}
-		if(pgroup->container.size() == 0)
+		if(pgroup->container.size() == 0) {
+			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, FALSE, 0);
 			return TRUE;
+		}
 		return FALSE;
 	}
 	case 27: {


### PR DESCRIPTION
Fix: When pendulum summon is disabled by Solemn Warning, the trigger effect of EVENT_TO_GRAVE, etc cannot be activated immediately.

When pendulum summoning, if there are some monsters are disabled but some are not, the trigger effect of EVENT_TO_GRAVE and the trigger effect of EVENT_SPSUMMON_SUCCESS should be activated in a chain.