### PR TITLE
fix control adjust(Remove Brainwashing) and unique cards(self destroy)

### DIFF
--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -1014,13 +1014,19 @@ int32 field::control_adjust(uint16 step) {
 		card_set* adjust_set = (card_set*)core.units.begin()->ptarget;
 		delete adjust_set;
 		core.control_adjust_set[0].insert(core.control_adjust_set[1].begin(), core.control_adjust_set[1].end());
-		for(auto cit = core.control_adjust_set[0].begin(); cit != core.control_adjust_set[0].end(); ++cit) {
-			(*cit)->filter_disable_related_cards();
-			if((*cit)->unique_code)
-				add_unique_card(*cit);
-			raise_single_event((*cit), 0, EVENT_CONTROL_CHANGED, 0, REASON_RULE, 0, 0, 0);
+		for(auto cit = core.control_adjust_set[0].begin(); cit != core.control_adjust_set[0].end(); ) {
+			card* pcard = *cit++;
+			if(!(pcard->current.location & LOCATION_ONFIELD)) {
+				core.control_adjust_set[0].erase(pcard);
+				continue;
+			}
+			pcard->filter_disable_related_cards();
+			if(pcard->unique_code)
+				add_unique_card(pcard);
+			raise_single_event(pcard, 0, EVENT_CONTROL_CHANGED, 0, REASON_RULE, 0, 0, 0);
 		}
-		raise_event(&core.control_adjust_set[0], EVENT_CONTROL_CHANGED, 0, 0, 0, 0, 0);
+		if(core.control_adjust_set[0].size())
+			raise_event(&core.control_adjust_set[0], EVENT_CONTROL_CHANGED, 0, 0, 0, 0, 0);
 		process_single_event();
 		process_instant_event();
 		return FALSE;


### PR DESCRIPTION
When Remove Brainwashing is applying and there is a Kaiju monster on field, special sommon another Kaiju monster on opponent's field, then this Kaiju monster returns control and is destroyed, but it is added to unique cards set in the control adjust step.
This will result that if the initial Kaiju monster on field is destroyed and spcial sommon another Kaiju on opponent's field, this Kaiju monster returns control and still be destroyed although there is no other Kaiju monster on field.