### PR TITLE
fix Trojan Blast

### DIFF
--- a/script/c63323539.lua
+++ b/script/c63323539.lua
@@ -23,7 +23,9 @@ function c63323539.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=eg:FilterSelect(tp,c63323539.filter,1,1,nil,e,tp)
 	local tc=g:GetFirst()
+	local atk=tc:GetAttack()
+	if atk<0 or tc:IsFacedown() then atk=0 end
 	if tc and Duel.Destroy(tc,REASON_EFFECT)~=0 then
-		Duel.Damage(1-tp,tc:GetAttack(),REASON_EFFECT)
+		Duel.Damage(1-tp,atk,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
相手の「アポクリフォート・カーネル」の効果で自分の裏側守備表示の「シャドール・ドラゴン」のコントールが相手に移った時に「トロイボム」を発動した場合、相手が受けるダメージはいくらになりますか？ 
A. 
「トロイボム」の効果によって、コントロールが移った裏側守備表示の「シャドール・ドラゴン」を破壊した場合であっても、相手に与えられるダメージは【0】となります。