### PR TITLE
fix Yang Zing Unleashed

### DIFF
--- a/script/c16825874.lua
+++ b/script/c16825874.lua
@@ -17,6 +17,12 @@ function c16825874.initial_effect(c)
 	e2:SetCondition(c16825874.ccon)
 	e2:SetOperation(c16825874.cop)
 	c:RegisterEffect(e2)
+	--hand synchro for Yang Zing
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e3:SetCode(77783947)
+	c:RegisterEffect(e3)
 end
 c16825874.tuner_filter=aux.FALSE
 function c16825874.filter(c,syncard,tuner,f,lv)

--- a/script/c55863245.lua
+++ b/script/c55863245.lua
@@ -28,6 +28,13 @@ function c55863245.initial_effect(c)
 	e3:SetCondition(c55863245.syncon)
 	e3:SetCode(55863245)
 	c:RegisterEffect(e3)
+	--hand synchro for Yang Zing
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e4:SetCondition(c55863245.syncon)
+	e4:SetCode(77783947)
+	c:RegisterEffect(e4)
 end
 function c55863245.synfilter1(c,syncard,tuner,f)
 	return c:IsFaceup() and c:IsCanBeSynchroMaterial(syncard,tuner) and (f==nil or f(c))

--- a/script/c77783947.lua
+++ b/script/c77783947.lua
@@ -40,6 +40,9 @@ function c77783947.sccon(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	return ph==PHASE_MAIN1 or ph==PHASE_BATTLE or ph==PHASE_MAIN2
 end
+function c77783947.tfilter(c)
+	return c:IsHasEffect(77783947)
+end
 function c77783947.mfilter(c)
 	return c:IsSetCard(0x9e)
 end
@@ -55,13 +58,23 @@ function c77783947.sccost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c77783947.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local mg=Duel.GetMatchingGroup(c77783947.mfilter,tp,LOCATION_MZONE,0,nil)
+		local mg=nil
+		if Duel.IsExistingMatchingCard(c77783947.tfilter,tp,LOCATION_MZONE,0,1,nil) then
+			mg=Duel.GetMatchingGroup(c77783947.mfilter,tp,LOCATION_HAND+LOCATION_MZONE,0,nil)
+		else
+			mg=Duel.GetMatchingGroup(c77783947.mfilter,tp,LOCATION_MZONE,0,nil)
+		end
 		return Duel.IsExistingMatchingCard(c77783947.spfilter,tp,LOCATION_EXTRA,0,1,nil,mg)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c77783947.scop(e,tp,eg,ep,ev,re,r,rp)
-	local mg=Duel.GetMatchingGroup(c77783947.mfilter,tp,LOCATION_MZONE,0,nil)
+	local mg=nil
+	if Duel.IsExistingMatchingCard(c77783947.tfilter,tp,LOCATION_MZONE,0,1,nil) then
+		mg=Duel.GetMatchingGroup(c77783947.mfilter,tp,LOCATION_HAND+LOCATION_MZONE,0,nil)
+	else
+		mg=Duel.GetMatchingGroup(c77783947.mfilter,tp,LOCATION_MZONE,0,nil)
+	end
 	local g=Duel.GetMatchingGroup(c77783947.spfilter,tp,LOCATION_EXTRA,0,nil,mg)
 	if g:GetCount()>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10197&keyword=&tag=-1
Q.自分のモンスターゾーンに「エキセントリック・ボーイ」が1体のみ表側表示で存在し、自分の魔法＆罠ゾーンに「竜星の極み」が表側表示で存在しています。
また、自分の手札に「炎竜星－シュンゲイ」が存在しています。

この状況で、「竜星の極み」の『②：自分または相手のメインフェイズ及びバトルフェイズに魔法＆罠ゾーンに表側表示で存在するこのカードを墓地へ送ってこの効果を発動できる。「竜星」モンスター１体以上を含むモンスターを素材としてSモンスター１体をS召喚する』効果を発動する事はできますか？
A.「竜星の極み」の効果を発動する場合、「竜星」と名のついたモンスター1体以上を含むシンクロ素材モンスター一組を揃え、その合計のレベルを持つシンクロモンスターを正しくシンクロ召喚できる状態でなければなりません。

質問の状況の場合、モンスターゾーンのエキセントリック・ボーイ」と手札の「炎竜星－シュンゲイ」をシンクロ素材モンスター一組として、エクストラデッキからレベルのシンクロモンスターをシンクロ召喚できるのであれば、「竜星の極み」の効果を発動する事ができます。

（なお、質問の状況では、モンスターゾーンに「竜星」と名のついたモンスターが表側表示で存在していませんので、手札に「竜星」と名のついたモンスターが存在しないような場合であれば、「竜星の極み」の効果を発動する事自体ができません。） 