### PR TITLE
Update client_field.cpp and event_handler.cpp

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -375,7 +375,7 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 						selectable_cards[i]->sequence + 1);
 				mainGame->stCardPos[i]->setText(formatBuffer);
 				mainGame->stCardPos[i]->setVisible(true);
-				if(selectable_cards[i]->controler)
+				if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->overlayTarget->controler : selectable_cards[i]->controler)
 					mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
 				else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 			} else {
@@ -416,7 +416,7 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 						selectable_cards[i]->sequence + 1);
 				mainGame->stCardPos[i]->setText(formatBuffer);
 				mainGame->stCardPos[i]->setVisible(true);
-				if(selectable_cards[i]->controler)
+				if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->overlayTarget->controler : selectable_cards[i]->controler)
 					mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
 				else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 			} else {
@@ -453,7 +453,7 @@ void ClientField::ShowChainCard() {
 				selectable_cards[i]->sequence + 1);
 			mainGame->stCardPos[i]->setText(formatBuffer);
 			mainGame->stCardPos[i]->setVisible(true);
-			if(selectable_cards[i]->controler)
+			if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->overlayTarget->controler : selectable_cards[i]->controler)
 				mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
 			else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 			mainGame->stCardPos[i]->setRelativePosition(rect<s32>(startpos + i * 125, 30, startpos + 120 + i * 125, 50));
@@ -477,7 +477,7 @@ void ClientField::ShowChainCard() {
 				selectable_cards[i]->sequence + 1);
 			mainGame->stCardPos[i]->setText(formatBuffer);
 			mainGame->stCardPos[i]->setVisible(true);
-			if(selectable_cards[i]->controler)
+			if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->overlayTarget->controler : selectable_cards[i]->controler)
 				mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
 			else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 			mainGame->stCardPos[i]->setRelativePosition(rect<s32>(30 + i * 125, 30, 150 + i * 125, 50));
@@ -507,7 +507,7 @@ void ClientField::ShowLocationCard() {
 				display_cards[i]->sequence + 1);
 			mainGame->stDisplayPos[i]->setText(formatBuffer);
 			mainGame->stDisplayPos[i]->setVisible(true);
-			if(display_cards[i]->controler)
+			if(display_cards[i]->overlayTarget ? display_cards[i]->overlayTarget->controler : display_cards[i]->controler)
 				mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
 			else mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
 			mainGame->stDisplayPos[i]->setRelativePosition(rect<s32>(startpos + i * 125, 30, startpos + 120 + i * 125, 50));
@@ -531,7 +531,7 @@ void ClientField::ShowLocationCard() {
 				display_cards[i]->sequence + 1);
 			mainGame->stDisplayPos[i]->setText(formatBuffer);
 			mainGame->stDisplayPos[i]->setVisible(true);
-			if(display_cards[i]->controler)
+			if(display_cards[i]->overlayTarget ? display_cards[i]->overlayTarget->controler : display_cards[i]->controler)
 				mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
 			else mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
 			mainGame->stDisplayPos[i]->setRelativePosition(rect<s32>(30 + i * 125, 30, 150 + i * 125, 50));

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -375,7 +375,7 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 						selectable_cards[i]->sequence + 1);
 				mainGame->stCardPos[i]->setText(formatBuffer);
 				mainGame->stCardPos[i]->setVisible(true);
-				if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->overlayTarget->controler : selectable_cards[i]->controler)
+				if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->owner : selectable_cards[i]->controler)
 					mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
 				else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 			} else {
@@ -416,7 +416,7 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 						selectable_cards[i]->sequence + 1);
 				mainGame->stCardPos[i]->setText(formatBuffer);
 				mainGame->stCardPos[i]->setVisible(true);
-				if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->overlayTarget->controler : selectable_cards[i]->controler)
+				if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->owner : selectable_cards[i]->controler)
 					mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
 				else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 			} else {
@@ -453,7 +453,7 @@ void ClientField::ShowChainCard() {
 				selectable_cards[i]->sequence + 1);
 			mainGame->stCardPos[i]->setText(formatBuffer);
 			mainGame->stCardPos[i]->setVisible(true);
-			if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->overlayTarget->controler : selectable_cards[i]->controler)
+			if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->owner : selectable_cards[i]->controler)
 				mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
 			else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 			mainGame->stCardPos[i]->setRelativePosition(rect<s32>(startpos + i * 125, 30, startpos + 120 + i * 125, 50));
@@ -477,7 +477,7 @@ void ClientField::ShowChainCard() {
 				selectable_cards[i]->sequence + 1);
 			mainGame->stCardPos[i]->setText(formatBuffer);
 			mainGame->stCardPos[i]->setVisible(true);
-			if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->overlayTarget->controler : selectable_cards[i]->controler)
+			if(selectable_cards[i]->overlayTarget ? selectable_cards[i]->owner : selectable_cards[i]->controler)
 				mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
 			else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 			mainGame->stCardPos[i]->setRelativePosition(rect<s32>(30 + i * 125, 30, 150 + i * 125, 50));
@@ -507,7 +507,7 @@ void ClientField::ShowLocationCard() {
 				display_cards[i]->sequence + 1);
 			mainGame->stDisplayPos[i]->setText(formatBuffer);
 			mainGame->stDisplayPos[i]->setVisible(true);
-			if(display_cards[i]->overlayTarget ? display_cards[i]->overlayTarget->controler : display_cards[i]->controler)
+			if(display_cards[i]->overlayTarget ? display_cards[i]->owner : display_cards[i]->controler)
 				mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
 			else mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
 			mainGame->stDisplayPos[i]->setRelativePosition(rect<s32>(startpos + i * 125, 30, startpos + 120 + i * 125, 50));
@@ -531,7 +531,7 @@ void ClientField::ShowLocationCard() {
 				display_cards[i]->sequence + 1);
 			mainGame->stDisplayPos[i]->setText(formatBuffer);
 			mainGame->stDisplayPos[i]->setVisible(true);
-			if(display_cards[i]->overlayTarget ? display_cards[i]->overlayTarget->controler : display_cards[i]->controler)
+			if(display_cards[i]->overlayTarget ? display_cards[i]->owner : display_cards[i]->controler)
 				mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
 			else mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
 			mainGame->stDisplayPos[i]->setRelativePosition(rect<s32>(30 + i * 125, 30, 150 + i * 125, 50));

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -555,7 +555,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						int i = 0;
 						while(selected_cards[i] != command_card) i++;
 						selected_cards.erase(selected_cards.begin() + i);
-						if(command_card->overlayTarget ? command_card->overlayTarget->controler : command_card->controler)
+						if(command_card->overlayTarget ? command_card->owner : command_card->controler)
 							mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffd0d0d0);
 						else mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffffff);
 					} else {
@@ -752,7 +752,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					mainGame->stCardPos[i]->setText(formatBuffer);
 					if(selectable_cards[i + pos]->is_selected)
 						mainGame->stCardPos[i]->setBackgroundColor(0xffffff00);
-					else if(selectable_cards[i + pos]->overlayTarget ? selectable_cards[i + pos]->overlayTarget->controler : selectable_cards[i + pos]->controler)
+					else if(selectable_cards[i + pos]->overlayTarget ? selectable_cards[i + pos]->owner : selectable_cards[i + pos]->controler)
 						mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
 					else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 				}
@@ -769,7 +769,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					myswprintf(formatBuffer, L"%ls[%d]", dataManager.FormatLocation(display_cards[i + pos]->location, display_cards[i + pos]->sequence),
 						display_cards[i + pos]->sequence + 1);
 					mainGame->stDisplayPos[i]->setText(formatBuffer);
-					if(display_cards[i + pos]->overlayTarget ? display_cards[i + pos]->overlayTarget->controler : display_cards[i + pos]->controler)
+					if(display_cards[i + pos]->overlayTarget ? display_cards[i + pos]->owner : : display_cards[i + pos]->controler)
 						mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
 					else mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
 				}

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -555,7 +555,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						int i = 0;
 						while(selected_cards[i] != command_card) i++;
 						selected_cards.erase(selected_cards.begin() + i);
-						if(command_card->controler)
+						if(command_card->overlayTarget ? command_card->overlayTarget->controler : command_card->controler)
 							mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffd0d0d0);
 						else mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffffff);
 					} else {
@@ -752,7 +752,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					mainGame->stCardPos[i]->setText(formatBuffer);
 					if(selectable_cards[i + pos]->is_selected)
 						mainGame->stCardPos[i]->setBackgroundColor(0xffffff00);
-					else if(selectable_cards[i + pos]->controler)
+					else if(selectable_cards[i + pos]->overlayTarget ? selectable_cards[i + pos]->overlayTarget->controler : selectable_cards[i + pos]->controler)
 						mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
 					else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 				}
@@ -769,7 +769,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					myswprintf(formatBuffer, L"%ls[%d]", dataManager.FormatLocation(display_cards[i + pos]->location, display_cards[i + pos]->sequence),
 						display_cards[i + pos]->sequence + 1);
 					mainGame->stDisplayPos[i]->setText(formatBuffer);
-					if(display_cards[i + pos]->controler)
+					if(display_cards[i + pos]->overlayTarget ? display_cards[i + pos]->overlayTarget->controler : display_cards[i + pos]->controler)
 						mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
 					else mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
 				}

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -769,7 +769,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					myswprintf(formatBuffer, L"%ls[%d]", dataManager.FormatLocation(display_cards[i + pos]->location, display_cards[i + pos]->sequence),
 						display_cards[i + pos]->sequence + 1);
 					mainGame->stDisplayPos[i]->setText(formatBuffer);
-					if(display_cards[i + pos]->overlayTarget ? display_cards[i + pos]->owner : : display_cards[i + pos]->controler)
+					if(display_cards[i + pos]->overlayTarget ? display_cards[i + pos]->owner : display_cards[i + pos]->controler)
 						mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
 					else mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
 				}


### PR DESCRIPTION
我觉得选择超量素材的时候，位置框的背景颜色应该由超量素材的持有者决定，因为超量素材没有控制者，所以如果用超量素材的控制者决定的话，永远都会视为不属于自己的卡，从而显示为灰色。由自己【持有】的超量素材显示为白色而由对方持有的显示为灰色，我觉得会更好。

I think when selecting Xyz Materials, background color should be up to the owner of Xyz Material, instead of controller of Xyz Material, because an Xyz Material has no controller, so that its background color would always be 0xffd0d0d0(grey). 
I guess Xyz Material's background color is 0xffffffff(white) whose owner was you and your opponent's is 0xffd0d0d0(grey) would be better than all grey. 

最初的打算是根据骑着素材的怪兽的控制者来决定背景色，但我觉得还是夏娜肚肚说得有道理，所以改成Owner了。

I planned to make it up to the controller of the monster ridding on the Xyz Material, but I think Shana is right, so I changed my mind. 