### PR TITLE
fix duel end when changing side

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -205,6 +205,11 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				DuelClient::SendBufferToServer(CTOS_UPDATE_DECK, deckbuf, pdeck - deckbuf);
 				break;
 			}
+			case BUTTON_MSG_OK: {
+				mainGame->HideElement(mainGame->wMessage);
+				mainGame->actionSignal.Set();
+				break;
+			}
 			case BUTTON_YES: {
 				mainGame->HideElement(mainGame->wQuery);
 				if(!mainGame->is_building || mainGame->is_siding)

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -522,6 +522,8 @@ void DuelClient::HandleSTOCPacketLan(char* data, unsigned int len) {
 		mainGame->closeDoneSignal.Wait();
 		mainGame->gMutex.Lock();
 		mainGame->dInfo.isStarted = false;
+		mainGame->is_building = false;
+		mainGame->wDeckEdit->setVisible(false);
 		mainGame->btnCreateHost->setEnabled(true);
 		mainGame->btnJoinHost->setEnabled(true);
 		mainGame->btnJoinCancel->setEnabled(true);


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/13391795/21612823/9d5e7080-d20d-11e6-86e8-646db5f5afe1.png)
`DeckBuilder` didn't handle `BUTTON_MSG_OK`, so it will stuck in this dialog if one player quit when changing side.