### PR TITLE
update draw dual field spell

### DIFF
--- a/gframe/materials.cpp
+++ b/gframe/materials.cpp
@@ -45,14 +45,14 @@ Materials::Materials() {
 	vFieldSpell[1] = S3DVertex(vector3df(6.7f, -3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(1, 0));
 	vFieldSpell[2] = S3DVertex(vector3df(1.2f, 3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(0, 1));
 	vFieldSpell[3] = S3DVertex(vector3df(6.7f, 3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(1, 1));
-	vFieldSpell1[0] = S3DVertex(vector3df(1.2f, 0.8f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(0, 0));
-	vFieldSpell1[1] = S3DVertex(vector3df(6.7f, 0.8f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(1, 0));
-	vFieldSpell1[2] = S3DVertex(vector3df(1.2f, 3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(0, 1));
-	vFieldSpell1[3] = S3DVertex(vector3df(6.7f, 3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(1, 1));
-	vFieldSpell2[0] = S3DVertex(vector3df(1.2f, -3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(0, 0));
-	vFieldSpell2[1] = S3DVertex(vector3df(6.7f, -3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(1, 0));
-	vFieldSpell2[2] = S3DVertex(vector3df(1.2f, -0.8f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(0, 1));
-	vFieldSpell2[3] = S3DVertex(vector3df(6.7f, -0.8f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(1, 1));
+	vFieldSpell1[0] = S3DVertex(vector3df(1.2f, 0.8f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(0, 0.2f));
+	vFieldSpell1[1] = S3DVertex(vector3df(6.7f, 0.8f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(1, 0.2f));
+	vFieldSpell1[2] = S3DVertex(vector3df(1.2f, 3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(0, 0.63636f));
+	vFieldSpell1[3] = S3DVertex(vector3df(6.7f, 3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(1, 0.63636f));
+	vFieldSpell2[0] = S3DVertex(vector3df(1.2f, -3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(1, 0.63636f));
+	vFieldSpell2[1] = S3DVertex(vector3df(6.7f, -3.2f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(0, 0.63636f));
+	vFieldSpell2[2] = S3DVertex(vector3df(1.2f, -0.8f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(1, 0.2f));
+	vFieldSpell2[3] = S3DVertex(vector3df(6.7f, -0.8f, 0), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(0, 0.2f));
 	//background grids
 	for (int i = 0; i < 6; ++i) {
 		vBackLine[i * 6 + 0] = S3DVertex(vector3df(1.2f + i * 1.1f, 0.5f, -0.01f), vector3df(0, 0, 1), SColor(255, 255, 255, 255), vector2df(0, 0));


### PR DESCRIPTION
在显示两个场地时，把对方的场地改为背对我方。并且双方的场地使用裁剪，而不是变形。

Before:
![qq 20160530100949](https://cloud.githubusercontent.com/assets/13391795/15638121/07c0ebda-264f-11e6-9edf-f39da9126549.jpg)

After:
![qq 20160530100957](https://cloud.githubusercontent.com/assets/13391795/15638125/0defbdec-264f-11e6-8f29-9c151d919ea4.jpg)
![qq 20160530101016](https://cloud.githubusercontent.com/assets/13391795/15638124/0dc4cd6c-264f-11e6-8444-424d8239acff.jpg)
![qq 20160530101103](https://cloud.githubusercontent.com/assets/13391795/15638127/0e15bef2-264f-11e6-998e-c17dceada8a6.jpg)
![qq 20160530101005](https://cloud.githubusercontent.com/assets/13391795/15638126/0e156498-264f-11e6-990b-165d73eb2e02.jpg)
