### PR TITLE
Added support for messages in the puzzle selection window

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -954,6 +954,7 @@ void Game::RefreshReplay() {
 }
 void Game::RefreshSingleplay() {
 	lstSinglePlayList->clear();
+	mainGame->stSinglePlayInfo->setText(L"");
 #ifdef _WIN32
 	WIN32_FIND_DATAW fdataw;
 	HANDLE fh = FindFirstFileW(L"./single/*.lua", &fdataw);
@@ -1491,6 +1492,40 @@ void Game::SetCursor(ECURSOR_ICON icon) {
 	if(cursor->getActiveIcon() != icon) {
 		cursor->setActiveIcon(icon);
 	}
+}
+std::wstring Game::ReadPuzzleMessage(const char* script_name) {
+	std::ifstream infile(script_name);
+	std::wstring str((std::istreambuf_iterator<char>(infile)),
+		std::istreambuf_iterator<char>());
+	std::wstring res = L"";
+	size_t start = str.find(L"#header");
+	if(start != std::wstring::npos) {
+		size_t end = str.rfind(L"#endheader");
+		res = str.substr(start + 7, end - (start + 7));
+		int len = 0;
+		for(wchar_t c : res) {
+			if(iswalnum(c))
+				break;
+			len++;
+			if(c == L'\n') {
+				break;
+			}
+		}
+		if(len)
+			res = res.substr(len);
+	}
+	return res;
+}
+std::string Game::ReadPuzzleBuffer(const char* script_name) {
+	std::ifstream infile(script_name);
+	std::string str((std::istreambuf_iterator<char>(infile)),
+		std::istreambuf_iterator<char>());
+	size_t start = str.rfind("#endheader");
+	if(start != std::string::npos) {
+		std::string res = str.substr(start + 10);
+		return res;
+	}
+	return str;
 }
 
 }

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -149,6 +149,9 @@ public:
 	void SetWindowsIcon();
 	void FlashWindow();
 	void SetCursor(ECURSOR_ICON icon);
+	
+	std::wstring ReadPuzzleMessage(const char* script_name);
+	std::string ReadPuzzleBuffer(const char* script_name);
 
 	Mutex gMutex;
 	Mutex gBuffer;

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -463,6 +463,18 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				mainGame->SetStaticText(mainGame->stReplayInfo, 180, mainGame->guiFont, (wchar_t*)repinfo.c_str());
 				break;
 			}
+			case LISTBOX_SINGLEPLAY_LIST: {
+				int sel = mainGame->lstSinglePlayList->getSelected();
+				if(sel == -1)
+					break;
+				const wchar_t* name = mainGame->lstSinglePlayList->getListItem(mainGame->lstSinglePlayList->getSelected());
+				wchar_t fname[256];
+				char filename[256];
+				myswprintf(fname, L"./single/%ls", name);
+				BufferIO::EncodeUTF8(fname, filename);
+				mainGame->stSinglePlayInfo->setText(mainGame->ReadPuzzleMessage(filename).c_str());
+				break;
+			}
 			case LISTBOX_BOT_LIST: {
 				int sel = mainGame->lstBotList->getSelected();
 				if(sel == -1)

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -218,9 +218,9 @@ bool ReplayMode::StartDuel() {
 		size_t slen = cur_replay.ReadInt16();
 		cur_replay.ReadData(filename, slen);
 		filename[slen] = 0;
-		if(!preload_script(pduel, filename, slen)) {
+		std::string scriptbuff = mainGame->ReadPuzzleBuffer(filename);
+		if(!preload_script(pduel, filename, slen, scriptbuff.length(), (char *)scriptbuff.c_str()))
 			return false;
-		}
 	}
 	start_duel(pduel, opt);
 	return true;

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -53,14 +53,16 @@ int SingleMode::SinglePlayThread(void* param) {
 	mainGame->dInfo.turn = 0;
 	char filename[256];
 	size_t slen = 0;
+	std::string scriptbuff;
 	if(open_file) {
 		open_file = false;
-		slen = BufferIO::EncodeUTF8(open_file_name, filename);
-		if(!preload_script(pduel, filename, slen)) {
+		scriptbuff = mainGame->ReadPuzzleBuffer(filename);
+		if(!preload_script(pduel, filename, slen, scriptbuff.length(), (char *)scriptbuff.c_str())) {
 			wchar_t fname[256];
 			myswprintf(fname, L"./single/%ls", open_file_name);
 			slen = BufferIO::EncodeUTF8(fname, filename);
-			if(!preload_script(pduel, filename, slen))
+			scriptbuff = mainGame->ReadPuzzleBuffer(filename);
+			if(!preload_script(pduel, filename, slen, scriptbuff.length(), (char *)scriptbuff.c_str()))
 				slen = 0;
 		}
 	} else {
@@ -68,7 +70,8 @@ int SingleMode::SinglePlayThread(void* param) {
 		wchar_t fname[256];
 		myswprintf(fname, L"./single/%ls", name);
 		slen = BufferIO::EncodeUTF8(fname, filename);
-		if(!preload_script(pduel, filename, slen))
+		scriptbuff = mainGame->ReadPuzzleBuffer(filename);
+		if(!preload_script(pduel, filename, slen, scriptbuff.length(), (char *)scriptbuff.c_str()))
 			slen = 0;
 	}
 	if(slen == 0) {


### PR DESCRIPTION
With this, by butting a specific header in the script of a puzzle, the client will be able to read a message from it 
![image](https://user-images.githubusercontent.com/18705342/44985194-b52af980-af7f-11e8-9820-2e34f6186f83.png)

the header should be put in this way
```
#header
things that will be shown
#endheader
lua script
```

this commit is required first https://github.com/Fluorohydride/ygopro-core/pull/185
