### PR TITLE
fix an infinite loop

### DIFF
--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -1039,8 +1039,10 @@ int32 field::self_destroy(uint16 step) {
 	}
 	case 1: {
 		core.self_destroy_set.clear();
-		if(!(core.global_flag & GLOBALFLAG_SELF_TOGRAVE))
+		if(!(core.global_flag & GLOBALFLAG_SELF_TOGRAVE)) {
+			core.operated_set.clear();
 			return TRUE;
+		}
 		core.units.begin()->arg1 = returns.ivalue[0];
 		if(!core.self_tograve_set.empty())
 			send_to(&core.self_tograve_set, 0, REASON_EFFECT, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
@@ -1050,6 +1052,7 @@ int32 field::self_destroy(uint16 step) {
 	}
 	case 2: {
 		core.self_tograve_set.clear();
+		core.operated_set.clear();
 		returns.ivalue[0] += core.units.begin()->arg1;
 		return TRUE;
 	}


### PR DESCRIPTION
an infinite loop between control adjust and self destroy adjust.
when Graydle Eagle is activated and target a Buring Abyss monster and there are some other monsters on the field, then the Buring Abyss monster will be sent to grave and move to field infinitely.
The loop:
process control_adjust, step 3: move_to_field
process move_to_field, step 2: adjust_instant
then process self_destroy calls destroy function, whick makes core.operated_set nonempty
return to control_adjust process, step 3, line 1000: the condition if(core.operated_set.size() == 0) is false and add a move_to_field process again. a loop forms