### PR TITLE
Extra Deck Cards handling change + new functions

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -203,8 +203,20 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 		break;
 	}
 	case LOCATION_EXTRA: {
-		extra[controler].push_back(pcard);
-		pcard->sequence = extra[controler].size() - 1;
+		if(extra_p_count[controler] == 0 || (pcard->position & POS_FACEUP)) {
+			extra[controler].push_back(pcard);
+			pcard->sequence = extra[controler].size() - 1;
+		} else {
+			extra[controler].push_back(0);
+			for (int i = extra[controler].size() - 1; i > extra[controler].size() - extra_p_count[controler] - 1; --i) {
+				extra[controler][i] = extra[controler][i - 1];
+				extra[controler][i]->sequence++;
+				extra[controler][i]->curPos += irr::core::vector3df(0, 0, 0.01f);
+				extra[controler][i]->mTransform.setTranslation(extra[controler][i]->curPos);
+			}
+			extra[controler][extra[controler].size() - extra_p_count[controler] - 1] = pcard;
+			pcard->sequence = extra[controler].size() - extra_p_count[controler] - 1;
+		}
 		if (pcard->position & POS_FACEUP)
 			extra_p_count[controler]++;
 		break;

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -208,14 +208,15 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 			pcard->sequence = extra[controler].size() - 1;
 		} else {
 			extra[controler].push_back(0);
-			for (int i = extra[controler].size() - 1; i > extra[controler].size() - extra_p_count[controler] - 1; --i) {
+			int p = extra[controler].size() - extra_p_count[controler] - 1;
+			for(int i = extra[controler].size() - 1; i > p; --i) {
 				extra[controler][i] = extra[controler][i - 1];
 				extra[controler][i]->sequence++;
 				extra[controler][i]->curPos += irr::core::vector3df(0, 0, 0.01f);
 				extra[controler][i]->mTransform.setTranslation(extra[controler][i]->curPos);
 			}
-			extra[controler][extra[controler].size() - extra_p_count[controler] - 1] = pcard;
-			pcard->sequence = extra[controler].size() - extra_p_count[controler] - 1;
+			extra[controler][p] = pcard;
+			pcard->sequence = p;
 		}
 		if (pcard->position & POS_FACEUP)
 			extra_p_count[controler]++;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1707,9 +1707,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 				pcard->dPos = irr::core::vector3df(0, -0.20f, 0);
 			else
 				pcard->dPos = irr::core::vector3df(0.15f, 0, 0);
-			if(!mainGame->dField.deck_reversed)
-				pcard->dRot = irr::core::vector3df(0, 3.14159f / 5.0f, 0);
-			else pcard->dRot = irr::core::vector3df(0, 0, 0);
+			pcard->dRot = irr::core::vector3df(0, 3.14159f / 5.0f, 0);
 			pcard->is_moving = true;
 			pcard->aniFrame = 5;
 			mainGame->WaitFrameSignal(45);
@@ -1897,7 +1895,6 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		return true;
 	}
 	case MSG_SHUFFLE_EXTRA: {
-		mainGame->PlaySoundEffect("./sound/shuffle.wav");
 		int player = mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
 		/*int count = */BufferIO::ReadInt8(pbuf);
 		if((mainGame->dField.extra[player].size() - mainGame->dField.extra_p_count[player]) < 2)

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1678,6 +1678,46 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		}
 		return true;
 	}
+	case MSG_CONFIRM_EXTRATOP: {
+		int player = mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
+		int count = BufferIO::ReadInt8(pbuf);
+		int code;
+		ClientCard* pcard;
+		mainGame->dField.selectable_cards.clear();
+		for (int i = 0; i < count; ++i) {
+			code = BufferIO::ReadInt32(pbuf);
+			pbuf += 3;
+			pcard = *(mainGame->dField.extra[player].rbegin() + i + mainGame->dField.extra_p_count[player]);
+			if (code != 0)
+				pcard->SetCode(code);
+		}
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+			return true;
+		myswprintf(textBuffer, dataManager.GetSysString(207), count);
+		mainGame->lstLog->addItem(textBuffer);
+		mainGame->logParam.push_back(0);
+		for (int i = 0; i < count; ++i) {
+			pcard = *(mainGame->dField.extra[player].rbegin() + i + mainGame->dField.extra_p_count[player]);
+			mainGame->gMutex.Lock();
+			myswprintf(textBuffer, L"*[%ls]", dataManager.GetName(pcard->code));
+			mainGame->lstLog->addItem(textBuffer);
+			mainGame->logParam.push_back(pcard->code);
+			mainGame->gMutex.Unlock();
+			if (player == 0)
+				pcard->dPos = irr::core::vector3df(0, -0.20f, 0);
+			else
+				pcard->dPos = irr::core::vector3df(0.15f, 0, 0);
+			if(!mainGame->dField.deck_reversed)
+				pcard->dRot = irr::core::vector3df(0, 3.14159f / 5.0f, 0);
+			else pcard->dRot = irr::core::vector3df(0, 0, 0);
+			pcard->is_moving = true;
+			pcard->aniFrame = 5;
+			mainGame->WaitFrameSignal(45);
+			mainGame->dField.MoveCard(pcard, 5);
+			mainGame->WaitFrameSignal(5);
+		}
+		return true;
+	}
 	case MSG_CONFIRM_CARDS: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
 		int count = BufferIO::ReadInt8(pbuf);
@@ -1854,6 +1894,34 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 			}
 			mainGame->WaitFrameSignal(5);
 		}
+		return true;
+	}
+	case MSG_SHUFFLE_EXTRA: {
+		mainGame->PlaySoundEffect("./sound/shuffle.wav");
+		int player = mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
+		/*int count = */BufferIO::ReadInt8(pbuf);
+		if((mainGame->dField.extra[player].size() - mainGame->dField.extra_p_count[player]) < 2)
+			return true;
+		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
+			for (int i = 0; i < 5; ++i) {
+				for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit) {
+					if(!((*cit)->position & POS_FACEUP)) {
+						(*cit)->dPos = irr::core::vector3df(rand() * 0.4f / RAND_MAX - 0.2f, 0, 0);
+						(*cit)->dRot = irr::core::vector3df(0, 0, 0);
+						(*cit)->is_moving = true;
+						(*cit)->aniFrame = 3;
+					}
+				}
+				mainGame->WaitFrameSignal(3);
+				for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit)
+					if(!((*cit)->position & POS_FACEUP))
+						mainGame->dField.MoveCard(*cit, 3);
+				mainGame->WaitFrameSignal(3);
+			}
+		}
+		for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit)
+			if(!((*cit)->position & POS_FACEUP))
+				(*cit)->SetCode(BufferIO::ReadInt32(pbuf));
 		return true;
 	}
 	case MSG_REFRESH_DECK: {

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -443,6 +443,13 @@ bool ReplayMode::ReplayAnalyze(char* msg, unsigned int len) {
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
+		case MSG_CONFIRM_EXTRATOP: {
+			player = BufferIO::ReadInt8(pbuf);
+			count = BufferIO::ReadInt8(pbuf);
+			pbuf += count * 7;
+			DuelClient::ClientAnalyze(offset, pbuf - offset);
+			break;
+		}
 		case MSG_CONFIRM_CARDS: {
 			player = BufferIO::ReadInt8(pbuf);
 			count = BufferIO::ReadInt8(pbuf);
@@ -457,6 +464,13 @@ bool ReplayMode::ReplayAnalyze(char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
+			/*int oplayer = */BufferIO::ReadInt8(pbuf);
+			int count = BufferIO::ReadInt8(pbuf);
+			pbuf += count * 4;
+			DuelClient::ClientAnalyze(offset, pbuf - offset);
+			break;
+		}
+		case MSG_SHUFFLE_EXTRA: {
 			/*int oplayer = */BufferIO::ReadInt8(pbuf);
 			int count = BufferIO::ReadInt8(pbuf);
 			pbuf += count * 4;

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -754,6 +754,16 @@ int SingleDuel::Analyze(char* msgbuffer, unsigned int len) {
 				NetServer::ReSendToPlayer(*oit);
 			break;
 		}
+		case MSG_CONFIRM_EXTRATOP: {
+			player = BufferIO::ReadInt8(pbuf);
+			count = BufferIO::ReadInt8(pbuf);
+			pbuf += count * 7;
+			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
+			NetServer::ReSendToPlayer(players[1]);
+			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
+				NetServer::ReSendToPlayer(*oit);
+			break;
+		}
 		case MSG_CONFIRM_CARDS: {
 			player = BufferIO::ReadInt8(pbuf);
 			count = BufferIO::ReadInt8(pbuf);
@@ -787,6 +797,18 @@ int SingleDuel::Analyze(char* msgbuffer, unsigned int len) {
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 				NetServer::ReSendToPlayer(*oit);
 			RefreshHand(player, 0x781fff, 0);
+			break;
+		}
+		case MSG_SHUFFLE_EXTRA: {
+			player = BufferIO::ReadInt8(pbuf);
+			count = BufferIO::ReadInt8(pbuf);
+			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
+			for (int i = 0; i < count; ++i)
+				BufferIO::WriteInt32(pbuf, 0);
+			NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, offset, pbuf - offset);
+			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
+				NetServer::ReSendToPlayer(*oit);
+			RefreshExtra(player);
 			break;
 		}
 		case MSG_REFRESH_DECK: {

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -295,6 +295,13 @@ bool SingleMode::SinglePlayAnalyze(char* msg, unsigned int len) {
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
+		case MSG_CONFIRM_EXTRATOP: {
+			player = BufferIO::ReadInt8(pbuf);
+			count = BufferIO::ReadInt8(pbuf);
+			pbuf += count * 7;
+			DuelClient::ClientAnalyze(offset, pbuf - offset);
+			break;
+		}
 		case MSG_CONFIRM_CARDS: {
 			player = BufferIO::ReadInt8(pbuf);
 			count = BufferIO::ReadInt8(pbuf);
@@ -311,6 +318,13 @@ bool SingleMode::SinglePlayAnalyze(char* msg, unsigned int len) {
 		case MSG_SHUFFLE_HAND: {
 			/*int oplayer = */BufferIO::ReadInt8(pbuf);
 			int count = BufferIO::ReadInt8(pbuf);
+			pbuf += count * 4;
+			DuelClient::ClientAnalyze(offset, pbuf - offset);
+			break;
+		}
+		case MSG_SHUFFLE_EXTRA: {
+			player = BufferIO::ReadInt8(pbuf);
+			count = BufferIO::ReadInt8(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -688,6 +688,18 @@ int TagDuel::Analyze(char* msgbuffer, unsigned int len) {
 				NetServer::ReSendToPlayer(*oit);
 			break;
 		}
+		case MSG_CONFIRM_EXTRATOP: {
+			player = BufferIO::ReadInt8(pbuf);
+			count = BufferIO::ReadInt8(pbuf);
+			pbuf += count * 7;
+			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
+			NetServer::ReSendToPlayer(players[1]);
+			NetServer::ReSendToPlayer(players[2]);
+			NetServer::ReSendToPlayer(players[3]);
+			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
+				NetServer::ReSendToPlayer(*oit);
+			break;
+		}
 		case MSG_CONFIRM_CARDS: {
 			player = BufferIO::ReadInt8(pbuf);
 			count = BufferIO::ReadInt8(pbuf);
@@ -727,6 +739,20 @@ int TagDuel::Analyze(char* msgbuffer, unsigned int len) {
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 				NetServer::ReSendToPlayer(*oit);
 			RefreshHand(player, 0x781fff, 0);
+			break;
+		}
+		case MSG_SHUFFLE_EXTRA: {
+			player = BufferIO::ReadInt8(pbuf);
+			count = BufferIO::ReadInt8(pbuf);
+			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
+			NetServer::ReSendToPlayer(players[player * 2 + 1]);
+			for(int i = 0; i < count; ++i)
+				BufferIO::WriteInt32(pbuf, 0);
+			for (int p = (1 - player) * 2, i = 0; i < 2; i++, p++)
+				NetServer::SendBufferToPlayer(players[p], STOC_GAME_MSG, offset, pbuf - offset);
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+				NetServer::ReSendToPlayer(*oit);
+			RefreshExtra(player);
 			break;
 		}
 		case MSG_REFRESH_DECK: {


### PR DESCRIPTION
I changed the way pendulums faceup in extra are handled, now they will always be on top on the deck, even if a card is returned from anywhere into the extra, also i added 2 new messages to handle the new functions needed for "Cynet Storm", MSG_SHUFFLE_EXTRA and MSG_CONFIRM_EXTRA_TOP

https://github.com/Fluorohydride/ygopro-core/pull/127