### PR TITLE
update announce card

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -1424,8 +1424,21 @@ void ClientField::UpdateDeclarableCodeType(bool enter) {
 		ancard.push_back(trycode);
 		return;
 	}
-	if((pname[0] == 0 || pname[1] == 0) && !enter)
-		return;
+	if((pname[0] == 0 || pname[1] == 0) && !enter && ancard.size() < 50) {
+		int index = 0;
+		for(auto it = ancard.begin(); it != ancard.end();) {
+			int trycode = *it;
+			if(dataManager.GetString(trycode, &cstr) && dataManager.GetData(trycode, &cd) && !is_declarable(cd, declarable_type)) {
+				it = ancard.erase(it);
+				mainGame->lstANCard->removeItem(index);
+			} else {
+				++it;
+				++index;
+			}
+		}
+		if(!ancard.empty())
+			return;
+	}
 	mainGame->lstANCard->clear();
 	ancard.clear();
 	for(auto cit = dataManager._strings.begin(); cit != dataManager._strings.end(); ++cit) {
@@ -1456,8 +1469,21 @@ void ClientField::UpdateDeclarableCodeOpcode(bool enter) {
 		ancard.push_back(trycode);
 		return;
 	}
-	if((pname[0] == 0 || pname[1] == 0) && !enter)
-		return;
+	if((pname[0] == 0 || pname[1] == 0) && !enter && ancard.size() < 50) {
+		int index = 0;
+		for(auto it = ancard.begin(); it != ancard.end();) {
+			int trycode = *it;
+			if(dataManager.GetString(trycode, &cstr) && dataManager.GetData(trycode, &cd) && !is_declarable(cd, opcode)) {
+				it = ancard.erase(it);
+				mainGame->lstANCard->removeItem(index);
+			} else {
+				++it;
+				++index;
+			}
+		}
+		if(!ancard.empty())
+			return;
+	}
 	mainGame->lstANCard->clear();
 	ancard.clear();
 	for(auto cit = dataManager._strings.begin(); cit != dataManager._strings.end(); ++cit) {

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -1424,16 +1424,18 @@ void ClientField::UpdateDeclarableCodeType(bool enter) {
 		ancard.push_back(trycode);
 		return;
 	}
-	if((pname[0] == 0 || pname[1] == 0) && !enter && ancard.size() < 50) {
-		int index = 0;
-		for(auto it = ancard.begin(); it != ancard.end();) {
-			int trycode = *it;
+	if((pname[0] == 0 || pname[1] == 0) && !enter) {
+		std::vector<int> cache;
+		cache.swap(ancard);
+		int sel = mainGame->lstANCard->getSelected();
+		int selcode = (sel == -1) ? 0 : cache[sel];
+		mainGame->lstANCard->clear();
+		for(const auto& trycode : cache) {
 			if(dataManager.GetString(trycode, &cstr) && dataManager.GetData(trycode, &cd) && is_declarable(cd, declarable_type)) {
-				++it;
-				++index;
-			} else {
-				it = ancard.erase(it);
-				mainGame->lstANCard->removeItem(index);
+				ancard.push_back(trycode);
+				mainGame->lstANCard->addItem(cstr.name.c_str());
+				if(trycode == selcode)
+					mainGame->lstANCard->setSelected(cstr.name.c_str());
 			}
 		}
 		if(!ancard.empty())
@@ -1469,16 +1471,18 @@ void ClientField::UpdateDeclarableCodeOpcode(bool enter) {
 		ancard.push_back(trycode);
 		return;
 	}
-	if((pname[0] == 0 || pname[1] == 0) && !enter && ancard.size() < 50) {
-		int index = 0;
-		for(auto it = ancard.begin(); it != ancard.end();) {
-			int trycode = *it;
+	if((pname[0] == 0 || pname[1] == 0) && !enter) {
+		std::vector<int> cache;
+		cache.swap(ancard);
+		int sel = mainGame->lstANCard->getSelected();
+		int selcode = (sel == -1) ? 0 : cache[sel];
+		mainGame->lstANCard->clear();
+		for(const auto& trycode : cache) {
 			if(dataManager.GetString(trycode, &cstr) && dataManager.GetData(trycode, &cd) && is_declarable(cd, opcode)) {
-				++it;
-				++index;
-			} else {
-				it = ancard.erase(it);
-				mainGame->lstANCard->removeItem(index);
+				ancard.push_back(trycode);
+				mainGame->lstANCard->addItem(cstr.name.c_str());
+				if(trycode == selcode)
+					mainGame->lstANCard->setSelected(cstr.name.c_str());
 			}
 		}
 		if(!ancard.empty())

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -1428,12 +1428,12 @@ void ClientField::UpdateDeclarableCodeType(bool enter) {
 		int index = 0;
 		for(auto it = ancard.begin(); it != ancard.end();) {
 			int trycode = *it;
-			if(dataManager.GetString(trycode, &cstr) && dataManager.GetData(trycode, &cd) && !is_declarable(cd, declarable_type)) {
-				it = ancard.erase(it);
-				mainGame->lstANCard->removeItem(index);
-			} else {
+			if(dataManager.GetString(trycode, &cstr) && dataManager.GetData(trycode, &cd) && is_declarable(cd, declarable_type)) {
 				++it;
 				++index;
+			} else {
+				it = ancard.erase(it);
+				mainGame->lstANCard->removeItem(index);
 			}
 		}
 		if(!ancard.empty())
@@ -1473,12 +1473,12 @@ void ClientField::UpdateDeclarableCodeOpcode(bool enter) {
 		int index = 0;
 		for(auto it = ancard.begin(); it != ancard.end();) {
 			int trycode = *it;
-			if(dataManager.GetString(trycode, &cstr) && dataManager.GetData(trycode, &cd) && !is_declarable(cd, opcode)) {
-				it = ancard.erase(it);
-				mainGame->lstANCard->removeItem(index);
-			} else {
+			if(dataManager.GetString(trycode, &cstr) && dataManager.GetData(trycode, &cd) && is_declarable(cd, opcode)) {
 				++it;
 				++index;
+			} else {
+				it = ancard.erase(it);
+				mainGame->lstANCard->removeItem(index);
 			}
 		}
 		if(!ancard.empty())

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -3373,12 +3373,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 	}
 	case MSG_ANNOUNCE_CARD: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
-		bool enter = true;
-		int ttypes = BufferIO::ReadInt32(pbuf);
-		if(ttypes == mainGame->dField.declarable_type)
-			enter = false;
-		else
-			mainGame->dField.declarable_type = ttypes;
+		mainGame->dField.declarable_type = BufferIO::ReadInt32(pbuf);
 		mainGame->dField.opcode.clear();
 		if(select_hint)
 			myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
@@ -3387,7 +3382,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		mainGame->gMutex.Lock();
 		mainGame->ebANCard->setText(L"");
 		mainGame->wANCard->setText(textBuffer);
-		mainGame->dField.UpdateDeclarableCode(enter);
+		mainGame->dField.UpdateDeclarableCode(false);
 		mainGame->PopupElement(mainGame->wANCard);
 		mainGame->gMutex.Unlock();
 		return false;
@@ -3415,15 +3410,10 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 	case MSG_ANNOUNCE_CARD_FILTER: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
 		int count = BufferIO::ReadInt8(pbuf);
-		bool enter = true;
-		std::vector<int> opcode;
-		for (int i = 0; i < count; ++i)
-			opcode.push_back(BufferIO::ReadInt32(pbuf));
-		if(mainGame->dField.opcode == opcode)
-			enter = false;
-		else
-			mainGame->dField.opcode = std::move(opcode);
 		mainGame->dField.declarable_type = 0;
+		mainGame->dField.opcode.clear();
+		for (int i = 0; i < count; ++i)
+			mainGame->dField.opcode.push_back(BufferIO::ReadInt32(pbuf));
 		if(select_hint)
 			myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
 		else myswprintf(textBuffer, dataManager.GetSysString(564));
@@ -3431,7 +3421,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		mainGame->gMutex.Lock();
 		mainGame->ebANCard->setText(L"");
 		mainGame->wANCard->setText(textBuffer);
-		mainGame->dField.UpdateDeclarableCode(enter);
+		mainGame->dField.UpdateDeclarableCode(false);
 		mainGame->PopupElement(mainGame->wANCard);
 		mainGame->gMutex.Unlock();
 		return false;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -3373,7 +3373,12 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 	}
 	case MSG_ANNOUNCE_CARD: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
-		mainGame->dField.declarable_type = BufferIO::ReadInt32(pbuf);
+		bool enter = true;
+		int ttypes = BufferIO::ReadInt32(pbuf);
+		if(ttypes == mainGame->dField.declarable_type)
+			enter = false;
+		else
+			mainGame->dField.declarable_type = ttypes;
 		mainGame->dField.opcode.clear();
 		if(select_hint)
 			myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
@@ -3382,7 +3387,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		mainGame->gMutex.Lock();
 		mainGame->ebANCard->setText(L"");
 		mainGame->wANCard->setText(textBuffer);
-		mainGame->dField.UpdateDeclarableCode(true);
+		mainGame->dField.UpdateDeclarableCode(enter);
 		mainGame->PopupElement(mainGame->wANCard);
 		mainGame->gMutex.Unlock();
 		return false;
@@ -3410,10 +3415,15 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 	case MSG_ANNOUNCE_CARD_FILTER: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::ReadInt8(pbuf));
 		int count = BufferIO::ReadInt8(pbuf);
-		mainGame->dField.declarable_type = 0;
-		mainGame->dField.opcode.clear();
+		bool enter = true;
+		std::vector<int> opcode;
 		for (int i = 0; i < count; ++i)
-			mainGame->dField.opcode.push_back(BufferIO::ReadInt32(pbuf));
+			opcode.push_back(BufferIO::ReadInt32(pbuf));
+		if(mainGame->dField.opcode == opcode)
+			enter = false;
+		else
+			mainGame->dField.opcode = std::move(opcode);
+		mainGame->dField.declarable_type = 0;
 		if(select_hint)
 			myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
 		else myswprintf(textBuffer, dataManager.GetSysString(564));
@@ -3421,7 +3431,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		mainGame->gMutex.Lock();
 		mainGame->ebANCard->setText(L"");
 		mainGame->wANCard->setText(textBuffer);
-		mainGame->dField.UpdateDeclarableCode(true);
+		mainGame->dField.UpdateDeclarableCode(enter);
 		mainGame->PopupElement(mainGame->wANCard);
 		mainGame->gMutex.Unlock();
 		return false;


### PR DESCRIPTION
If the announcable range is the same as the last announce, the list will not refresh

update:
When announcing card name, the name list used last time will be showed, after removing invalid names