### PR TITLE
set working dir on windows

### DIFF
--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -34,6 +34,13 @@ void ClickButton(irr::gui::IGUIElement* btn) {
 
 int main(int argc, char* argv[]) {
 #ifdef _WIN32
+	wchar_t exepath[MAX_PATH];
+	GetModuleFileName(NULL, exepath, MAX_PATH);
+	wchar_t* p = wcsrchr(exepath, '\\');
+	*p = '\0';
+	SetCurrentDirectory(exepath);
+#endif //_WIN32
+#ifdef _WIN32
 	WORD wVersionRequested;
 	WSADATA wsaData;
 	wVersionRequested = MAKEWORD(2, 2);


### PR DESCRIPTION
目前YGOPRO的工作目录会遵循调用它的路径，也就是说，在D:\DATA下运行E:\GAME\YGOPRO\YGOPRO.EXE，YGOPRO会试图从D:\DATA中寻找数据库和卡图。这可能是不合理的。
此外这也造成了 -d 等参数无法通过文件关联正常使用，因为文件关联后双击打开时的工作目录也不是YGOPRO.EXE的目录，而是文件所在目录。
因此我觉得有必要将工作目录设定为程序所在目录。