### PR TITLE
fix Soul Rope

### DIFF
--- a/script/c37383714.lua
+++ b/script/c37383714.lua
@@ -12,7 +12,8 @@ function c37383714.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c37383714.cfilter(c,tp)
-	return c:IsReason(REASON_DESTROY) and c:IsType(TYPE_MONSTER) and c:GetPreviousControler()==tp and c:IsPreviousLocation(LOCATION_MZONE)
+	return c:IsReason(REASON_DESTROY) and c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:IsType(TYPE_MONSTER)
+		and c:GetPreviousControler()==tp and c:IsPreviousLocation(LOCATION_MZONE)
 end
 function c37383714.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c37383714.cfilter,1,nil,tp)


### PR DESCRIPTION
Fix this: If Koa'ki Meiru monster destroyed during your End Phase, you can activate Soul Rope.

遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「コアキメイル・ガーディアン」が『このカードのコントローラーは自分エンドフェイズ毎に手札から「コアキメイルの鋼核」１枚を墓地へ送るか、手札の岩石族モンスター１体を相手に見せる。または、どちらも行わずにこのカードを破壊する』によって破壊された場合「魂の綱」を発動できますか？ 
A. 
「コアキメイル・ガーディアン」の『このカードのコントローラーは自分のエンドフェイズ毎に、手札から「コアキメイルの鋼核」１枚を墓地へ送るか、手札の岩石族モンスター１体を相手に見せる。または、どちらも行わずにこのカードを破壊する』は、モンスター効果ではありません。 

よって、「コアキメイル・ガーディアン」が「コアキメイルの鋼核」を墓地へ送らない、または岩石族モンスターを見せずに破壊された場合、この「コアキメイル・ガーディアン」は、モンスター効果で破壊された扱いにはなりません。 
よって、「魂の綱」を発動する事もできません。