### PR TITLE
fix EFFECT_NECRO_VALLEY

### DIFF
--- a/script/c57734012.lua
+++ b/script/c57734012.lua
@@ -44,7 +44,7 @@ function c57734012.filter1(c,e,tp)
 	if not m then return false end
 	local no=m.xyz_number
 	return no and no>=101 and no<=107 and c:IsSetCard(0x48) and not c:IsSetCard(0x1048)
-		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and Duel.IsExistingMatchingCard(c57734012.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,no)
 end
 function c57734012.filter2(c,e,tp,mc,no)
@@ -64,7 +64,7 @@ function c57734012.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g1=Duel.SelectMatchingCard(tp,c57734012.filter1,tp,LOCATION_GRAVE+LOCATION_EXTRA,0,1,1,nil,e,tp)
 	local tc1=g1:GetFirst()
-	if tc1 and Duel.SpecialSummon(tc1,0,tp,tp,false,false,POS_FACEUP)~=0 then
+	if tc1 and not tc1:IsHasEffect(EFFECT_NECRO_VALLEY) and Duel.SpecialSummon(tc1,0,tp,tp,false,false,POS_FACEUP)~=0 then
 		local m=_G["c"..tc1:GetCode()]
 		if not m then return end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c67273917.lua
+++ b/script/c67273917.lua
@@ -24,7 +24,6 @@ function c67273917.thcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c67273917.filter(c)
 	return c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_FIRE) and c:IsAbleToHand()
-		and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c67273917.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -44,7 +43,7 @@ function c67273917.thop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.Destroy(dg,REASON_EFFECT)~=2 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectMatchingCard(tp,c67273917.filter,tp,LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil)
-	if g:GetCount()>0 then
+	if g:GetCount()>0 and not g:GetFirst():IsHasEffect(EFFECT_NECRO_VALLEY) then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
 	end

--- a/script/c71921856.lua
+++ b/script/c71921856.lua
@@ -33,7 +33,7 @@ function c71921856.initial_effect(c)
 end
 c71921856.xyz_number=79
 function c71921856.filter(c)
-	return c:IsSetCard(0x84) and c:IsType(TYPE_MONSTER) and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
+	return c:IsSetCard(0x84) and c:IsType(TYPE_MONSTER)
 end
 function c71921856.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c71921856.filter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil) end
@@ -43,7 +43,7 @@ function c71921856.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
 	local g=Duel.SelectMatchingCard(tp,c71921856.filter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil)
-	if g:GetCount()>0 then
+	if g:GetCount()>0 and not g:GetFirst():IsHasEffect(EFFECT_NECRO_VALLEY) then
 		Duel.Overlay(c,g)
 	end
 end

--- a/script/c93662626.lua
+++ b/script/c93662626.lua
@@ -24,7 +24,6 @@ function c93662626.thcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c93662626.filter(c)
 	return c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_FIRE) and c:IsAbleToHand()
-		and not c:IsHasEffect(EFFECT_NECRO_VALLEY)
 end
 function c93662626.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -44,7 +43,7 @@ function c93662626.thop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.Destroy(dg,REASON_EFFECT)~=2 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectMatchingCard(tp,c93662626.filter,tp,LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil)
-	if g:GetCount()>0 then
+	if g:GetCount()>0 and not g:GetFirst():IsHasEffect(EFFECT_NECRO_VALLEY) then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
 	end


### PR DESCRIPTION
Q. 
「王家の眠る谷－ネクロバレー」適用中に自分の手札に「ＢＫ」と名のついたモンスターが存在せず、自分の墓地に「ＢＫ」と名のついたモンスターが存在する場合、「Ｎｏ.７９ ＢＫ 新星のカイザー」の『自分の手札・墓地から「ＢＫ」と名のついたモンスター１体を選んで、このカードの下に重ねてエクシーズ素材とする』効果を発動できますか？ 
A. 
「王家の眠る谷－ネクロバレー」の効果が適用されている場合でも、「No.79 BK 新星のカイザー 」の効果を発動する事はできます。 
なお、ご質問の状況では、「No.79 BK 新星のカイザー」の下にエクシーズ素材として置くカードが手札にないため無効化されます。

Q. 
「王家の眠る谷－ネクロバレー」適用中に自分のエクストラデッキに「Ｎｏ.１０１」～「Ｎｏ.１０７」のいずれかをカード名に含むモンスターが存在せず、自分の墓地に「Ｎｏ.１０１」～「Ｎｏ.１０７」のいずれかをカード名に含むモンスターが存在する場合、「ＲＵＭ－七皇の剣」を発動できますか？ 
A. 
「王家の眠る谷－ネクロバレー」の効果が適用されている場合でも、「RUM－七皇の剣 」を発動する事はできます。 
なお、ご質問の状況のようにエクストラデッキに『「CNo.」以外の「No.101」～「No.107」のいずれかをカード名に含むモンスター』が存在しない場合、結果的に「RUM－七皇の剣」の効果は無効化されます。

Q. 
「王家の眠る谷－ネクロバレー」適用中に自分のデッキに戦士族・炎属性モンスターが存在せず、自分の墓地に戦士族・炎属性モンスターが存在する場合、「イグナイト・ウージー」のP効果を発動できますか？ 
A. 
「王家の眠る谷－ネクロバレー」の効果が適用されている場合でも、「イグナイト・ウージー」のペンデュラム効果を発動する事はできます。 
なお、ご質問の状況では墓地にしか戦士族・炎属性のモンスターが存在しない為、「イグナイト・ウージー」のペンデュラム効果は無効化されます。