### PR TITLE
fix Darklord Desire

### DIFF
--- a/script/c55690251.lua
+++ b/script/c55690251.lua
@@ -23,7 +23,7 @@ function c55690251.initial_effect(c)
 	--send to grave
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(55690251,1))
-	e4:SetCategory(CATEGORY_REMOVE)
+	e4:SetCategory(CATEGORY_TOGRAVE)
 	e4:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e4:SetType(EFFECT_TYPE_IGNITION)
 	e4:SetCountLimit(1)
@@ -66,7 +66,7 @@ function c55690251.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)
 		e1:SetValue(-1000)
 		c:RegisterEffect(e1)
-		if tc and tc:IsRelateToEffect(e) then
+		if tc and tc:IsRelateToEffect(e) and not c:IsHasEffect(EFFECT_REVERSE_UPDATE) then
 			Duel.SendtoGrave(tc,REASON_EFFECT)
 		end
 	end


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%C2%C4%C5%B7%BB%C8%A5%C7%A5%A3%A5%B6%A5%A4%A5%A2%A1%D5#r32def2c
Ｑ：《あまのじゃくの呪い》の効果が適用されている時に墓地へ送る効果解決時にこのカードの攻撃力がダウンする代わりにアップした場合、墓地へ送る処理は行われますか？
Ａ：いいえ、このカードの効果で攻撃力がダウンする処理ができなかった場合、墓地へ送る処理は行われません。(14/10/25)