### PR TITLE
Fix Scattershot tag

### DIFF
--- a/script/c69750546.lua
+++ b/script/c69750546.lua
@@ -47,6 +47,9 @@ function c69750546.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c69750546.costfilter,tp,LOCATION_DECK+LOCATION_HAND,0,2,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g=Duel.GetMatchingGroup(c69750546.costfilter,tp,LOCATION_DECK+LOCATION_HAND,0,nil)
+	if g:GetCount()>2 then
+		g=Duel.SelectMatchingCard(tp,c69750546.costfilter,tp,LOCATION_DECK+LOCATION_HAND,0,2,2,nil)
+	end
 	Duel.SendtoGrave(g,REASON_COST)
 end
 function c69750546.destg(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION
In a tag duel, if you have more than 2 Scattershot in your deck/hand due
to getting your partners extra copies you shouldn't send more than 2 to
the grave to activate the destruction effect.