### PR TITLE
fix and update del deck and clear deck

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -51,9 +51,11 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 		case irr::gui::EGET_BUTTON_CLICKED: {
 			switch(id) {
 			case BUTTON_CLEAR_DECK: {
-				deckManager.current_deck.main.clear();
-				deckManager.current_deck.extra.clear();
-				deckManager.current_deck.side.clear();
+				mainGame->gMutex.Lock();
+				mainGame->SetStaticText(mainGame->stQMessage, 310, mainGame->textFont, (wchar_t*)dataManager.GetSysString(1339));
+				mainGame->PopupElement(mainGame->wQuery);
+				mainGame->gMutex.Unlock();
+				is_clearing = true;
 				break;
 			}
 			case BUTTON_SORT_DECK: {
@@ -97,12 +99,16 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_DELETE_DECK: {
-				if(mainGame->cbDBDecks->getSelected() == -1)
+				int sel = mainGame->cbDBDecks->getSelected();
+				if(sel == -1)
 					break;
 				mainGame->gMutex.Lock();
-				mainGame->SetStaticText(mainGame->stQMessage, 310, mainGame->textFont, (wchar_t*)dataManager.GetSysString(1337));
+				wchar_t textBuffer[256];
+				myswprintf(textBuffer, L"%ls\n%ls", mainGame->cbDBDecks->getItem(sel), dataManager.GetSysString(1337));
+				mainGame->SetStaticText(mainGame->stQMessage, 310, mainGame->textFont, (wchar_t*)textBuffer);
 				mainGame->PopupElement(mainGame->wQuery);
 				mainGame->gMutex.Unlock();
+				is_deleting = true;
 				break;
 			}
 			case BUTTON_LEAVE_GAME: {
@@ -181,22 +187,35 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_YES: {
 				mainGame->HideElement(mainGame->wQuery);
-				int sel = mainGame->cbDBDecks->getSelected();
-				if(deckManager.DeleteDeck(deckManager.current_deck, mainGame->cbDBDecks->getItem(sel))) {
-					mainGame->cbDBDecks->removeItem(sel);
-					int count = mainGame->cbDBDecks->getItemCount();
-					if(sel >= count)
-						sel = count - 1;
-					mainGame->cbDBDecks->setSelected(sel);
-					if(sel != -1)
-						deckManager.LoadDeck(mainGame->cbDBDecks->getItem(sel));
-					mainGame->stACMessage->setText(dataManager.GetSysString(1338));
-					mainGame->PopupElement(mainGame->wACMessage, 20);
+				if(!mainGame->is_building || mainGame->is_siding)
+					break;
+				if(is_deleting) {
+					int sel = mainGame->cbDBDecks->getSelected();
+					if (deckManager.DeleteDeck(deckManager.current_deck, mainGame->cbDBDecks->getItem(sel))) {
+						mainGame->cbDBDecks->removeItem(sel);
+						int count = mainGame->cbDBDecks->getItemCount();
+						if (sel >= count)
+							sel = count - 1;
+						mainGame->cbDBDecks->setSelected(sel);
+						if (sel != -1)
+							deckManager.LoadDeck(mainGame->cbDBDecks->getItem(sel));
+						mainGame->stACMessage->setText(dataManager.GetSysString(1338));
+						mainGame->PopupElement(mainGame->wACMessage, 20);
+					}
+					is_deleting = false;
+				}
+				if(is_clearing) {
+					deckManager.current_deck.main.clear();
+					deckManager.current_deck.extra.clear();
+					deckManager.current_deck.side.clear();
+					is_clearing = false;
 				}
 				break;
 			}
 			case BUTTON_NO: {
 				mainGame->HideElement(mainGame->wQuery);
+				is_deleting = false;
+				is_clearing = false;
 				break;
 			}
 			}

--- a/gframe/deck_con.h
+++ b/gframe/deck_con.h
@@ -41,6 +41,8 @@ public:
 	size_t pre_extrac;
 	size_t pre_sidec;
 	code_pointer draging_pointer;
+	bool is_deleting;
+	bool is_clearing;
 	
 	std::unordered_map<int, int>* filterList;
 	std::vector<code_pointer> results;

--- a/strings.conf
+++ b/strings.conf
@@ -318,6 +318,7 @@
 !system 1336 刻度：
 !system 1337 是否删除这个卡组？
 !system 1338 删除成功
+!system 1339 是否清空正在编辑的卡组？
 !system 1340 是否保存录像？
 !system 1341 保存
 !system 1342 录像文件：


### PR DESCRIPTION
Fix: In duel, if a dialog is being shown, and the opponent surrender and enter side, if the player click yes of the remaining dialog, the deck will be deleted.

Add: Show deck name when deleting.

Add: Confirm for clearing deck.