### PR TITLE
Added MSG_ROCK_PAPER_SCISSORS and MSG_HAND_RES

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2923,7 +2923,10 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		mainGame->stHintMsg->setVisible(false);
-		mainGame->showcardcode = ((res & 0x3) - 1) + ((((res >> 2) & 0x3) - 1) << 16);
+		if(mainGame->dInfo.isFirst)
+			mainGame->showcardcode = ((res & 0x3) - 1) + ((((res >> 2) & 0x3) - 1) << 16);
+		else
+			mainGame->showcardcode = (((res >> 2) & 0x3) - 1) + (((res & 0x3) - 1) << 16);
 		mainGame->showcarddif = 50;
 		mainGame->showcardp = 0;
 		mainGame->showcard = 100;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2911,6 +2911,8 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 	}
 	case MSG_ROCK_PAPER_SCISSORS: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+			return true;
 		mainGame->gMutex.Lock();
 		mainGame->PopupElement(mainGame->wHand);
 		mainGame->gMutex.Unlock();
@@ -2918,6 +2920,8 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 	}
 	case MSG_HAND_RES: {
 		int res = BufferIO::ReadInt8(pbuf);
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+			return true;
 		mainGame->stHintMsg->setVisible(false);
 		mainGame->showcardcode = ((res & 0x3) - 1) + ((((res >> 2) & 0x3) - 1) << 16);
 		mainGame->showcarddif = 50;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2917,10 +2917,9 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		return false;
 	}
 	case MSG_HAND_RES: {
-		int res1 = BufferIO::ReadInt8(pbuf);
-		int res2 = BufferIO::ReadInt8(pbuf);
+		int res = BufferIO::ReadInt8(pbuf);
 		mainGame->stHintMsg->setVisible(false);
-		mainGame->showcardcode = (res1 - 1) + ((res2 - 1) << 16);
+		mainGame->showcardcode = ((res & 0x3) - 1) + ((((res >> 2) & 0x3) - 1) << 16);
 		mainGame->showcarddif = 50;
 		mainGame->showcardp = 0;
 		mainGame->showcard = 100;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2909,6 +2909,24 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		mainGame->WaitFrameSignal(40);
 		return true;
 	}
+	case MSG_ROCK_PAPER_SCISSORS: {
+		/*int player = */mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
+		mainGame->gMutex.Lock();
+		mainGame->PopupElement(mainGame->wHand);
+		mainGame->gMutex.Unlock();
+		return false;
+	}
+	case MSG_HAND_RES: {
+		int res1 = BufferIO::ReadInt8(pbuf);
+		int res2 = BufferIO::ReadInt8(pbuf);
+		mainGame->stHintMsg->setVisible(false);
+		mainGame->showcardcode = (res1 - 1) + ((res2 - 1) << 16);
+		mainGame->showcarddif = 50;
+		mainGame->showcardp = 0;
+		mainGame->showcard = 100;
+		mainGame->WaitFrameSignal(60);
+		return false;
+	}
 	case MSG_ANNOUNCE_RACE: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
 		mainGame->dField.announce_count = BufferIO::ReadInt8(pbuf);

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -29,11 +29,16 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			case BUTTON_HAND2:
 			case BUTTON_HAND3: {
 				mainGame->wHand->setVisible(false);
-				mainGame->stHintMsg->setText(L"");
-				mainGame->stHintMsg->setVisible(true);
-				CTOS_HandResult cshr;
-				cshr.res = id - BUTTON_HAND1 + 1;
-				DuelClient::SendPacketToServer(CTOS_HAND_RESULT, cshr);
+				if(mainGame->dInfo.curMsg == MSG_ROCK_PAPER_SCISSORS){
+					DuelClient::SetResponseI(id - BUTTON_HAND1 + 1);
+					DuelClient::SendResponse();
+				} else {
+					mainGame->stHintMsg->setText(L"");
+					mainGame->stHintMsg->setVisible(true);
+					CTOS_HandResult cshr;
+					cshr.res = id - BUTTON_HAND1 + 1;
+					DuelClient::SendPacketToServer(CTOS_HAND_RESULT, cshr);
+				}
 				break;
 			}
 			case BUTTON_FIRST:

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -743,6 +743,15 @@ bool ReplayMode::ReplayAnalyze(char* msg, unsigned int len) {
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
+		case MSG_ROCK_PAPER_SCISSORS: {
+			player = BufferIO::ReadInt8(pbuf);
+			return ReadReplayResponse();
+		}
+		case MSG_HAND_RES: {
+			pbuf += 1;
+			DuelClient::ClientAnalyze(offset, pbuf - offset);
+			break;
+		}
 		case MSG_ANNOUNCE_RACE: {
 			player = BufferIO::ReadInt8(pbuf);
 			pbuf += 5;

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1257,7 +1257,7 @@ int SingleDuel::Analyze(char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_HAND_RES: {
-			pbuf += 2;
+			pbuf += 1;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			for (auto oit = observers.begin(); oit != observers.end(); ++oit)

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1250,6 +1250,20 @@ int SingleDuel::Analyze(char* msgbuffer, unsigned int len) {
 				NetServer::ReSendToPlayer(*oit);
 			break;
 		}
+		case MSG_ROCK_PAPER_SCISSORS: {
+			player = BufferIO::ReadInt8(pbuf);
+			WaitforResponse(player);
+			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
+			return 1;
+		}
+		case MSG_HAND_RES: {
+			pbuf += 2;
+			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
+			NetServer::ReSendToPlayer(players[1]);
+			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
+				NetServer::ReSendToPlayer(*oit);
+			break;
+		}
 		case MSG_ANNOUNCE_RACE: {
 			player = BufferIO::ReadInt8(pbuf);
 			pbuf += 5;

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -578,7 +578,7 @@ bool SingleMode::SinglePlayAnalyze(char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_HAND_RES: {
-			pbuf += 2;
+			pbuf += 1;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -569,6 +569,19 @@ bool SingleMode::SinglePlayAnalyze(char* msg, unsigned int len) {
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
+		case MSG_ROCK_PAPER_SCISSORS: {
+			player = BufferIO::ReadInt8(pbuf);
+			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
+				mainGame->singleSignal.Reset();
+				mainGame->singleSignal.Wait();
+			}
+			break;
+		}
+		case MSG_HAND_RES: {
+			pbuf += 2;
+			DuelClient::ClientAnalyze(offset, pbuf - offset);
+			break;
+		}
 		case MSG_ANNOUNCE_RACE: {
 			player = BufferIO::ReadInt8(pbuf);
 			pbuf += 5;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1289,6 +1289,22 @@ int TagDuel::Analyze(char* msgbuffer, unsigned int len) {
 				NetServer::ReSendToPlayer(*oit);
 			break;
 		}
+		case MSG_ROCK_PAPER_SCISSORS: {
+			player = BufferIO::ReadInt8(pbuf);
+			WaitforResponse(player);
+			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
+			return 1;
+		}
+		case MSG_HAND_RES: {
+			pbuf += 2;
+			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
+			NetServer::ReSendToPlayer(players[1]);
+			NetServer::ReSendToPlayer(players[2]);
+			NetServer::ReSendToPlayer(players[3]);
+			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
+				NetServer::ReSendToPlayer(*oit);
+			break;
+		}
 		case MSG_ANNOUNCE_RACE: {
 			player = BufferIO::ReadInt8(pbuf);
 			pbuf += 5;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1296,7 +1296,7 @@ int TagDuel::Analyze(char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_HAND_RES: {
-			pbuf += 2;
+			pbuf += 1;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);


### PR DESCRIPTION
This function allows you to use the rock paper scissors used at the start of the duel, while dueling. I made it to support the new card (Transmission Gear) that requires this function
![image](https://cloud.githubusercontent.com/assets/18705342/25024664/0eaf9e14-209f-11e7-9a9b-c03b1dea1602.png)

core related commit: https://github.com/Fluorohydride/ygopro-core/pull/89