### PR TITLE
use windows api instead of c runtime library in myfilesystem.h

### DIFF
--- a/gframe/myfilesystem.h
+++ b/gframe/myfilesystem.h
@@ -5,10 +5,7 @@
 #include <functional>
 #include "bufferio.h"
 
-#ifdef _WIN32
-#include <direct.h>
-#include <sys/stat.h>
-#else
+#ifndef _WIN32
 #include <dirent.h>
 #include <sys/stat.h>
 #endif

--- a/gframe/myfilesystem.h
+++ b/gframe/myfilesystem.h
@@ -20,8 +20,8 @@
 class FileSystem {
 public:
 	static bool IsFileExists(const wchar_t* wfile) {
-		struct _stat fileStat;
-		return (_wstat(wfile, &fileStat) == 0) && !(fileStat.st_mode & _S_IFDIR);
+		DWORD attr = GetFileAttributesW(wfile);
+		return attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY);
 	}
 
 	static bool IsFileExists(const char* file) {
@@ -31,8 +31,8 @@ public:
 	}
 
 	static bool IsDirExists(const wchar_t* wdir) {
-		struct _stat fileStat;
-		return (_wstat(wdir, &fileStat) == 0) && (fileStat.st_mode & _S_IFDIR);
+		DWORD attr = GetFileAttributesW(wdir);
+		return attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY);
 	}
 
 	static bool IsDirExists(const char* dir) {
@@ -42,7 +42,7 @@ public:
 	}
 
 	static bool MakeDir(const wchar_t* wdir) {
-		return _wmkdir(wdir) == 0;
+		return CreateDirectoryW(wdir, NULL);
 	}
 
 	static bool MakeDir(const char* dir) {


### PR DESCRIPTION
There is a known bug in UCRT, and it is much easier to switch to another way than fixing this bug in UCRT way.

https://developercommunity.visualstudio.com/content/problem/19317/windows-c-function-wstat-does-not-work-correctly-w.html