### PR TITLE
fix Delinquent Duo

### DIFF
--- a/script/c44763025.lua
+++ b/script/c44763025.lua
@@ -16,7 +16,7 @@ function c44763025.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,1000)
 end
 function c44763025.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)>1 end
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)>0 end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,1-tp,2)
 end


### PR DESCRIPTION
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
相手の手札が１枚のみの場合「いたずら好きな双子悪魔」を発動できますか？ 
A. 
相手の手札が1枚の場合であっても「いたずら好きな双子悪魔」を発動する事はできます。 
結果的に、相手はその手札1枚を捨てる事になります。 

これからも遊戯王オフィシャルカードゲームをはじめ、コナミの商品をよろしくお願い申し上げます。