### PR TITLE
fix data_manager.cpp

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -290,7 +290,7 @@ const wchar_t* DataManager::FormatSetName(unsigned long long setcode) {
 	for(int i = 0; i < 4; ++i) {
 		const wchar_t* setname = GetSetName((setcode >> i * 16) & 0xffff);
 		if(setname) {
-			BufferIO::CopyWStrRef(setname, p, 16);
+			BufferIO::CopyWStrRef(setname, p, 32);
 			*p = L'|';
 			*++p = 0;
 		}


### PR DESCRIPTION
Fix this: English setname don't show fully.

Before:
![before](https://user-images.githubusercontent.com/10573786/26998692-b8833c02-4dc2-11e7-8707-b9966df2c455.JPG)
After:
![after](https://user-images.githubusercontent.com/10573786/26998695-c250765a-4dc2-11e7-99bb-054b87a11ca3.JPG)