### PR TITLE
Add announce card cache

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -1424,16 +1424,27 @@ void ClientField::UpdateDeclarableCodeType(bool enter) {
 		ancard.push_back(trycode);
 		return;
 	}
-	bool use_cache = false;
+	bool try_cache = false;
 	if(pname[0] == 0 || pname[1] == 0) {
 		if(!enter)
 			return;
-		use_cache = (mainGame->dInfo.announce_cache.size() != 0);
+		try_cache = true;
 	}
 	mainGame->lstANCard->clear();
 	ancard.clear();
+	if(try_cache && mainGame->dInfo.announce_cache.size()) {
+		for(int i = 0; i < mainGame->dInfo.announce_cache.size(); ++i) {
+			unsigned int cache_code = mainGame->dInfo.announce_cache[i];
+			if(dataManager.GetString(cache_code, &cstr) && dataManager.GetData(cache_code, &cd) && is_declarable(cd, opcode)) {
+				mainGame->lstANCard->addItem(cstr.name.c_str());
+				ancard.push_back(cache_code);
+			}
+		}
+		if(ancard.size())
+			return;
+	}
 	for(auto cit = dataManager._strings.begin(); cit != dataManager._strings.end(); ++cit) {
-		if((!use_cache && cit->second.name.find(pname) != std::wstring::npos) || (use_cache && std::find(mainGame->dInfo.announce_cache.begin(), mainGame->dInfo.announce_cache.end(), cit->first) != mainGame->dInfo.announce_cache.end())) {
+		if(cit->second.name.find(pname) != std::wstring::npos) {
 			auto cp = dataManager.GetCodePointer(cit->first);	//verified by _strings
 			//datas.alias can be double card names or alias
 			if(is_declarable(cp->second, declarable_type)) {
@@ -1460,16 +1471,27 @@ void ClientField::UpdateDeclarableCodeOpcode(bool enter) {
 		ancard.push_back(trycode);
 		return;
 	}
-	bool use_cache = false;
+	bool try_cache = false;
 	if(pname[0] == 0 || pname[1] == 0) {
 		if(!enter)
 			return;
-		use_cache = (mainGame->dInfo.announce_cache.size() != 0);
+		try_cache = true;
 	}
 	mainGame->lstANCard->clear();
 	ancard.clear();
+	if(try_cache && mainGame->dInfo.announce_cache.size()) {
+		for(int i = 0; i < mainGame->dInfo.announce_cache.size(); ++i) {
+			unsigned int cache_code = mainGame->dInfo.announce_cache[i];
+			if(dataManager.GetString(cache_code, &cstr) && dataManager.GetData(cache_code, &cd) && is_declarable(cd, opcode)) {
+				mainGame->lstANCard->addItem(cstr.name.c_str());
+				ancard.push_back(cache_code);
+			}
+		}
+		if(ancard.size())
+			return;
+	}
 	for(auto cit = dataManager._strings.begin(); cit != dataManager._strings.end(); ++cit) {
-		if((!use_cache && cit->second.name.find(pname) != std::wstring::npos) || (use_cache && std::find(mainGame->dInfo.announce_cache.begin(), mainGame->dInfo.announce_cache.end(), cit->first) != mainGame->dInfo.announce_cache.end())) {
+		if(cit->second.name.find(pname) != std::wstring::npos) {
 			auto cp = dataManager.GetCodePointer(cit->first);	//verified by _strings
 			//datas.alias can be double card names or alias
 			if(is_declarable(cp->second, opcode)) {

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -1435,7 +1435,7 @@ void ClientField::UpdateDeclarableCodeType(bool enter) {
 	if(try_cache && mainGame->dInfo.announce_cache.size()) {
 		for(int i = 0; i < mainGame->dInfo.announce_cache.size(); ++i) {
 			unsigned int cache_code = mainGame->dInfo.announce_cache[i];
-			if(dataManager.GetString(cache_code, &cstr) && dataManager.GetData(cache_code, &cd) && is_declarable(cd, opcode)) {
+			if(dataManager.GetString(cache_code, &cstr) && dataManager.GetData(cache_code, &cd) && is_declarable(cd, declarable_type)) {
 				mainGame->lstANCard->addItem(cstr.name.c_str());
 				ancard.push_back(cache_code);
 			}

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -1424,12 +1424,16 @@ void ClientField::UpdateDeclarableCodeType(bool enter) {
 		ancard.push_back(trycode);
 		return;
 	}
-	if((pname[0] == 0 || pname[1] == 0) && !enter)
-		return;
+	bool use_cache = false;
+	if(pname[0] == 0 || pname[1] == 0) {
+		if(!enter)
+			return;
+		use_cache = (mainGame->dInfo.announce_cache.size() != 0);
+	}
 	mainGame->lstANCard->clear();
 	ancard.clear();
 	for(auto cit = dataManager._strings.begin(); cit != dataManager._strings.end(); ++cit) {
-		if(cit->second.name.find(pname) != std::wstring::npos) {
+		if((!use_cache && cit->second.name.find(pname) != std::wstring::npos) || (use_cache && std::find(mainGame->dInfo.announce_cache.begin(), mainGame->dInfo.announce_cache.end(), cit->first) != mainGame->dInfo.announce_cache.end())) {
 			auto cp = dataManager.GetCodePointer(cit->first);	//verified by _strings
 			//datas.alias can be double card names or alias
 			if(is_declarable(cp->second, declarable_type)) {
@@ -1456,12 +1460,16 @@ void ClientField::UpdateDeclarableCodeOpcode(bool enter) {
 		ancard.push_back(trycode);
 		return;
 	}
-	if((pname[0] == 0 || pname[1] == 0) && !enter)
-		return;
+	bool use_cache = false;
+	if(pname[0] == 0 || pname[1] == 0) {
+		if(!enter)
+			return;
+		use_cache = (mainGame->dInfo.announce_cache.size() != 0);
+	}
 	mainGame->lstANCard->clear();
 	ancard.clear();
 	for(auto cit = dataManager._strings.begin(); cit != dataManager._strings.end(); ++cit) {
-		if(cit->second.name.find(pname) != std::wstring::npos) {
+		if((!use_cache && cit->second.name.find(pname) != std::wstring::npos) || (use_cache && std::find(mainGame->dInfo.announce_cache.begin(), mainGame->dInfo.announce_cache.end(), cit->first) != mainGame->dInfo.announce_cache.end())) {
 			auto cp = dataManager.GetCodePointer(cit->first);	//verified by _strings
 			//datas.alias can be double card names or alias
 			if(is_declarable(cp->second, opcode)) {

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -576,6 +576,7 @@ void DuelClient::HandleSTOCPacketLan(char* data, unsigned int len) {
 		mainGame->dInfo.time_left[1] = 0;
 		mainGame->dInfo.time_player = 2;
 		mainGame->dInfo.isReplaySwapped = false;
+		mainGame->dInfo.announce_cache.clear();
 		mainGame->is_building = false;
 		mainGame->wCardImg->setVisible(true);
 		mainGame->wInfos->setVisible(true);
@@ -651,6 +652,7 @@ void DuelClient::HandleSTOCPacketLan(char* data, unsigned int len) {
 		mainGame->gMutex.Lock();
 		mainGame->dInfo.isStarted = false;
 		mainGame->dInfo.isFinished = true;
+		mainGame->dInfo.announce_cache.clear();
 		mainGame->is_building = false;
 		mainGame->wDeckEdit->setVisible(false);
 		mainGame->btnCreateHost->setEnabled(true);

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -338,6 +338,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				if(sel == -1)
 					break;
 				DuelClient::SetResponseI(ancard[sel]);
+				mainGame->dInfo.announce_cache.push_back(ancard[sel]);
 				mainGame->HideElement(mainGame->wANCard, true);
 				break;
 			}

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -338,7 +338,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				if(sel == -1)
 					break;
 				DuelClient::SetResponseI(ancard[sel]);
-				mainGame->dInfo.announce_cache.push_back(ancard[sel]);
+				mainGame->dInfo.announce_cache.insert(mainGame->dInfo.announce_cache.begin(), ancard[sel]);
 				mainGame->HideElement(mainGame->wANCard, true);
 				break;
 			}

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -74,6 +74,7 @@ struct DuelInfo {
 	unsigned short time_limit;
 	unsigned short time_left[2];
 	bool isReplaySwapped;
+	std::vector<unsigned int> announce_cache;
 };
 
 struct BotInfo {

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -51,6 +51,7 @@ int SingleMode::SinglePlayThread(void* param) {
 	BufferIO::CopyWStr(mainGame->ebNickName->getText(), mainGame->dInfo.hostname, 20);
 	mainGame->dInfo.clientname[0] = 0;
 	mainGame->dInfo.turn = 0;
+	mainGame->dInfo.announce_cache.clear();
 	char filename[256];
 	size_t slen = 0;
 	if(open_file) {


### PR DESCRIPTION
When you announce a card for the 2nd time or more this match, the announced card will be displayed at the first page.
![a1](https://user-images.githubusercontent.com/19840160/44705916-92f23100-aad2-11e8-98fa-3db1ed857fcb.png)
![a3](https://user-images.githubusercontent.com/19840160/44705926-98e81200-aad2-11e8-8621-dc967ea56180.png)
![a2](https://user-images.githubusercontent.com/19840160/44705919-94235e00-aad2-11e8-8f8d-f01e16032eec.png)


