### PR TITLE
fix Generation Shift

### DIFF
--- a/script/c34460239.lua
+++ b/script/c34460239.lua
@@ -27,9 +27,10 @@ function c34460239.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c34460239.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
+	local code=tc:GetCode()
 	if tc:IsFaceup() and tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)>0 then
 		Duel.BreakEffect()
-		local hc=Duel.GetFirstMatchingCard(c34460239.filter2,tp,LOCATION_DECK,0,nil,tc:GetCode())
+		local hc=Duel.GetFirstMatchingCard(c34460239.filter2,tp,LOCATION_DECK,0,nil,code)
 		if hc then
 			Duel.SendtoHand(hc,nil,REASON_EFFECT)
 			Duel.ConfirmCards(1-tp,hc)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14024
 Q.「プロト・サイバー・ドラゴン」が、自身の『このカードのカード名は、フィールド上に表側表示で存在する限り「サイバー・ドラゴン」として扱う』効果によって、「サイバー・ドラゴン」として扱われています。

その「プロト・サイバー・ドラゴン」を対象として「ジェネレーション・チェンジ」を発動する場合、どのように処理を行いますか？
A.自身の効果によってカード名が「サイバー・ドラゴン」として扱われている「プロト・サイバー・ドラゴン」を対象に選択して「ジェネレーション・チェンジ」を発動する場合、その効果処理によって手札に加えるカードは「サイバー・ドラゴン」になります。