### PR TITLE
Update c81907872.lua

### DIFF
--- a/script/c81907872.lua
+++ b/script/c81907872.lua
@@ -48,7 +48,7 @@ function c81907872.posop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c81907872.cfilter(c,tp)
 	return c:IsControler(tp) and c:GetPreviousControler()==tp and c:IsSetCard(0x8d) and c:IsReason(REASON_DESTROY) and c:IsType(TYPE_MONSTER)
-		and (not c:IsReason(REASON_BATTLE) or c==Duel.GetAttackTarget())
+		and (not c:IsReason(REASON_BATTLE) or c==Duel.GetAttackTarget()) and not c:IsPreviousLocation(LOCATION_SZONE)
 end
 function c81907872.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return rp~=tp and eg:IsExists(c81907872.cfilter,1,nil,tp)


### PR DESCRIPTION
Fix: Now does not activate if a Ghostrick Monster in the Spell/Trap zone is destroyed.