### PR TITLE
Use std::string instead of C string in LoadExpansionDB

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -782,19 +782,16 @@ void Game::LoadExpansionDB() {
 #else
 	DIR * dir;
 	struct dirent * dirp;
-	const char *foldername = "./expansions/";
-	if((dir = opendir(foldername)) != NULL) {
+	std::string foldername = "./expansions/";
+	if((dir = opendir(foldername.c_str())) != NULL) {
 		while((dirp = readdir(dir)) != NULL) {
 			size_t len = strlen(dirp->d_name);
 			if(len < 5 || strcasecmp(dirp->d_name + len - 4, ".cdb") != 0)
 				continue;
-			char *filepath = (char *)malloc(sizeof(char)*(len + strlen(foldername)));
-			strncpy(filepath, foldername, strlen(foldername) + 1);
-			strncat(filepath, dirp->d_name, len);
+			std::string filepath = foldername + dirp->d_name;
 			std::cout << "Found file " << filepath << std::endl;
-			if(!dataManager.LoadDB(filepath))
+			if(!dataManager.LoadDB(filepath.c_str()))
 				std::cout << "Error loading file" << std::endl;
-			free(filepath);
 		}
 		closedir(dir);
 	}


### PR DESCRIPTION
In the original code, the terminating NUL character is not considered in size, and the strncat writes the NUL character outside the buffer.