### PR TITLE
update search filter

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -133,7 +133,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_CLEAR_FILTER: {
-				ClearFilter();
+				ClearSearch();
 				break;
 			}
 			case BUTTON_CATEGORY_OK: {
@@ -202,9 +202,17 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case COMBOBOX_MAINTYPE: {
+				mainGame->cbCardType2->setSelected(0);
+				mainGame->cbAttribute->setSelected(0);
+				mainGame->cbRace->setSelected(0);
+				mainGame->ebAttack->setText(L"");
+				mainGame->ebDefence->setText(L"");
+				mainGame->ebStar->setText(L"");
+				mainGame->ebScale->setText(L"");
 				switch(mainGame->cbCardType->getSelected()) {
 				case 0: {
 					mainGame->cbCardType2->setEnabled(false);
+					mainGame->cbCardType2->setSelected(0);
 					mainGame->cbRace->setEnabled(false);
 					mainGame->cbAttribute->setEnabled(false);
 					mainGame->ebAttack->setEnabled(false);
@@ -214,6 +222,8 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					break;
 				}
 				case 1: {
+					wchar_t normaltuner[32];
+					wchar_t normalpen[32];
 					wchar_t syntuner[32];
 					mainGame->cbCardType2->setEnabled(true);
 					mainGame->cbRace->setEnabled(true);
@@ -229,10 +239,14 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					mainGame->cbCardType2->addItem(dataManager.GetSysString(1056), TYPE_MONSTER + TYPE_FUSION);
 					mainGame->cbCardType2->addItem(dataManager.GetSysString(1057), TYPE_MONSTER + TYPE_RITUAL);
 					mainGame->cbCardType2->addItem(dataManager.GetSysString(1063), TYPE_MONSTER + TYPE_SYNCHRO);
-					myswprintf(syntuner, L"%ls|%ls", dataManager.GetSysString(1063), dataManager.GetSysString(1062));
-					mainGame->cbCardType2->addItem(syntuner, TYPE_MONSTER + TYPE_SYNCHRO + TYPE_TUNER);
 					mainGame->cbCardType2->addItem(dataManager.GetSysString(1073), TYPE_MONSTER + TYPE_XYZ);
 					mainGame->cbCardType2->addItem(dataManager.GetSysString(1074), TYPE_MONSTER + TYPE_PENDULUM);
+					myswprintf(normaltuner, L"%ls|%ls", dataManager.GetSysString(1054), dataManager.GetSysString(1062));
+					mainGame->cbCardType2->addItem(normaltuner, TYPE_MONSTER + TYPE_NORMAL + TYPE_TUNER);
+					myswprintf(normalpen, L"%ls|%ls", dataManager.GetSysString(1054), dataManager.GetSysString(1074));
+					mainGame->cbCardType2->addItem(normalpen, TYPE_MONSTER + TYPE_NORMAL + TYPE_PENDULUM);
+					myswprintf(syntuner, L"%ls|%ls", dataManager.GetSysString(1063), dataManager.GetSysString(1062));
+					mainGame->cbCardType2->addItem(syntuner, TYPE_MONSTER + TYPE_SYNCHRO + TYPE_TUNER);
 					mainGame->cbCardType2->addItem(dataManager.GetSysString(1062), TYPE_MONSTER + TYPE_TUNER);
 					mainGame->cbCardType2->addItem(dataManager.GetSysString(1061), TYPE_MONSTER + TYPE_DUAL);
 					mainGame->cbCardType2->addItem(dataManager.GetSysString(1060), TYPE_MONSTER + TYPE_UNION);
@@ -721,6 +735,19 @@ void DeckBuilder::FilterCards() {
 		mainGame->scrFilter->setPos(0);
 	}
 	std::sort(results.begin(), results.end(), ClientCard::deck_sort_lv);
+}
+void DeckBuilder::ClearSearch() {
+	mainGame->cbCardType->setSelected(0);
+	mainGame->cbCardType2->setSelected(0);
+	mainGame->cbCardType2->setEnabled(false);
+	mainGame->cbRace->setEnabled(false);
+	mainGame->cbAttribute->setEnabled(false);
+	mainGame->ebAttack->setEnabled(false);
+	mainGame->ebDefence->setEnabled(false);
+	mainGame->ebStar->setEnabled(false);
+	mainGame->ebScale->setEnabled(false);
+	mainGame->ebCardName->setText(L"");
+	ClearFilter();
 }
 void DeckBuilder::ClearFilter() {
 	mainGame->cbAttribute->setSelected(0);

--- a/gframe/deck_con.h
+++ b/gframe/deck_con.h
@@ -13,6 +13,7 @@ public:
 	virtual bool OnEvent(const irr::SEvent& event);
 	void FilterCards();
 	void ClearFilter();
+	void ClearSearch();
 
 	long long filter_effect;
 	unsigned int filter_type;

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -434,18 +434,19 @@ bool Game::Initialize() {
 	ebDefence = env->addEditBox(L"", rect<s32>(260, 49, 340, 69), true, wFilter);
 	ebDefence->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
 	env->addStaticText(dataManager.GetSysString(1324), rect<s32>(10, 74, 80, 94), false, false, wFilter);
-	ebStar = env->addEditBox(L"", rect<s32>(60, 72, 120, 92), true, wFilter);
+	ebStar = env->addEditBox(L"", rect<s32>(60, 72, 190, 92), true, wFilter);
 	ebStar->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
-	ebScale = env->addEditBox(L"", rect<s32>(130, 72, 190, 92), true, wFilter);
+	env->addStaticText(dataManager.GetSysString(1336), rect<s32>(10, 97, 80, 127), false, false, wFilter);
+	ebScale = env->addEditBox(L"", rect<s32>(60, 95, 190, 115), true, wFilter);
 	ebScale->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
 	env->addStaticText(dataManager.GetSysString(1325), rect<s32>(205, 74, 280, 94), false, false, wFilter);
 	ebCardName = env->addEditBox(L"", rect<s32>(260, 72, 390, 92), true, wFilter, EDITBOX_KEYWORD);
 	ebCardName->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
 	btnEffectFilter = env->addButton(rect<s32>(345, 28, 390, 69), wFilter, BUTTON_EFFECT_FILTER, dataManager.GetSysString(1326));
-	btnStartFilter = env->addButton(rect<s32>(210, 96, 390, 118), wFilter, BUTTON_START_FILTER, dataManager.GetSysString(1327));
+	btnStartFilter = env->addButton(rect<s32>(205, 96, 390, 116), wFilter, BUTTON_START_FILTER, dataManager.GetSysString(1327));
 	if(mainGame->gameConf.separate_clear_button) {
-		btnStartFilter->setRelativePosition(rect<s32>(210, 96, 335, 118));
-		btnClearFilter = env->addButton(rect<s32>(340, 96, 390, 118), wFilter, BUTTON_CLEAR_FILTER, dataManager.GetSysString(1304));
+		btnStartFilter->setRelativePosition(rect<s32>(260, 96, 390, 116));
+		btnClearFilter = env->addButton(rect<s32>(205, 96, 255, 116), wFilter, BUTTON_CLEAR_FILTER, dataManager.GetSysString(1304));
 	}
 	wCategories = env->addWindow(rect<s32>(630, 60, 1000, 270), false, dataManager.strBuffer);
 	wCategories->getCloseButton()->setVisible(false);

--- a/strings.conf
+++ b/strings.conf
@@ -303,7 +303,7 @@
 !system 1324 星数：
 !system 1325 关键字：
 !system 1326 效果
-!system 1327 重新搜索
+!system 1327 搜索
 !system 1328 结果中搜索
 !system 1329 系列：
 !system 1330 主卡组：
@@ -312,6 +312,7 @@
 !system 1333 搜索结果：
 !system 1334 副卡组更换完成
 !system 1335 保存成功
+!system 1336 刻度：
 !system 1340 是否保存录像？
 !system 1341 保存
 !system 1342 录像文件：


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/13391795/15446974/c3c8a30c-1f62-11e6-9bac-0b22a1d3e746.png)

1. 刻度改为另起一行，因为和等级放在一起会令人误解是 _1_ 到 _12_ 级
2. 搜索和清空按钮位置对调
3. 令清空按钮清除所有的输入
4. 增加通常+调整、通常+灵摆的搜索条件