### PR TITLE
check timeout when waiting CTOS_TIME_CONFIRM

### DIFF
--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1424,6 +1424,9 @@ void SingleDuel::WaitforResponse(int playerid) {
 		NetServer::SendPacketToPlayer(players[0], STOC_TIME_LIMIT, sctl);
 		NetServer::SendPacketToPlayer(players[1], STOC_TIME_LIMIT, sctl);
 		players[playerid]->state = CTOS_TIME_CONFIRM;
+		time_elapsed = 0;
+		timeval timeout = { 1, 0 };
+		event_add(etimer, &timeout);
 	} else
 		players[playerid]->state = CTOS_RESPONSE;
 }
@@ -1432,6 +1435,7 @@ void SingleDuel::TimeConfirm(DuelPlayer* dp) {
 		return;
 	if(dp->type != last_response)
 		return;
+	event_del(etimer);
 	players[last_response]->state = CTOS_RESPONSE;
 	time_elapsed = 0;
 	timeval timeout = {1, 0};


### PR DESCRIPTION
for #2132
Not only `MSG_CONFIRM_CARDS`, all msg except `MSG_SELECT_*` have this issue as long as the client hang on when solving these msg intentionally.
The elapsed time do not count in the time limit of the player.