### PR TITLE
fix Darklight

### DIFF
--- a/script/c29876529.lua
+++ b/script/c29876529.lua
@@ -10,6 +10,21 @@ function c29876529.initial_effect(c)
 	e1:SetTarget(c29876529.target)
 	e1:SetOperation(c29876529.activate)
 	c:RegisterEffect(e1)
+	if not c29876529.global_check then
+		c29876529.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_SPSUMMON_SUCCESS)
+		ge1:SetOperation(c29876529.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
+end
+function c29876529.checkop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	while tc do
+		tc:RegisterFlagEffect(29876529,RESET_EVENT+0x46c0000+RESET_PHASE+PHASE_END,0,1)
+		tc=eg:GetNext()
+	end
 end
 function c29876529.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)
@@ -20,7 +35,7 @@ function c29876529.costfilter(c)
 		and Duel.IsExistingMatchingCard(c29876529.dfilter,0,LOCATION_MZONE,LOCATION_MZONE,1,c)
 end
 function c29876529.dfilter(c)
-	return c:GetTurnID()==Duel.GetTurnCount() and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)~=0 and c:IsDestructable()
+	return c:GetFlagEffect(29876529)~=0 and c:IsDestructable()
 end
 function c29876529.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then


### PR DESCRIPTION
Fix this: If monsters are not Special Summoned this turn is returned to the field, it is destroyed by "Darklight" effect.