### PR TITLE
fix Starduston

### DIFF
--- a/script/c95403418.lua
+++ b/script/c95403418.lua
@@ -75,5 +75,5 @@ function c95403418.spop(e,tp,eg,ep,ev,re,r,rp,c)
 end
 function c95403418.descon(e)
 	local tp=e:GetHandlerPlayer()
-	return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)
+	return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)<Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)
 end


### PR DESCRIPTION
Fix this: If your opponent controls more monsters than you do, Starduston is destroyed.