### PR TITLE
fix Harpie Lady Phoenix Formation

### DIFF
--- a/script/c86308219.lua
+++ b/script/c86308219.lua
@@ -20,7 +20,7 @@ function c86308219.cfilter(c)
 	return c:IsFaceup() and (c:IsCode(76812113) or c:IsCode(12206212))
 end
 function c86308219.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c86308219.cfilter,tp,LOCATION_MZONE,0,3,nil)
+	return Duel.IsExistingMatchingCard(c86308219.cfilter,tp,LOCATION_ONFIELD,0,3,nil)
 end
 function c86308219.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(86308219,tp,ACTIVITY_SPSUMMON)==0


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13619
Q.自分フィールドに装備カード扱いの、「ハーピィ・レディ」を含めて、３体の「ハーピィ・レディ」が存在する場合、「ハーピィ・レディ －鳳凰の陣－」を発動する事はできますか？
A.できます。 