### PR TITLE
add button for cancel or finish selecting

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -1131,6 +1131,7 @@ bool ClientField::ShowSelectSum(bool panelmode) {
 		if(CheckSelectSum()) {
 			if(selectsum_cards.size() == 0 || selectable_cards.size() == 0) {
 				SetResponseSelectedCards();
+				ShowCancelOrFinishButton(0);
 				if(mainGame->wCardSelect->isVisible())
 					mainGame->HideElement(mainGame->wCardSelect, true);
 				else {
@@ -1151,6 +1152,7 @@ bool ClientField::ShowSelectSum(bool panelmode) {
 		if(CheckSelectSum()) {
 			if(selectsum_cards.size() == 0 || selectable_cards.size() == 0) {
 				SetResponseSelectedCards();
+				ShowCancelOrFinishButton(0);
 				DuelClient::SendResponse();
 				return true;
 			} else {
@@ -1164,6 +1166,11 @@ bool ClientField::ShowSelectSum(bool panelmode) {
 			}
 		} else
 			select_ready = false;
+	}
+	if (select_ready) {
+		ShowCancelOrFinishButton(1);
+	} else {
+		ShowCancelOrFinishButton(0);
 	}
 	return false;
 }

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -127,6 +127,7 @@ public:
 	void GetHoverField(int x, int y);
 	void ShowMenu(int flag, int x, int y);
 	void UpdateChainButtons();
+	void ShowCancelOrFinishButton(int buttonOp);
 	void SetResponseSelectedCards() const;
 };
 

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -288,6 +288,7 @@ void DuelClient::HandleSTOCPacketLan(char* data, unsigned int len) {
 		mainGame->btnChainIgnore->setVisible(false);
 		mainGame->btnChainAlways->setVisible(false);
 		mainGame->btnChainWhenAvail->setVisible(false);
+		mainGame->btnCancelOrFinish->setVisible(false);
 		mainGame->deckBuilder.result_string[0] = L'0';
 		mainGame->deckBuilder.result_string[1] = 0;
 		mainGame->deckBuilder.results.clear();
@@ -510,6 +511,7 @@ void DuelClient::HandleSTOCPacketLan(char* data, unsigned int len) {
 		mainGame->btnChainIgnore->setVisible(false);
 		mainGame->btnChainAlways->setVisible(false);
 		mainGame->btnChainWhenAvail->setVisible(false);
+		mainGame->btnCancelOrFinish->setVisible(false);
 		mainGame->stMessage->setText(dataManager.GetSysString(1500));
 		mainGame->PopupElement(mainGame->wMessage);
 		mainGame->gMutex.Unlock();
@@ -539,6 +541,7 @@ void DuelClient::HandleSTOCPacketLan(char* data, unsigned int len) {
 		mainGame->btnChainIgnore->setVisible(false);
 		mainGame->btnChainAlways->setVisible(false);
 		mainGame->btnChainWhenAvail->setVisible(false);
+		mainGame->btnCancelOrFinish->setVisible(false);
 		time_t nowtime = time(NULL);
 		struct tm *localedtime = localtime(&nowtime);
 		char timebuf[40];
@@ -1179,6 +1182,9 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 			mainGame->stHintMsg->setText(textBuffer);
 			mainGame->stHintMsg->setVisible(true);
 		}
+		if (mainGame->dField.select_cancelable) {
+			mainGame->dField.ShowCancelOrFinishButton(1);
+		}
 		return false;
 	}
 	case MSG_SELECT_CHAIN: {
@@ -1412,6 +1418,9 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		mainGame->gMutex.Lock();
 		mainGame->stHintMsg->setText(textBuffer);
 		mainGame->stHintMsg->setVisible(true);
+		if (mainGame->dField.select_cancelable) {
+			mainGame->dField.ShowCancelOrFinishButton(1);
+		}
 		mainGame->gMutex.Unlock();
 		return false;
 	}
@@ -1875,6 +1884,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 				mainGame->btnChainIgnore->setVisible(false);
 				mainGame->btnChainAlways->setVisible(false);
 				mainGame->btnChainWhenAvail->setVisible(false);
+				mainGame->btnCancelOrFinish->setVisible(false);
 			}
 		}
 		if(mainGame->dInfo.isTag && mainGame->dInfo.turn != 1) {

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -541,6 +541,9 @@ bool Game::Initialize() {
 	btnChainIgnore->setVisible(false);
 	btnChainAlways->setVisible(false);
 	btnChainWhenAvail->setVisible(false);
+	//cancel or finish
+	btnCancelOrFinish = env->addButton(rect<s32>(205, 230, 295, 265), 0, BUTTON_CANCEL_OR_FINISH, dataManager.GetSysString(1295));
+	btnCancelOrFinish->setVisible(false);
 	//leave/surrender/exit
 	btnLeaveGame = env->addButton(rect<s32>(205, 5, 295, 80), 0, BUTTON_LEAVE_GAME, L"");
 	btnLeaveGame->setVisible(false);
@@ -1122,6 +1125,7 @@ void Game::CloseDuelWindow() {
 	btnChainIgnore->setVisible(false);
 	btnChainAlways->setVisible(false);
 	btnChainWhenAvail->setVisible(false);
+	btnCancelOrFinish->setVisible(false);
 	wChat->setVisible(false);
 	lstLog->clear();
 	logParam.clear();

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -395,7 +395,8 @@ public:
 	irr::gui::IGUIButton* btnChainIgnore;
 	irr::gui::IGUIButton* btnChainAlways;
 	irr::gui::IGUIButton* btnChainWhenAvail;
-
+	//cancel or finish
+	irr::gui::IGUIButton* btnCancelOrFinish;
 };
 
 extern Game* mainGame;
@@ -486,6 +487,7 @@ extern Game* mainGame;
 #define BUTTON_CHAIN_IGNORE			264
 #define BUTTON_CHAIN_ALWAYS			265
 #define BUTTON_CHAIN_WHENAVAIL		266
+#define BUTTON_CANCEL_OR_FINISH		267
 #define BUTTON_CLEAR_LOG			270
 #define LISTBOX_LOG					271
 #define SCROLL_CARDTEXT				280

--- a/strings.conf
+++ b/strings.conf
@@ -286,6 +286,8 @@
 !system 1292 忽略时点
 !system 1293 显示时点
 !system 1294 可用时点
+!system 1295 取消操作
+!system 1296 完成选择
 !system 1300 禁限卡表：
 !system 1301 卡组列表：
 !system 1302 保存


### PR DESCRIPTION
![qq 20160909210335](https://cloud.githubusercontent.com/assets/13391795/18387727/ec853f56-76d0-11e6-9672-ab494e6415eb.jpg)
![qq 20160909210319](https://cloud.githubusercontent.com/assets/13391795/18387726/ec853ed4-76d0-11e6-916b-47ed4ce7b4a0.jpg)
![qq 20160909210324](https://cloud.githubusercontent.com/assets/13391795/18387730/eca70e24-76d0-11e6-9125-f2bdf91a5512.jpg)
![qq 20160909210328](https://cloud.githubusercontent.com/assets/13391795/18387729/ec8a0aae-76d0-11e6-813a-45b6c75698c3.jpg)
![qq 20160909210331](https://cloud.githubusercontent.com/assets/13391795/18387728/ec863672-76d0-11e6-9e21-00cac7488544.jpg)

Add one button for cancel or finish selecting cards or chain, where those operation can be done with mouse right button before.
This button will only appear when the selecting is able to cancel or finish.