### PR TITLE
Update c98263709.lua

### DIFF
--- a/script/c98263709.lua
+++ b/script/c98263709.lua
@@ -70,5 +70,6 @@ function c98263709.spop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_EVENT+0x47e0000)
 		e1:SetValue(LOCATION_REMOVED)
 		tc:RegisterEffect(e1,true)
+		Duel.SpecialSummonComplete()
 	end
 end


### PR DESCRIPTION
Fix: Will no longer cause monsters Special Summoned by itself to be not treated as Galaxy.