### PR TITLE
fix Kozmo Sliprider

### DIFF
--- a/script/c94454495.lua
+++ b/script/c94454495.lua
@@ -45,7 +45,7 @@ function c94454495.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsReason(REASON_DESTROY) and c:IsReason(REASON_BATTLE+REASON_EFFECT)
 end
 function c94454495.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() and e:GetHandler():IsLocation(LOCATION_GRAVE) end
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
 end
 function c94454495.spfilter(c,e,tp)


### PR DESCRIPTION
If Sliprider is destroyed, send to the grave and then banished in the same chain (for example using torrential on the summon of trishula) you are able to use his effect without paying the cost. This should get rid of that problem.