### PR TITLE
fix

### DIFF
--- a/script/c18175965.lua
+++ b/script/c18175965.lua
@@ -98,9 +98,9 @@ function c18175965.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
 function c18175965.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,true,false) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_HANDES,0,0,tp,1)
+	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end
 function c18175965.spop2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
Even if Pot of Duality has been activated, when Guardian Dreadscythe is sent to grave from field, its effect has to be activated.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7313&keyword=&tag=-1