### PR TITLE
fix effect type

### DIFF
--- a/script/c25857246.lua
+++ b/script/c25857246.lua
@@ -11,7 +11,7 @@ function c25857246.initial_effect(c)
 	--atk
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(25857246,0))
-	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
 	e2:SetRange(LOCATION_HAND)
 	e2:SetCountLimit(1,25857246)


### PR DESCRIPTION
Effect type should be Trigger

■『①：相手モンスターの攻撃宣言時に自分の墓地の「影霊衣」カード１枚を除外し、このカードを手札から捨てて発動できる。その攻撃を無効にし、その後バトルフェイズを終了する』モンスター効果は、手札にて発動する誘発効果です。
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11487&request_locale=ja