### PR TITLE
display number of pendulum in extra deck

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -58,6 +58,8 @@ void ClientField::Clear() {
 	for(auto sit = overlay_cards.begin(); sit != overlay_cards.end(); ++sit)
 		delete *sit;
 	overlay_cards.clear();
+	extra_p_count[0] = 0;
+	extra_p_count[1] = 0;
 	chains.clear();
 	disabled_field = 0;
 	deck_act = false;
@@ -194,6 +196,8 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 			extra[controler][0] = pcard;
 			pcard->sequence = 0;
 		}
+		if ((pcard->type & TYPE_PENDULUM) && (pcard->position & POS_FACEUP))
+			extra_p_count[controler]++;
 		break;
 	}
 	}
@@ -262,6 +266,8 @@ ClientCard* ClientField::RemoveCard(int controler, int location, int sequence) {
 			extra[controler][i]->mTransform.setTranslation(extra[controler][i]->curPos);
 		}
 		extra[controler].erase(extra[controler].end() - 1);
+		if ((pcard->type & TYPE_PENDULUM) && (pcard->position & POS_FACEUP))
+			extra_p_count[controler]--;
 		break;
 	}
 	}
@@ -495,6 +501,7 @@ void ClientField::ReplaySwap() {
 	std::swap(grave[0], grave[1]);
 	std::swap(remove[0], remove[1]);
 	std::swap(extra[0], extra[1]);
+	std::swap(extra_p_count[0], extra_p_count[1]);
 	for(int p = 0; p < 2; ++p) {
 		for(auto cit = deck[p].begin(); cit != deck[p].end(); ++cit) {
 			(*cit)->controler = 1 - (*cit)->controler;

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -182,8 +182,18 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 		break;
 	}
 	case LOCATION_EXTRA: {
-		extra[controler].push_back(pcard);
-		pcard->sequence = extra[controler].size() - 1;
+		if (sequence != 0 || extra[controler].size() == 0) {
+			extra[controler].push_back(pcard);
+			pcard->sequence = extra[controler].size() - 1;
+		} else {
+			extra[controler].push_back(0);
+			for(int i = extra[controler].size() - 1; i > 0; --i) {
+				extra[controler][i] = extra[controler][i - 1];
+				extra[controler][i]->sequence++;
+			}
+			extra[controler][0] = pcard;
+			pcard->sequence = 0;
+		}
 		break;
 	}
 	}

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -40,6 +40,7 @@ public:
 	std::vector<int> activatable_descs;
 	std::vector<int> select_options;
 	std::vector<ChainInfo> chains;
+	int extra_p_count[2];
 	
 	size_t selected_option;
 	ClientCard* attacker;

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -182,8 +182,15 @@ const wchar_t* DataManager::GetCounterName(int code) {
 		return unknown_string;
 	return csit->second;
 }
-const wchar_t* DataManager::GetNumString(int num) {
-	return numStrings[num];
+const wchar_t* DataManager::GetNumString(int num, bool bracket) {
+	if(!bracket)
+		return numStrings[num];
+	wchar_t* p = numBuffer;
+	*p++ = L'(';
+	BufferIO::CopyWStrRef(numStrings[num], p, 4);
+	*p = L')';
+	*++p = 0;
+	return numBuffer;
 }
 const wchar_t* DataManager::FormatLocation(int location, int sequence) {
 	if(location == 0x8) {

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -23,7 +23,7 @@ public:
 	const wchar_t* GetSysString(int code);
 	const wchar_t* GetVictoryString(int code);
 	const wchar_t* GetCounterName(int code);
-	const wchar_t* GetNumString(int num);
+	const wchar_t* GetNumString(int num, bool bracket = false);
 	const wchar_t* FormatLocation(int location, int sequence);
 	const wchar_t* FormatAttribute(int attribute);
 	const wchar_t* FormatRace(int race);
@@ -36,6 +36,7 @@ public:
 
 	wchar_t* _sysStrings[2048];
 	wchar_t numStrings[256][4];
+	wchar_t numBuffer[6];
 	wchar_t attBuffer[128];
 	wchar_t racBuffer[128];
 	wchar_t tpBuffer[128];

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -423,8 +423,10 @@ void Game::DrawMisc() {
 		adFont->draw(pcard->rscstring, recti(464, 246, 496, 266), 0xffffffff, true, false, 0);
 	}
 	if(dField.extra[0].size()) {
-		numFont->draw(dataManager.GetNumString(dField.extra[0].size()), recti(330, 562, 381, 552), 0xff000000, true, false, 0);
-		numFont->draw(dataManager.GetNumString(dField.extra[0].size()), recti(330, 563, 383, 553), 0xffffff00, true, false, 0);
+		numFont->draw(dataManager.GetNumString(dField.extra[0].size()), recti(320, 562, 371, 552), 0xff000000, true, false, 0);
+		numFont->draw(dataManager.GetNumString(dField.extra[0].size()), recti(320, 563, 373, 553), 0xffffff00, true, false, 0);
+		numFont->draw(dataManager.GetNumString(dField.extra_p_count[0], true), recti(340, 562, 391, 552), 0xff000000, true, false, 0);
+		numFont->draw(dataManager.GetNumString(dField.extra_p_count[0], true), recti(340, 563, 393, 553), 0xffffff00, true, false, 0);
 	}
 	if(dField.deck[0].size()) {
 		numFont->draw(dataManager.GetNumString(dField.deck[0].size()), recti(907, 562, 1021, 552), 0xff000000, true, false, 0);
@@ -439,8 +441,10 @@ void Game::DrawMisc() {
 		numFont->draw(dataManager.GetNumString(dField.remove[0].size()), recti(1015, 376, 959, 381), 0xffffff00, true, false, 0);
 	}
 	if(dField.extra[1].size()) {
-		numFont->draw(dataManager.GetNumString(dField.extra[1].size()), recti(818, 207, 908, 232), 0xff000000, true, false, 0);
-		numFont->draw(dataManager.GetNumString(dField.extra[1].size()), recti(818, 208, 910, 233), 0xffffff00, true, false, 0);
+		numFont->draw(dataManager.GetNumString(dField.extra[1].size()), recti(808, 207, 898, 232), 0xff000000, true, false, 0);
+		numFont->draw(dataManager.GetNumString(dField.extra[1].size()), recti(808, 208, 900, 233), 0xffffff00, true, false, 0);
+		numFont->draw(dataManager.GetNumString(dField.extra_p_count[1], true), recti(828, 207, 918, 232), 0xff000000, true, false, 0);
+		numFont->draw(dataManager.GetNumString(dField.extra_p_count[1], true), recti(828, 208, 920, 233), 0xffffff00, true, false, 0);
 	}
 	if(dField.deck[1].size()) {
 		numFont->draw(dataManager.GetNumString(dField.deck[1].size()), recti(465, 207, 481, 232), 0xff000000, true, false, 0);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -3105,6 +3105,8 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 				mainGame->dField.AddCard(ccard, p, LOCATION_REMOVED, seq);
 				mainGame->dField.GetCardLocation(ccard, &ccard->curPos, &ccard->curRot, true);
 			}
+			val = BufferIO::ReadInt8(pbuf);
+			mainGame->dField.extra_p_count[p] = val;
 		}
 		val = BufferIO::ReadInt8(pbuf); //chains
 		for(int i = 0; i < val; ++i) {

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -667,6 +667,8 @@ bool SingleMode::SinglePlayAnalyze(char* msg, unsigned int len) {
 					ClientCard* ccard = new ClientCard;
 					mainGame->dField.AddCard(ccard, p, LOCATION_EXTRA, seq);
 				}
+				val = BufferIO::ReadInt8(pbuf);
+				mainGame->dField.extra_p_count[p] = val;
 			}
 			BufferIO::ReadInt8(pbuf); //chain count, always 0
 			SinglePlayReload();

--- a/ocgcore/field.cpp
+++ b/ocgcore/field.cpp
@@ -41,6 +41,7 @@ field::field(duel* pduel) {
 		player[i].draw_count = 1;
 		player[i].disabled_location = 0;
 		player[i].used_location = 0;
+		player[i].extra_p_count = 0;
 		player[i].list_mzone.reserve(5);
 		player[i].list_szone.reserve(8);
 		player[i].list_main.reserve(45);
@@ -128,6 +129,7 @@ void field::reload_field_info() {
 		pduel->write_buffer8(player[playerid].list_grave.size());
 		pduel->write_buffer8(player[playerid].list_remove.size());
 		pduel->write_buffer8(player[playerid].list_extra.size());
+		pduel->write_buffer8(player[playerid].extra_p_count);
 	}
 	pduel->write_buffer8(core.current_chain.size());
 	for(auto chit = core.current_chain.begin(); chit != core.current_chain.end(); ++chit) {

--- a/ocgcore/field.cpp
+++ b/ocgcore/field.cpp
@@ -148,6 +148,7 @@ void field::add_card(uint8 playerid, card* pcard, uint8 location, uint8 sequence
 		return;
 	if((pcard->data.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ)) && (location & (LOCATION_HAND | LOCATION_DECK))) {
 		location = LOCATION_EXTRA;
+		sequence = 1;
 		pcard->operation_param = (pcard->operation_param & 0x00ffffff) | (POS_FACEDOWN_DEFENCE << 24);
 	}
 	pcard->current.controler = playerid;
@@ -193,8 +194,13 @@ void field::add_card(uint8 playerid, card* pcard, uint8 location, uint8 sequence
 		pcard->current.sequence = player[playerid].list_remove.size() - 1;
 		break;
 	case LOCATION_EXTRA:
-		player[playerid].list_extra.push_back(pcard);
-		pcard->current.sequence = player[playerid].list_extra.size() - 1;
+		if (sequence == 1) {
+			player[playerid].list_extra.insert(player[playerid].list_extra.begin(), pcard);
+			reset_sequence(playerid, LOCATION_EXTRA);
+		} else {
+			player[playerid].list_extra.push_back(pcard);
+			pcard->current.sequence = player[playerid].list_extra.size() - 1;
+		}
 		break;
 	}
 	pcard->apply_field_effect();
@@ -260,6 +266,7 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 	uint8 presequence = pcard->current.sequence;
 	if((pcard->data.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ)) && (location & (LOCATION_HAND | LOCATION_DECK))) {
 		location = LOCATION_EXTRA;
+		sequence = 1;
 		pcard->operation_param = (pcard->operation_param & 0x00ffffff) | (POS_FACEDOWN_DEFENCE << 24);
 	}
 	if (pcard->current.location) {
@@ -367,6 +374,7 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 			        && (((pcard->current.location == LOCATION_MZONE) && !pcard->is_status(STATUS_SUMMON_DISABLED))
 			        || ((pcard->current.location == LOCATION_SZONE) && !pcard->is_status(STATUS_ACTIVATE_DISABLED)))) {
 				location = LOCATION_EXTRA;
+				sequence = 0;
 				pcard->operation_param = (pcard->operation_param & 0x00ffffff) | (POS_FACEUP_DEFENCE << 24);
 			}
 			remove_card(pcard);

--- a/ocgcore/field.h
+++ b/ocgcore/field.h
@@ -71,6 +71,7 @@ struct player_info {
 	int32 draw_count;
 	uint32 used_location;
 	uint32 disabled_location;
+	uint32 extra_p_count;
 	card_vector list_mzone;
 	card_vector list_szone;
 	card_vector list_main;

--- a/ocgcore/libdebug.cpp
+++ b/ocgcore/libdebug.cpp
@@ -45,6 +45,8 @@ int32 scriptlib::debug_add_card(lua_State *L) {
 			pcard->enable_field_effect(TRUE);
 			pduel->game_field->adjust_instant();
 		}
+		if((pcard->data.type & TYPE_PENDULUM) && (location == LOCATION_EXTRA) && (position & POS_FACEUP))
+			pduel->game_field->player[playerid].extra_p_count += 1;
 		if(proc)
 			pcard->set_status(STATUS_PROC_COMPLETE, TRUE);
 		interpreter::card2value(L, pcard);


### PR DESCRIPTION
also send Fusion/Synchro/Xyz monsters to the bottom of extra deck, making pendulum cards always on the top of extra deck