### PR TITLE
fix

### DIFF
--- a/script/c2055403.lua
+++ b/script/c2055403.lua
@@ -10,7 +10,8 @@ function c2055403.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c2055403.filter(c,tp)
-	return c:GetSummonPlayer()~=tp and bit.band(c:GetSummonLocation(),LOCATION_HAND+LOCATION_EXTRA)~=0 and c:IsAbleToDeck()
+	return c:GetSummonPlayer()~=tp and bit.band(c:GetSummonLocation(),LOCATION_HAND+LOCATION_EXTRA)~=0
+		and c:IsAbleToDeck() and c:IsLocation(LOCATION_MZONE)
 end
 function c2055403.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=eg:Filter(c2055403.filter,nil,tp)

--- a/script/c24919805.lua
+++ b/script/c24919805.lua
@@ -15,6 +15,7 @@ function c24919805.initial_effect(c)
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetCondition(c24919805.regcon)
 	e2:SetOperation(c24919805.regop)
 	c:RegisterEffect(e2)
 end
@@ -37,6 +38,9 @@ end
 function c24919805.damop(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	Duel.Damage(p,d,REASON_EFFECT)
+end
+function c24919805.regcon(e,tp,eg,ep,ev,re,r,rp)
+	return not e:GetHandler():IsReason(REASON_RETURN)
 end
 function c24919805.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/script/c464362.lua
+++ b/script/c464362.lua
@@ -36,7 +36,7 @@ function c464362.mfilter(c,mg)
 	return (c:IsCode(30068120) or c:IsHasEffect(EFFECT_FUSION_SUBSTITUTE)) and mg:IsExists(Card.IsSetCard,1,c,0xa9)
 end
 function c464362.fscon(e,mg,gc)
-	if mg==nil then return false end
+	if mg==nil then return true end
 	if gc then return (gc:IsCode(30068120) or gc:IsHasEffect(EFFECT_FUSION_SUBSTITUTE))
 		and mg:IsExists(Card.IsSetCard,1,gc,0xa9) end
 	return mg:IsExists(c464362.mfilter,1,nil,mg)

--- a/script/c6733059.lua
+++ b/script/c6733059.lua
@@ -6,7 +6,6 @@ function c6733059.initial_effect(c)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetHintTiming(0,0x1c0)
 	e1:SetCost(c6733059.cost1)
-	e1:SetOperation(c6733059.operation)
 	c:RegisterEffect(e1)
 	--instant(chain)
 	local e2=Effect.CreateEffect(c)
@@ -28,66 +27,48 @@ function c6733059.tfilter(c,lv)
 end
 function c6733059.cost1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	e:SetLabel(0)
-	local cg=Duel.GetMatchingGroup(c6733059.cfilter,tp,LOCATION_GRAVE,0,nil)
-	local tg=Duel.GetMatchingGroup(c6733059.tfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,cg:GetCount())
-	if tg:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(6733059,0)) then
-		local lvt={}
-		local tc=tg:GetFirst()
-		while tc do
-			local tlv=tc:GetLevel()
-			lvt[tlv]=tlv
-			tc=tg:GetNext()
-		end
-		local pc=1
-		for i=1,12 do
-			if lvt[i] then lvt[i]=nil lvt[pc]=i pc=pc+1 end
-		end
-		lvt[pc]=nil
-		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(6733059,2))
-		local lv=Duel.AnnounceNumber(tp,table.unpack(lvt))
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-		local rg=cg:Select(tp,lv,lv,nil)
-		Duel.Remove(rg,POS_FACEUP,REASON_COST)
-		Duel.SetOperationInfo(0,CATEGORY_DESTROY,tg,1,0,0)
-		Duel.SetTargetParam(lv)
+	if c6733059.cost2(e,tp,eg,ep,ev,re,r,rp,0) and Duel.SelectYesNo(tp,aux.Stringid(6733059,0)) then
+		e:SetCategory(CATEGORY_DESTROY)
+		e:SetOperation(c6733059.operation)
+		c6733059.cost2(e,tp,eg,ep,ev,re,r,rp,1)
+	else
+		e:SetCategory(0)
+		e:SetOperation(nil)
+		e:SetLabel(0)
 	end
 end
 function c6733059.cost2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local cg=Duel.GetMatchingGroup(c6733059.cfilter,tp,LOCATION_GRAVE,0,nil)
 		local tg=Duel.GetMatchingGroup(c6733059.tfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,cg:GetCount())
-		return tg:GetCount()>0
+		return tg:GetCount()>0 and Duel.GetFlagEffect(tp,6733059)==0
 	end
-	e:SetLabel(0)
 	local cg=Duel.GetMatchingGroup(c6733059.cfilter,tp,LOCATION_GRAVE,0,nil)
 	local tg=Duel.GetMatchingGroup(c6733059.tfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,cg:GetCount())
 	local lvt={}
 	local tc=tg:GetFirst()
+	local i=1
 	while tc do
 		local tlv=tc:GetLevel()
-		lvt[tlv]=tlv
+		lvt[i]=tlv
 		tc=tg:GetNext()
+		i=i+1
 	end
-	local pc=1
-	for i=1,12 do
-		if lvt[i] then lvt[i]=nil lvt[pc]=i pc=pc+1 end
-	end
-	lvt[pc]=nil
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(6733059,2))
 	local lv=Duel.AnnounceNumber(tp,table.unpack(lvt))
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local rg=cg:Select(tp,lv,lv,nil)
 	Duel.Remove(rg,POS_FACEUP,REASON_COST)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tg,1,0,0)
-	Duel.SetTargetParam(lv)
+	e:SetLabel(lv)
+	Duel.RegisterFlagEffect(tp,6733059,RESET_CHAIN,0,1)
 end
 function c6733059.dfilter(c,lv)
 	return c:IsFaceup() and c:GetLevel()==lv and c:IsDestructable()
 end
 function c6733059.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
-	local lv=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
+	local lv=e:GetLabel()
 	if lv==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectMatchingCard(tp,c6733059.dfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,lv)

--- a/script/c79606837.lua
+++ b/script/c79606837.lua
@@ -33,6 +33,7 @@ function c79606837.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e3:SetCode(EVENT_TO_GRAVE)
 	e3:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e3:SetCondition(c79606837.thcon)
 	e3:SetTarget(c79606837.thtg)
 	e3:SetOperation(c79606837.thop)
 	c:RegisterEffect(e3)
@@ -61,6 +62,9 @@ function c79606837.disop(e,tp,eg,ep,ev,re,r,rp)
 	if re:GetHandler():IsRelateToEffect(re) then
 		Duel.Destroy(eg,REASON_EFFECT)
 	end
+end
+function c79606837.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return not e:GetHandler():IsReason(REASON_RETURN)
 end
 function c79606837.filter(c)
 	return c:IsType(TYPE_RITUAL) and c:IsAbleToHand()

--- a/script/c80889750.lua
+++ b/script/c80889750.lua
@@ -43,7 +43,7 @@ function c80889750.mfilter2(c)
 	return c:IsSetCard(0xa9) or c:IsSetCard(0xc3)
 end
 function c80889750.fscon(e,mg,gc)
-	if mg==nil then return false end
+	if mg==nil then return true end
 	if gc then return false end
 	return mg:IsExists(c80889750.mfilter1,1,nil,mg)
 end


### PR DESCRIPTION
Time-Space Trap Hole
Fix: When it is activated respond to the special summon of Rank-Up-Magic - The Seventh One, the Xyz material is sent to the Main Deck instead.

Ruffian Railcar, Herald of the Arc Light
Exclude REASON_RETURN

Frightfur Tiger, Frightfur Sabre Tiger
There is no restriction that "Must be Fusion Summoned with the above Fusion Material Monsters".

Skull Lair
There is no restriction on the level of monster that to be destroyed and the effect of Skull Lair can only be activated once in a chain.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12599&keyword=&tag=-1