### PR TITLE
fix Cuben

### DIFF
--- a/script/c17530001.lua
+++ b/script/c17530001.lua
@@ -1,4 +1,4 @@
---큐분
+--キューブン
 function c17530001.initial_effect(c)
 	--
 	local e1=Effect.CreateEffect(c)
@@ -30,11 +30,8 @@ function c17530001.operation(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
 	c:RegisterEffect(e1)
 	local e2=e1:Clone()
-	e2:SetCode(EFFECT_CANNOT_MSET)
+	e2:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
 	c:RegisterEffect(e2)
-	local e3=e1:Clone()
-	e3:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
-	c:RegisterEffect(e3)
 end
 function c17530001.tglimit(e,c)
 	return c:GetLevel()==e:GetLabel()


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17048&keyword=&tag=-1
 Q.「キューブン」の『①：１ターンに１度、自分メインフェイズに発動できる。サイコロを１回振る。このモンスターがフィールドに表側表示で存在する限り、お互いに出た目と同じレベルのモンスターを召喚・特殊召喚できない』効果によって、お互いにレベル2のモンスターを召喚・特殊召喚できなくなっているターンです。

この状況でレベル2のモンスターを通常召喚や「浅すぎた墓穴」の効果で、裏側守備表示でセットする事はできますか？
A.質問の状況の場合、「キューブン」の効果によって、お互いにレベル2のモンスターを召喚・特殊召喚する事はできません。

モンスターを通常召喚する際に、レベル2のモンスターを裏側守備表示でセットする事はできますが、「浅すぎた墓穴」の効果による裏側守備表示のセットは特殊召喚となりますので、質問の状況の場合、レベル2のモンスターを対象として「浅すぎた墓穴」を発動する事はできません。 