### PR TITLE
Fix chat message receiving

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -643,7 +643,7 @@ void DuelClient::HandleSTOCPacketLan(char* data, unsigned int len) {
 		}
 		wchar_t msg[256];
 		BufferIO::CopyWStr(pkt->msg, msg, 256);
-		msg[(len - 3) / 2] = 0;
+		msg[((len - 3) / 2) - 1] = 0;
 		mainGame->gMutex.Lock();
 		mainGame->AddChatMsg(msg, player);
 		mainGame->gMutex.Unlock();

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -643,7 +643,6 @@ void DuelClient::HandleSTOCPacketLan(char* data, unsigned int len) {
 		}
 		wchar_t msg[256];
 		BufferIO::CopyWStr(pkt->msg, msg, 256);
-		msg[((len - 3) / 2) - 1] = 0;
 		mainGame->gMutex.Lock();
 		mainGame->AddChatMsg(msg, player);
 		mainGame->gMutex.Unlock();


### PR DESCRIPTION
Now it reads the index with the correct range, from 0 to 255, before it crashed when a message had the max length
--update--
I directly removed that part because the bufferio function already add the terminating character