### PR TITLE
do not adjust self destroy set in the process of move_to_field

### DIFF
--- a/ocgcore/operations.cpp
+++ b/ocgcore/operations.cpp
@@ -1021,19 +1021,13 @@ int32 field::control_adjust(uint16 step) {
 		card_set* adjust_set = (card_set*)core.units.begin()->ptarget;
 		delete adjust_set;
 		core.control_adjust_set[0].insert(core.control_adjust_set[1].begin(), core.control_adjust_set[1].end());
-		for(auto cit = core.control_adjust_set[0].begin(); cit != core.control_adjust_set[0].end(); ) {
-			card* pcard = *cit++;
-			if(!(pcard->current.location & LOCATION_ONFIELD)) {
-				core.control_adjust_set[0].erase(pcard);
-				continue;
-			}
-			pcard->filter_disable_related_cards();
-			if(pcard->unique_code)
-				add_unique_card(pcard);
-			raise_single_event(pcard, 0, EVENT_CONTROL_CHANGED, 0, REASON_RULE, 0, 0, 0);
+		for(auto cit = core.control_adjust_set[0].begin(); cit != core.control_adjust_set[0].end(); ++cit) {
+			(*cit)->filter_disable_related_cards();
+			if((*cit)->unique_code)
+				add_unique_card(*cit);
+			raise_single_event((*cit), 0, EVENT_CONTROL_CHANGED, 0, REASON_RULE, 0, 0, 0);
 		}
-		if(core.control_adjust_set[0].size())
-			raise_event(&core.control_adjust_set[0], EVENT_CONTROL_CHANGED, 0, 0, 0, 0, 0);
+		raise_event(&core.control_adjust_set[0], EVENT_CONTROL_CHANGED, 0, 0, 0, 0, 0);
 		process_single_event();
 		process_instant_event();
 		return FALSE;
@@ -3731,7 +3725,7 @@ int32 field::move_to_field(uint16 step, card * target, uint32 enable, uint32 ret
 			target->unequip();
 		if(enable || ((ret == 1) && target->is_position(POS_FACEUP)))
 			target->enable_field_effect(TRUE);
-		adjust_instant();
+		adjust_disable_check_list(); //part of adjust_instant
 		return FALSE;
 	}
 	case 3: {


### PR DESCRIPTION
when you get control of a Burning Abyss monster by the effect of No.11, that monster is sent to grave and then at the timing to activate its effect the program crash. The reason is in the process of get_control, when it is self destroy, the controler of No.11 still get control of that monster in grave.
I think in the process of move_to_field, adjusting self destroy set should not be raised, it has caused many curious problem.
According to http://yugioh-wiki.net/index.php?%A3%D3%A3%E9%A3%EE
Ｑ：フィールド魔法が存在していない状態で特殊召喚した場合その特殊召喚に対して《激流葬》を発動することは可能ですか？
Ａ：いいえ、できません。(11/06/08)

Ｑ：上記の例でフィールド上に他のモンスターが存在する場合は、《激流葬》を発動できますか？
Ａ：自分または相手は《激流葬》を発動できます。(12/07/06)
EVENT_CONTROL_CHANGED should also be raised even it has been self destroyed.