### PR TITLE
Update operations.cpp

### DIFF
--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -248,7 +248,7 @@ void field::send_to(card_set* targets, effect* reason_effect, uint32 reason, uin
 		 * also that card is in Triggering Player's Deck,
 		 * then send it to Triggering Player's Hand, insdead of Owner's Hand. 
 		 */
-		if(p == PLAYER_NONE && destination & LOCATION_HAND && pcard->current.location & LOCATION_DECK && pcard->current.controler == reason_player)
+		if(p == PLAYER_NONE && (destination & LOCATION_HAND) && (pcard->current.location & LOCATION_DECK) && pcard->current.controler == reason_player)
 			p = reason_player;
 		if(destination & (LOCATION_GRAVE + LOCATION_REMOVED) || p == PLAYER_NONE)
 			p = pcard->owner;

--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -243,6 +243,13 @@ void field::send_to(card_set* targets, effect* reason_effect, uint32 reason, uin
 		pcard->current.reason_effect = reason_effect;
 		pcard->current.reason_player = reason_player;
 		p = playerid;
+		/*
+		 * if playerid not given, will send card from Deck to Hand,
+		 * also that card is in Triggering Player's Deck,
+		 * then send it to Triggering Player's Hand, insdead of Owner's Hand. 
+		 */
+		if(p == PLAYER_NONE && destination & LOCATION_HAND && pcard->current.location & LOCATION_DECK && pcard->current.controler == reason_player)
+			p = reason_player;
 		if(destination & (LOCATION_GRAVE + LOCATION_REMOVED) || p == PLAYER_NONE)
 			p = pcard->owner;
 		if(destination != LOCATION_REMOVED)


### PR DESCRIPTION
既然Duel.SendtoHand函数如果没有指定送去谁的手卡，就默认送去持有者的手卡，今天我就心血来潮试了下，如果用「前线观察员」的②效果检索由对方混入我方卡组的「寄生虫 帕拉赛德」，最后那张「寄生虫 帕拉赛德」会进入谁的手卡。其结果是，「寄生虫 帕拉赛德」从我方的卡组，直接飞进了对方手卡。

为这个现象，我特地给事务局发了个邮件，得到的回复是这样的：
————————————————————
Q. 「フロント・オブザーバー」の②の効果で、自分のデッキにありで相手が持っている「寄生虫パラサイド」を手札に加える場合、どうちらの手札に加えるようになりますか？ 
A. ご質問の状況の場合、元々の持ち主が相手の「寄生虫パラサイド」は、自分の手札に加わります。 
なお、この「寄生虫パラサイド」はドローしたカードではないため、『相手がこのカードをドローした時、このカードは相手フィールド上に表側守備表示で特殊召喚され、相手ライフに１０００ポイントダメージを与える』効果は発動しません。 

Q：用「前线观察员」的②效果，把存在于自己卡组却由对方持有的「寄生虫 帕拉赛德」加入手卡的场合，会加入谁的手卡？
A：加入我方的手卡。此外，因为不是通过抽卡而加入手卡的，该「寄生虫 帕拉赛德」的效果不能发动。
————————————————————
很明显，我这是遇到了一个BUG。

为了修复这个BUG，我最初的想法是把所有检索卡全都改一次，直接指定把卡加入tp的手卡，但是我发现工作量过于巨大，用“HINTMSG_ATOHAND”为关键字进行查找的话，找到了五百多个结果，显然一个个改是改不过来的。

所以我觉得比较根本的办法是改这个文件，设置『如果要把存在于ReasonPlayer的卡组的卡送去手卡，但没有指定送去谁的手卡，则默认为送去ReasonPlayer的手卡』此规则，这样就可以解决此BUG。