### PR TITLE
don't respond gui event when showing or hiding dialog

### DIFF
--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -20,6 +20,8 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 		return false;
 	switch(event.EventType) {
 	case irr::EET_GUI_EVENT: {
+		if(mainGame->fadingList.size())
+			break;
 		s32 id = event.GUIEvent.Caller->getID();
 		switch(event.GUIEvent.EventType) {
 		case irr::gui::EGET_BUTTON_CLICKED: {


### PR DESCRIPTION
`EMIE_RMOUSE_LEFT_UP` had this already: https://github.com/Fluorohydride/ygopro/commit/1de0d4f86f6c919d5f02e8760c4f87eeb2bd5141#diff-ac569d93830cf8da0dc28fa6ec8de186L1061