### PR TITLE
fix showing wOptions

### DIFF
--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -968,7 +968,7 @@ void Game::ShowElement(irr::gui::IGUIElement * win, int autoframe) {
 	FadingUnit fu;
 	fu.fadingSize = win->getRelativePosition();
 	for(auto fit = fadingList.begin(); fit != fadingList.end(); ++fit)
-		if(win == fit->guiFading)
+		if(win == fit->guiFading && win != wOptions) // the size of wOptions is always setted by ClientField::ShowSelectOption before showing it
 			fu.fadingSize = fit->fadingSize;
 	irr::core::position2di center = fu.fadingSize.getCenter();
 	fu.fadingDiff.X = fu.fadingSize.getWidth() / 10;


### PR DESCRIPTION
Steps to reproduce:
1. assume _Eidos the Underworld Squire_ has a long string for extra summon
2. spsummon 3 monsters on both field, including Eidos
3. summon _The Winged Dragon of Ra - Sphere Mode_, select summoning on my field
4. the option window of extra summon will appear in wrong size
![image](https://user-images.githubusercontent.com/13391795/46146291-f4a1e880-c294-11e8-8167-956c268bc9bc.png)
![image](https://user-images.githubusercontent.com/13391795/46146306-02576e00-c295-11e8-8f73-4e0e2d4c6231.png)
![image](https://user-images.githubusercontent.com/13391795/46146386-3df23800-c295-11e8-92e9-e80a0a509a4e.png)


After fix:
![image](https://user-images.githubusercontent.com/13391795/46146323-0c796c80-c295-11e8-896a-54086655e5f4.png)
