### PR TITLE
fix Train Connection

### DIFF
--- a/script/c60879050.lua
+++ b/script/c60879050.lua
@@ -39,7 +39,7 @@ function c60879050.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c60879050.eqlimit(e,c)
-	return e:GetHandler():GetEquipTarget()==c
+	return e:GetHandler():GetEquipTarget()==c and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH)
 end
 function c60879050.filter(c)
 	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH)


### PR DESCRIPTION
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「DNA移植手術」の効果で地属性となっている「幻獣機ヤクルスラーン」を対象に「機関連結」を発動し装備しました。「DNA移植手術」が破壊された場合「幻獣機ヤクルスラーン」の属性は風属性になりますが装備されている「機関連結」は破壊されますか？ 
A. 
「DNA移植手術」が破壊され、「幻獣機ヤクルスラーン」の属性が【風属性】に戻った場合、「機関連結」を装備し続ける事ができなくなりますので、装備していた「機関連結」は破壊されます。