### PR TITLE
Fix Advanced Heraldry Art & Gazer Shark

### DIFF
--- a/script/c23536866.lua
+++ b/script/c23536866.lua
@@ -30,6 +30,9 @@ end
 function c23536866.mfilter2(c,mc)
 	return c.xyz_filter(mc)
 end
+function c23536866.mfilter3(c,mc,exg)
+	return exg:IsExists(Card.IsXyzSummonable,1,nil,Group.FromCards(c,mc))
+end
 function c23536866.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	local mg=Duel.GetMatchingGroup(c23536866.filter,tp,LOCATION_GRAVE,0,nil,e,tp)
@@ -40,9 +43,8 @@ function c23536866.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local sg1=mg:FilterSelect(tp,c23536866.mfilter1,1,1,nil,exg)
 	local tc1=sg1:GetFirst()
-	local exg2=exg:Filter(c23536866.mfilter2,nil,tc1)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local sg2=mg:FilterSelect(tp,c23536866.mfilter1,1,1,tc1,exg2)
+	local sg2=mg:FilterSelect(tp,c23536866.mfilter3,1,1,tc1,tc1,exg)
 	sg1:Merge(sg2)
 	Duel.SetTargetCard(sg1)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,sg1,2,0,0)

--- a/script/c61314842.lua
+++ b/script/c61314842.lua
@@ -23,6 +23,9 @@ end
 function c61314842.mfilter2(c,mc)
 	return c.xyz_filter(mc)
 end
+function c61314842.mfilter3(c,mc,exg)
+	return exg:IsExists(Card.IsXyzSummonable,1,nil,Group.FromCards(c,mc))
+end
 function c61314842.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	local mg=Duel.GetMatchingGroup(c61314842.filter,tp,LOCATION_GRAVE,0,nil,e,tp)
@@ -33,9 +36,8 @@ function c61314842.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local sg1=mg:FilterSelect(tp,c61314842.mfilter1,1,1,nil,exg)
 	local tc1=sg1:GetFirst()
-	local exg2=exg:Filter(c61314842.mfilter2,nil,tc1)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local sg2=mg:FilterSelect(tp,c61314842.mfilter1,1,1,tc1,exg2)
+	local sg2=mg:FilterSelect(tp,c61314842.mfilter3,1,1,tc1,tc1,exg)
 	sg1:Merge(sg2)
 	Duel.SetTargetCard(sg1)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,sg1,2,0,0)


### PR DESCRIPTION
「古遗物的解放」的写法允许多种意外情况，比如未来皇霍普那样的用超量怪兽去超量召唤，以及其他将来可能出现的非传统超量手续。或许应该在这里把这类的效果统一为「古遗物的解放」的写法，以预防意外。