### PR TITLE
fix Lavalval Chain

### DIFF
--- a/script/c34086406.lua
+++ b/script/c34086406.lua
@@ -35,7 +35,8 @@ function c34086406.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,0,1,tp,LOCATION_DECK)
 end
 function c34086406.target2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_DECK,0,1,nil,TYPE_MONSTER) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_DECK,0,1,nil,TYPE_MONSTER)
+		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>1 end
 end
 function c34086406.operation1(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10081&keyword=&tag=-1
 Q.自分のデッキが1枚以下の時、「ラヴァルバル・チェイン」の『●デッキからモンスター１体を選んでデッキの一番上に置く』効果を発動する事はできますか？

また、「ラヴァルバル・チェイン」の『●デッキからモンスター１体を選んでデッキの一番上に置く』効果の処理時に、自分のデッキが1枚になっている場合、処理はどうなりますか？
A.自分のデッキが1枚または0枚の時に、「ラヴァルバル・チェイン」の『●デッキからモンスター１体を選んでデッキの一番上に置く』効果を発動する事はできません。

また、「ラヴァルバル・チェイン」の『●デッキからモンスター１体を選んでデッキの一番上に置く』効果の処理時に、自分のデッキが1枚のみの場合には、そのカードを確認しデッキに戻す事になります。 