### PR TITLE
add nearest-neighbor anti-aliasing scaling for card pictures

### DIFF
--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -746,10 +746,10 @@ void Game::DrawSpec() {
 		switch(showcard) {
 		case 1: {
 			driver->draw2DImage(imageManager.GetTexture(showcardcode), position2di(574, 150));
-			driver->draw2DImage(imageManager.tMask, recti(574, 150, 574 + (showcarddif > 177 ? 177 : showcarddif), 404),
-			                    recti(254 - showcarddif, 0, 254 - (showcarddif > 177 ? showcarddif - 177 : 0), 254), 0, 0, true);
+			driver->draw2DImage(imageManager.tMask, recti(574, 150, 574 + (showcarddif > CARD_IMG_WIDTH ? CARD_IMG_WIDTH : showcarddif), 404),
+			                    recti(CARD_IMG_HEIGHT - showcarddif, 0, CARD_IMG_HEIGHT - (showcarddif > CARD_IMG_WIDTH ? showcarddif - CARD_IMG_WIDTH : 0), CARD_IMG_HEIGHT), 0, 0, true);
 			showcarddif += 15;
-			if(showcarddif >= 254) {
+			if(showcarddif >= CARD_IMG_HEIGHT) {
 				showcard = 2;
 				showcarddif = 0;
 			}
@@ -757,9 +757,9 @@ void Game::DrawSpec() {
 		}
 		case 2: {
 			driver->draw2DImage(imageManager.GetTexture(showcardcode), position2di(574, 150));
-			driver->draw2DImage(imageManager.tMask, recti(574 + showcarddif, 150, 761, 404), recti(0, 0, 177 - showcarddif, 254), 0, 0, true);
+			driver->draw2DImage(imageManager.tMask, recti(574 + showcarddif, 150, 761, 404), recti(0, 0, CARD_IMG_WIDTH - showcarddif, CARD_IMG_HEIGHT), 0, 0, true);
 			showcarddif += 15;
-			if(showcarddif >= 177) {
+			if(showcarddif >= CARD_IMG_WIDTH) {
 				showcard = 0;
 			}
 			break;
@@ -777,7 +777,7 @@ void Game::DrawSpec() {
 			matManager.c2d[2] = (showcarddif << 24) | 0xffffff;
 			matManager.c2d[3] = (showcarddif << 24) | 0xffffff;
 			driver->draw2DImage(imageManager.GetTexture(showcardcode), recti(574, 154, 751, 404),
-			                    recti(0, 0, 177, 254), 0, matManager.c2d, true);
+			                    recti(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), 0, matManager.c2d, true);
 			if(showcarddif < 255)
 				showcarddif += 17;
 			break;
@@ -788,7 +788,7 @@ void Game::DrawSpec() {
 			matManager.c2d[2] = (showcarddif << 25) | 0xffffff;
 			matManager.c2d[3] = (showcarddif << 25) | 0xffffff;
 			driver->draw2DImage(imageManager.GetTexture(showcardcode), recti(662 - showcarddif * 0.69685f, 277 - showcarddif, 662 + showcarddif * 0.69685f, 277 + showcarddif),
-			                    recti(0, 0, 177, 254), 0, matManager.c2d, true);
+			                    recti(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), 0, matManager.c2d, true);
 			if(showcarddif < 127)
 				showcarddif += 9;
 			break;
@@ -803,12 +803,12 @@ void Game::DrawSpec() {
 		}
 		case 7: {
 			core::position2d<s32> corner[4];
-			float y = sin(showcarddif * 3.1415926f / 180.0f) * 254;
-			corner[0] = core::position2d<s32>(574 - (254 - y) * 0.3f, 404 - y);
-			corner[1] = core::position2d<s32>(751 + (254 - y) * 0.3f, 404 - y);
+			float y = sin(showcarddif * 3.1415926f / 180.0f) * CARD_IMG_HEIGHT;
+			corner[0] = core::position2d<s32>(574 - (CARD_IMG_HEIGHT - y) * 0.3f, 404 - y);
+			corner[1] = core::position2d<s32>(751 + (CARD_IMG_HEIGHT - y) * 0.3f, 404 - y);
 			corner[2] = core::position2d<s32>(574, 404);
 			corner[3] = core::position2d<s32>(751, 404);
-			irr::gui::Draw2DImageQuad(driver, imageManager.GetTexture(showcardcode), rect<s32>(0, 0, 177, 254), corner);
+			irr::gui::Draw2DImageQuad(driver, imageManager.GetTexture(showcardcode), rect<s32>(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), corner);
 			showcardp++;
 			showcarddif += 9;
 			if(showcarddif >= 90)
@@ -1022,8 +1022,6 @@ void Game::WaitFrameSignal(int frame) {
 	frameSignal.Wait();
 }
 void Game::DrawThumb(code_pointer cp, position2di pos, std::unordered_map<int, int>* lflist) {
-	const int width = 44; //standard pic size, maybe it should be defined in game.h
-	const int height = 64;
 	int code = cp->first;
 	int lcode = cp->second.alias;
 	if(lcode == 0)
@@ -1032,7 +1030,7 @@ void Game::DrawThumb(code_pointer cp, position2di pos, std::unordered_map<int, i
 	if(img == NULL)
 		return; //NULL->getSize() will cause a crash
 	dimension2d<u32> size = img->getOriginalSize();
-	driver->draw2DImage(img, rect<s32>(pos.X, pos.Y, pos.X + width, pos.Y + height), rect<s32>(0, 0, size.Width, size.Height));
+	driver->draw2DImage(img, rect<s32>(pos.X, pos.Y, pos.X + CARD_THUMB_WIDTH, pos.Y + CARD_THUMB_HEIGHT), rect<s32>(0, 0, size.Width, size.Height));
 
 	if(lflist->count(lcode)) {
 		switch((*lflist)[lcode]) {

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -905,6 +905,8 @@ void Game::LoadConfig() {
 	char strbuf[32];
 	char valbuf[256];
 	wchar_t wstr[256];
+	gameConf.use_d3d = 0;
+	gameConf.use_image_scale = 1;
 	gameConf.antialias = 0;
 	gameConf.serverport = 7911;
 	gameConf.textfontsize = 12;
@@ -937,6 +939,8 @@ void Game::LoadConfig() {
 			gameConf.antialias = atoi(valbuf);
 		} else if(!strcmp(strbuf, "use_d3d")) {
 			gameConf.use_d3d = atoi(valbuf) > 0;
+		} else if(!strcmp(strbuf, "use_image_scale")) {
+			gameConf.use_image_scale = atoi(valbuf) > 0;
 		} else if(!strcmp(strbuf, "errorlog")) {
 			enable_log = atoi(valbuf);
 		} else if(!strcmp(strbuf, "textfont")) {
@@ -1009,6 +1013,7 @@ void Game::SaveConfig() {
 	fprintf(fp, "#config file\n#nickname & gamename should be less than 20 characters\n");
 	char linebuf[256];
 	fprintf(fp, "use_d3d = %d\n", gameConf.use_d3d ? 1 : 0);
+	fprintf(fp, "use_image_scale = %d\n", gameConf.use_image_scale ? 1 : 0);
 	fprintf(fp, "antialias = %d\n", gameConf.antialias);
 	fprintf(fp, "errorlog = %d\n", enable_log);
 	BufferIO::CopyWStr(ebNickName->getText(), gameConf.nickname, 20);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -197,10 +197,10 @@ bool Game::Initialize() {
 	btnHostPrepStart = env->addButton(rect<s32>(230, 280, 340, 305), wHostPrepare, BUTTON_HP_START, dataManager.GetSysString(1215));
 	btnHostPrepCancel = env->addButton(rect<s32>(350, 280, 460, 305), wHostPrepare, BUTTON_HP_CANCEL, dataManager.GetSysString(1210));
 	//img
-	wCardImg = env->addStaticText(L"", rect<s32>(1, 1, 199, 273), true, false, 0, -1, true);
+	wCardImg = env->addStaticText(L"", rect<s32>(1, 1, 1 + CARD_IMG_WIDTH + 20, 1 + CARD_IMG_HEIGHT + 18), true, false, 0, -1, true);
 	wCardImg->setBackgroundColor(0xc0c0c0c0);
 	wCardImg->setVisible(false);
-	imgCard = env->addImage(rect<s32>(10, 9, 187, 263), wCardImg);
+	imgCard = env->addImage(rect<s32>(10, 9, 10 + CARD_IMG_WIDTH, 9 + CARD_IMG_HEIGHT), wCardImg);
 	imgCard->setUseAlphaChannel(true);
 	//phase
 	wPhase = env->addStaticText(L"", rect<s32>(480, 310, 855, 330));
@@ -333,14 +333,14 @@ bool Game::Initialize() {
 	btnPSAU->setImageScale(core::vector2df(0.5, 0.5));
 	btnPSAD = irr::gui::CGUIImageButton::addImageButton(env, rect<s32>(155, 45, 295, 185), wPosSelect, BUTTON_POS_AD);
 	btnPSAD->setImageScale(core::vector2df(0.5, 0.5));
-	btnPSAD->setImage(imageManager.tCover[0], rect<s32>(0, 0, 177, 254));
+	btnPSAD->setImage(imageManager.tCover[0], rect<s32>(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT));
 	btnPSDU = irr::gui::CGUIImageButton::addImageButton(env, rect<s32>(300, 45, 440, 185), wPosSelect, BUTTON_POS_DU);
 	btnPSDU->setImageScale(core::vector2df(0.5, 0.5));
 	btnPSDU->setImageRotation(270);
 	btnPSDD = irr::gui::CGUIImageButton::addImageButton(env, rect<s32>(445, 45, 585, 185), wPosSelect, BUTTON_POS_DD);
 	btnPSDD->setImageScale(core::vector2df(0.5, 0.5));
 	btnPSDD->setImageRotation(270);
-	btnPSDD->setImage(imageManager.tCover[0], rect<s32>(0, 0, 177, 254));
+	btnPSDD->setImage(imageManager.tCover[0], rect<s32>(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT));
 	//card select
 	wCardSelect = env->addWindow(rect<s32>(320, 100, 1000, 400), false, L"");
 	wCardSelect->getCloseButton()->setVisible(false);

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -13,6 +13,7 @@ namespace ygo {
 
 struct Config {
 	bool use_d3d;
+	bool use_image_scale;
 	unsigned short antialias;
 	unsigned short serverport;
 	unsigned char textfontsize;

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -429,6 +429,11 @@ extern Game* mainGame;
 
 }
 
+#define CARD_IMG_WIDTH		177
+#define CARD_IMG_HEIGHT		254
+#define CARD_THUMB_WIDTH	44
+#define CARD_THUMB_HEIGHT	64
+
 #define UEVENT_EXIT			0x1
 #define UEVENT_TOWINDOW		0x2
 

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -173,10 +173,9 @@ irr::video::ITexture* ImageManager::GetTexture(int code) {
 		if(img == NULL && !mainGame->gameConf.use_image_scale) {
 			tMap[code] = NULL;
 			return GetTextureThumb(code);
-		} else {
-			tMap[code] = img;
-			return (img == NULL) ? tUnknown : img;
 		}
+		tMap[code] = img;
+		return (img == NULL) ? tUnknown : img;
 	}
 	if(tit->second)
 		return tit->second;
@@ -189,23 +188,22 @@ irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 	auto tit = tThumb.find(code);
 	if(tit == tThumb.end()) {
 		char file[256];
-		char exfile[256];
-		if(mainGame->gameConf.use_image_scale)
-			sprintf(file, "pics/%d.jpg", code);
-		else
-			sprintf(file, "pics/thumbnail/%d.jpg", code);
-		sprintf(exfile, "expansions/%s", file);
-		irr::video::ITexture* img = GetTextureFromFile(exfile, CARD_THUMB_WIDTH, CARD_THUMB_HEIGHT);
+		sprintf(file, "expansions/pics/thumbnail/%d.jpg", code);
+		irr::video::ITexture* img = GetTextureFromFile(file, CARD_THUMB_WIDTH, CARD_THUMB_HEIGHT);
 		if(img == NULL) {
+			sprintf(file, "pics/thumbnail/%d.jpg", code);
 			img = GetTextureFromFile(file, CARD_THUMB_WIDTH, CARD_THUMB_HEIGHT);
 		}
-		if(img == NULL) {
-			tThumb[code] = NULL;
-			return tUnknown;
-		} else {
-			tThumb[code] = img;
-			return img;
+		if(img == NULL && mainGame->gameConf.use_image_scale) {
+			sprintf(file, "expansions/pics/%d.jpg", code);
+			img = GetTextureFromFile(file, CARD_THUMB_WIDTH, CARD_THUMB_HEIGHT);
+			if(img == NULL) {
+				sprintf(file, "pics/%d.jpg", code);
+				img = GetTextureFromFile(file, CARD_THUMB_WIDTH, CARD_THUMB_HEIGHT);
+			}
 		}
+		tThumb[code] = img;
+		return (img == NULL) ? tUnknown : img;
 	}
 	if(tit->second)
 		return tit->second;

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -1,4 +1,5 @@
 #include "image_manager.h"
+#include "game.h"
 
 namespace ygo {
 
@@ -63,6 +64,100 @@ void ImageManager::RemoveTexture(int code) {
 		tMap.erase(tit);
 	}
 }
+// function by Warr1024, from https://github.com/minetest/minetest/issues/2419 , modified
+void imageScaleNNAA(irr::video::IImage *src, irr::video::IImage *dest)
+{
+	double sx, sy, minsx, maxsx, minsy, maxsy, area, ra, ga, ba, aa, pw, ph, pa;
+	u32 dy, dx;
+	irr::video::SColor pxl;
+
+	// Cache rectsngle boundaries.
+	double sw = src->getDimension().Width * 1.0;
+	double sh = src->getDimension().Height * 1.0;
+
+	// Walk each destination image pixel.
+	// Note: loop y around x for better cache locality.
+	irr::core::dimension2d<u32> dim = dest->getDimension();
+	for(dy = 0; dy < dim.Height; dy++)
+		for(dx = 0; dx < dim.Width; dx++) {
+
+			// Calculate floating-point source rectangle bounds.
+			minsx = dx * sw / dim.Width;
+			maxsx = minsx + sw / dim.Width;
+			minsy = dy * sh / dim.Height;
+			maxsy = minsy + sh / dim.Height;
+
+			// Total area, and integral of r, g, b values over that area,
+			// initialized to zero, to be summed up in next loops.
+			area = 0;
+			ra = 0;
+			ga = 0;
+			ba = 0;
+			aa = 0;
+
+			// Loop over the integral pixel positions described by those bounds.
+			for(sy = floor(minsy); sy < maxsy; sy++)
+				for(sx = floor(minsx); sx < maxsx; sx++) {
+
+					// Calculate width, height, then area of dest pixel
+					// that's covered by this source pixel.
+					pw = 1;
+					if(minsx > sx)
+						pw += sx - minsx;
+					if(maxsx < (sx + 1))
+						pw += maxsx - sx - 1;
+					ph = 1;
+					if(minsy > sy)
+						ph += sy - minsy;
+					if(maxsy < (sy + 1))
+						ph += maxsy - sy - 1;
+					pa = pw * ph;
+
+					// Get source pixel and add it to totals, weighted
+					// by covered area and alpha.
+					pxl = src->getPixel((u32)sx, (u32)sy);
+					area += pa;
+					ra += pa * pxl.getRed();
+					ga += pa * pxl.getGreen();
+					ba += pa * pxl.getBlue();
+					aa += pa * pxl.getAlpha();
+				}
+
+			// Set the destination image pixel to the average color.
+			if(area > 0) {
+				pxl.setRed(ra / area + 0.5);
+				pxl.setGreen(ga / area + 0.5);
+				pxl.setBlue(ba / area + 0.5);
+				pxl.setAlpha(aa / area + 0.5);
+			} else {
+				pxl.setRed(0);
+				pxl.setGreen(0);
+				pxl.setBlue(0);
+				pxl.setAlpha(0);
+			}
+			dest->setPixel(dx, dy, pxl);
+		}
+}
+irr::video::ITexture* ImageManager::GetTextureFromFile(char* file, s32 width, s32 height) {
+	if(mainGame->gameConf.use_image_scale) {
+		irr::video::ITexture* texture;
+		irr::video::IImage* srcimg = driver->createImageFromFile(file);
+		if(srcimg == NULL)
+			return NULL;
+		if(srcimg->getDimension() == irr::core::dimension2d<u32>(width, height)) {
+			texture = driver->addTexture(file, srcimg);
+		} else {
+			video::IImage *destimg = driver->createImage(srcimg->getColorFormat(), irr::core::dimension2d<u32>(width, height));
+			imageScaleNNAA(srcimg, destimg);
+			texture = driver->addTexture(file, destimg);
+			destimg->drop();
+		}
+		srcimg->drop();
+		return texture;
+	} else {
+		return driver->getTexture(file);
+	}
+}
 irr::video::ITexture* ImageManager::GetTexture(int code) {
 	if(code == 0)
 		return tUnknown;
@@ -70,12 +165,12 @@ irr::video::ITexture* ImageManager::GetTexture(int code) {
 	if(tit == tMap.end()) {
 		char file[256];
 		sprintf(file, "expansions/pics/%d.jpg", code);
-		irr::video::ITexture* img = driver->getTexture(file);
+		irr::video::ITexture* img = GetTextureFromFile(file, CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
 		if(img == NULL) {
 			sprintf(file, "pics/%d.jpg", code);
-			img = driver->getTexture(file);
+			img = GetTextureFromFile(file, CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
 		}
-		if(img == NULL) {
+		if(img == NULL && !mainGame->gameConf.use_image_scale) {
 			tMap[code] = NULL;
 			return GetTextureThumb(code);
 		} else {
@@ -86,7 +181,7 @@ irr::video::ITexture* ImageManager::GetTexture(int code) {
 	if(tit->second)
 		return tit->second;
 	else
-		return GetTextureThumb(code);
+		return mainGame->gameConf.use_image_scale ? tUnknown : GetTextureThumb(code);
 }
 irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 	if(code == 0)
@@ -94,11 +189,15 @@ irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 	auto tit = tThumb.find(code);
 	if(tit == tThumb.end()) {
 		char file[256];
-		sprintf(file, "expansions/pics/thumbnail/%d.jpg", code);
-		irr::video::ITexture* img = driver->getTexture(file);
-		if(img == NULL) {
+		char exfile[256];
+		if(mainGame->gameConf.use_image_scale)
+			sprintf(file, "pics/%d.jpg", code);
+		else
 			sprintf(file, "pics/thumbnail/%d.jpg", code);
-			img = driver->getTexture(file);
+		sprintf(exfile, "expansions/%s", file);
+		irr::video::ITexture* img = GetTextureFromFile(exfile, CARD_THUMB_WIDTH, CARD_THUMB_HEIGHT);
+		if(img == NULL) {
+			img = GetTextureFromFile(file, CARD_THUMB_WIDTH, CARD_THUMB_HEIGHT);
 		}
 		if(img == NULL) {
 			tThumb[code] = NULL;

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -175,7 +175,7 @@ irr::video::ITexture* ImageManager::GetTexture(int code) {
 			return GetTextureThumb(code);
 		} else {
 			tMap[code] = img;
-			return img;
+			return (img == NULL) ? tUnknown : img;
 		}
 	}
 	if(tit->second)
@@ -219,18 +219,18 @@ irr::video::ITexture* ImageManager::GetTextureField(int code) {
 	if(tit == tFields.end()) {
 		char file[256];
 		sprintf(file, "expansions/pics/field/%d.png", code);
-		irr::video::ITexture* img = driver->getTexture(file);
+		irr::video::ITexture* img = GetTextureFromFile(file, 512, 512);
 		if(img == NULL) {
 			sprintf(file, "expansions/pics/field/%d.jpg", code);
-			img = driver->getTexture(file);
+			img = GetTextureFromFile(file, 512, 512);
 		}
 		if(img == NULL) {
 			sprintf(file, "pics/field/%d.png", code);
-			img = driver->getTexture(file);
+			img = GetTextureFromFile(file, 512, 512);
 		}
 		if(img == NULL) {
 			sprintf(file, "pics/field/%d.jpg", code);
-			img = driver->getTexture(file);
+			img = GetTextureFromFile(file, 512, 512);
 			if(img == NULL) {
 				tFields[code] = NULL;
 				return NULL;

--- a/gframe/image_manager.h
+++ b/gframe/image_manager.h
@@ -13,6 +13,7 @@ public:
 	void SetDevice(irr::IrrlichtDevice* dev);
 	void ClearTexture();
 	void RemoveTexture(int code);
+	irr::video::ITexture* GetTextureFromFile(char* file, s32 width, s32 height);
 	irr::video::ITexture* GetTexture(int code);
 	irr::video::ITexture* GetTextureThumb(int code);
 	irr::video::ITexture* GetTextureField(int code);


### PR DESCRIPTION
`imageScaleNNAA` function taken from @Warr1024 in https://github.com/minetest/minetest

Scale the pictures with nearest-neighbor anti-aliasing algorithm, make it can read pics of any size perfectly. And no longer use thumbnail folder.

before vs after
![image](https://user-images.githubusercontent.com/13391795/29036013-3963e9e4-7bd0-11e7-912f-fa8ae5b8ce8e.png)
