### PR TITLE
fix imgCard size

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -175,7 +175,7 @@ bool Game::Initialize() {
 	wCardImg = env->addStaticText(L"", rect<s32>(1, 1, 199, 273), true, false, 0, -1, true);
 	wCardImg->setBackgroundColor(0xc0c0c0c0);
 	wCardImg->setVisible(false);
-	imgCard = env->addImage(rect<s32>(9, 9, 187, 262), wCardImg);
+	imgCard = env->addImage(rect<s32>(10, 8, 187, 262), wCardImg);
 	imgCard->setUseAlphaChannel(true);
 	//phase
 	wPhase = env->addStaticText(L"", rect<s32>(480, 310, 855, 330));


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro/blob/master/textures/cover.jpg
most of the card pics of ygopro are 177x254, but imgCard is 178x253.

![image](https://cloud.githubusercontent.com/assets/13391795/15818029/9fd21868-2c0d-11e6-98b0-7a6e2586aed2.png)
Left: Now
Mid: Fixed
Right: Original pic
