### PR TITLE
add show full setnames

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -293,6 +293,27 @@ const wchar_t* DataManager::FormatSetName(unsigned long long setcode) {
 		return unknown_string;
 	return scBuffer;
 }
+const wchar_t* DataManager::FormatFullSetName(unsigned long long setcode) {
+	wchar_t* p = scBuffer;
+	for(int i = 0; i < 4; ++i) {
+		unsigned long long code = (setcode >> i * 16) & 0xffff;
+		for(auto csit = _setnameStrings.begin(); csit != _setnameStrings.end(); ++csit)
+		{
+			unsigned long long settype = csit->first & 0xfff;
+			unsigned long long setsubtype = csit->first & 0xf000;
+			if((code & 0xfff) == settype && (code & 0xf000 & setsubtype) == setsubtype) {
+				BufferIO::CopyWStrRef(csit->second, p, 16);
+				*p = L'\n';
+				*++p = 0;
+			}
+		}
+	}
+	if (p != scBuffer)
+		*(p - 1) = 0;
+	else
+		return unknown_string;
+	return scBuffer;
+}
 int DataManager::CardReader(int code, void* pData) {
 	if(!dataManager.GetData(code, (CardData*)pData))
 		memset(pData, 0, sizeof(CardData));

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -31,6 +31,7 @@ public:
 	const wchar_t* FormatRace(int race);
 	const wchar_t* FormatType(int type);
 	const wchar_t* FormatSetName(unsigned long long setcode);
+	const wchar_t* FormatFullSetName(unsigned long long setcode);
 
 	std::unordered_map<unsigned int, CardDataC> _datas;
 	std::unordered_map<unsigned int, CardString> _strings;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -650,8 +650,21 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			int y = event.MouseInput.Y;
 			irr::core::position2di mouse_pos(x, y);
 			irr::gui::IGUIElement* root = mainGame->env->getRootGUIElement();
-			if(root->getElementFromPoint(mouse_pos) != root)
+			irr::gui::IGUIElement* elem = root->getElementFromPoint(mouse_pos);
+			if(elem != root) {
+				if(elem == mainGame->stSetName) {
+					wchar_t formatBuffer[2048];
+					myswprintf(formatBuffer, L"%ls", mainGame->showingsetname);
+					mainGame->stTip->setText(formatBuffer);
+					irr::core::dimension2d<unsigned int> dtip = mainGame->textFont->getDimension(formatBuffer) + irr::core::dimension2d<unsigned int>(10, 10);
+					mainGame->stTip->setRelativePosition(recti(x + 10, y + 10, x + 10 + dtip.Width, y + 10 + dtip.Height));
+					mainGame->stTip->setVisible(true);
+				} else {
+					mainGame->stTip->setVisible(false);
+				}
 				break;
+			}
+			mainGame->stTip->setVisible(false);
 			int pre_code = hovered_code;
 			if(x >= 314 && x <= 794 && y >= 164 && y <= 435) {
 				int lx = 10, px, py = (y - 164) / 68;

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1015,6 +1015,7 @@ void Game::ShowCardInfo(int code) {
 		if(sc) {
 			offset = 23;
 			myswprintf(formatBuffer, L"%ls%ls", dataManager.GetSysString(1329), dataManager.FormatSetName(sc));
+			showingsetname = dataManager.FormatFullSetName(sc);
 			stSetName->setText(formatBuffer);
 		} else
 			stSetName->setText(L"");

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -138,6 +138,7 @@ public:
 	int signalFrame;
 	int actionParam;
 	const wchar_t* showingtext;
+	const wchar_t* showingsetname;
 	int showcard;
 	int showcardcode;
 	int showcarddif;


### PR DESCRIPTION
鼠标放到卡片系列上时，显示所有的系列名。解决「红莲魔」「星辉士」「水晶机巧」等字段译名问题。

![image](https://cloud.githubusercontent.com/assets/13391795/19733005/467db2e4-9bd5-11e6-9c87-daba9aaa6e53.png)
![image](https://cloud.githubusercontent.com/assets/13391795/19733034/5840aa22-9bd5-11e6-8010-e4c4477c805f.png)
