### PR TITLE
fix Relay Soul

### DIFF
--- a/script/c42776960.lua
+++ b/script/c42776960.lua
@@ -28,23 +28,27 @@ function c42776960.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_FIELD)
 		e1:SetCode(EFFECT_CHANGE_DAMAGE)
 		e1:SetRange(LOCATION_MZONE)
-		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_AVAILABLE_BD+EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
 		e1:SetTargetRange(1,0)
-		e1:SetValue(0)
-		tc:RegisterEffect(e1)
+		e1:SetValue(c42776960.val)
+		tc:RegisterEffect(e1,true)
 		local e2=e1:Clone()
 		e2:SetCode(EFFECT_NO_EFFECT_DAMAGE)
 		e2:SetReset(RESET_EVENT+0x1fe0000)
-		tc:RegisterEffect(e2)
+		tc:RegisterEffect(e2,true)
 		local e3=Effect.CreateEffect(e:GetHandler())
 		e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 		e3:SetCode(EVENT_LEAVE_FIELD)
 		e3:SetLabel(1-tp)
 		e3:SetOperation(c42776960.leaveop)
 		e3:SetReset(RESET_EVENT+0xc020000)
-		tc:RegisterEffect(e3)
+		tc:RegisterEffect(e3,true)
 	end
+end
+function c42776960.val(e,re,val,r,rp,rc)
+	if e:GetHandlerPlayer()==e:GetOwnerPlayer() then return 0 end
+	return val
 end
 function c42776960.leaveop(e,tp,eg,ep,ev,re,r,rp)
 	local WIN_REASON_RELAY_SOUL=0x1a


### PR DESCRIPTION
Q. 
「Ｎｏ.１１ ビッグ・アイ」の効果で相手の「魂のリレー」の効果で特殊召喚したモンスターのコントロールを得た場合、コントロールを得たモンスターが存在する鍵リ自分はダメージを受けなくなりますか？ 
A. 
「魂のリレー」の効果で特殊召喚したモンスターのコントロールを得た場合、コントロールが変わった事で『自分が受ける全てのダメージは０になる』効果は適用されていない状態になります。 
したがって、「No.11 ビッグ・アイ」の効果によってコントロールを得たとしても、自分の受ける全てのダメージが0になる事はありません。

Q. 
「魂のリレー」の効果で「E・HERO ワイルドマン」を特殊召喚した場合『この効果で特殊召喚したモンスターが自分フィールドに表側表示で存在する限り、自分が受ける全てのダメージは０になる。そのモンスターがフィールドから離れた時に相手はデュエルに勝利する』効果は適用されますか？ 
A. 
「魂のリレー」の効果で特殊召喚するモンスターは、「魂のリレー」の効果が適用された状態で特殊召喚されます。 
よって、「魂のリレー」の効果で「E・HERO ワイルドマン」を特殊召喚した場合であっても、「魂のリレー」の効果が適用されています。