### PR TITLE
update CGUIImageButton

### DIFF
--- a/gframe/CGUIImageButton.cpp
+++ b/gframe/CGUIImageButton.cpp
@@ -97,7 +97,7 @@ void Draw2DImageQuad(video::IVideoDriver* driver, video::ITexture* image, core::
 CGUIImageButton::CGUIImageButton(IGUIEnvironment* environment, IGUIElement* parent, s32 id, core::rect<s32> rectangle)
 	: CGUIButton(environment, parent, id, rectangle) {
 	isDrawImage = true;
-	isFixSize = false;
+	isFixedSize = false;
 	imageRotation = 0.0f;
 	imageScale = core::vector2df(1.0f, 1.0f);
 	imageSize = core::dimension2di(rectangle.getWidth(), rectangle.getHeight());
@@ -141,7 +141,7 @@ void CGUIImageButton::setImage(video::ITexture* image)
 	Image = image;
 	if(image) {
 		ImageRect = core::rect<s32>(core::position2d<s32>(0, 0), image->getOriginalSize());
-		if(isFixSize)
+		if(isFixedSize)
 			imageScale = core::vector2df((irr::f32)imageSize.Width / image->getSize().Width, (irr::f32)imageSize.Height / image->getSize().Height);
 	}
 
@@ -158,7 +158,7 @@ void CGUIImageButton::setImageScale(core::vector2df s) {
 	imageScale = s;
 }
 void CGUIImageButton::setImageSize(core::dimension2di s) {
-	isFixSize = true;
+	isFixedSize = true;
 	imageSize = s;
 }
 

--- a/gframe/CGUIImageButton.cpp
+++ b/gframe/CGUIImageButton.cpp
@@ -97,8 +97,10 @@ void Draw2DImageQuad(video::IVideoDriver* driver, video::ITexture* image, core::
 CGUIImageButton::CGUIImageButton(IGUIEnvironment* environment, IGUIElement* parent, s32 id, core::rect<s32> rectangle)
 	: CGUIButton(environment, parent, id, rectangle) {
 	isDrawImage = true;
+	isFixSize = false;
 	imageRotation = 0.0f;
 	imageScale = core::vector2df(1.0f, 1.0f);
+	imageSize = core::dimension2di(rectangle.getWidth(), rectangle.getHeight());
 }
 CGUIImageButton* CGUIImageButton::addImageButton(IGUIEnvironment *env, const core::rect<s32>& rectangle, IGUIElement* parent, s32 id) {
 	CGUIImageButton* button = new CGUIImageButton(env, parent ? parent : 0, id, rectangle);
@@ -129,6 +131,23 @@ void CGUIImageButton::draw() {
 		irr::gui::Draw2DImageRotation(driver, Image, ImageRect, pos, center, imageRotation, imageScale);
 	IGUIElement::draw();
 }
+void CGUIImageButton::setImage(video::ITexture* image)
+{
+	if(image)
+		image->grab();
+	if(Image)
+		Image->drop();
+
+	Image = image;
+	if(image) {
+		ImageRect = core::rect<s32>(core::position2d<s32>(0, 0), image->getOriginalSize());
+		if(isFixSize)
+			imageScale = core::vector2df((irr::f32)imageSize.Width / image->getSize().Width, (irr::f32)imageSize.Height / image->getSize().Height);
+	}
+
+	if(!PressedImage)
+		setPressedImage(Image);
+}
 void CGUIImageButton::setDrawImage(bool b) {
 	isDrawImage = b;
 }
@@ -137,6 +156,10 @@ void CGUIImageButton::setImageRotation(f32 r) {
 }
 void CGUIImageButton::setImageScale(core::vector2df s) {
 	imageScale = s;
+}
+void CGUIImageButton::setImageSize(core::dimension2di s) {
+	isFixSize = true;
+	imageSize = s;
 }
 
 IGUIFont* CGUIImageButton::getOverrideFont( void ) const

--- a/gframe/CGUIImageButton.h
+++ b/gframe/CGUIImageButton.h
@@ -27,7 +27,7 @@ public:
 
 private:
 	bool isDrawImage;
-	bool isFixSize;
+	bool isFixedSize;
 	f32 imageRotation;
 	core::vector2df imageScale;
 	core::dimension2di imageSize;

--- a/gframe/CGUIImageButton.h
+++ b/gframe/CGUIImageButton.h
@@ -17,16 +17,20 @@ public:
 	CGUIImageButton(IGUIEnvironment* environment, IGUIElement* parent, s32 id, core::rect<s32> rectangle);
 	static CGUIImageButton* addImageButton(IGUIEnvironment *env, const core::rect<s32>& rectangle, IGUIElement* parent, s32 id);
 	virtual void draw();
+	virtual void setImage(video::ITexture* image = 0);
 	virtual void setDrawImage(bool b);
 	virtual void setImageRotation(f32 r);
 	virtual void setImageScale(core::vector2df s);
+	virtual void setImageSize(core::dimension2di s);
 	virtual IGUIFont* getOverrideFont(void) const;
 	virtual IGUIFont* getActiveFont() const;
 
 private:
 	bool isDrawImage;
+	bool isFixSize;
 	f32 imageRotation;
 	core::vector2df imageScale;
+	core::dimension2di imageSize;
 };
 
 }

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -414,15 +414,15 @@ bool Game::Initialize() {
 	wPosSelect->getCloseButton()->setVisible(false);
 	wPosSelect->setVisible(false);
 	btnPSAU = irr::gui::CGUIImageButton::addImageButton(env, rect<s32>(10, 45, 150, 185), wPosSelect, BUTTON_POS_AU);
-	btnPSAU->setImageScale(core::vector2df(0.5, 0.5));
+	btnPSAU->setImageSize(core::dimension2di(CARD_IMG_WIDTH * 0.5f, CARD_IMG_HEIGHT * 0.5f));
 	btnPSAD = irr::gui::CGUIImageButton::addImageButton(env, rect<s32>(155, 45, 295, 185), wPosSelect, BUTTON_POS_AD);
-	btnPSAD->setImageScale(core::vector2df(0.5, 0.5));
+	btnPSAD->setImageSize(core::dimension2di(CARD_IMG_WIDTH * 0.5f, CARD_IMG_HEIGHT * 0.5f));
 	btnPSAD->setImage(imageManager.tCover[2]);
 	btnPSDU = irr::gui::CGUIImageButton::addImageButton(env, rect<s32>(300, 45, 440, 185), wPosSelect, BUTTON_POS_DU);
-	btnPSDU->setImageScale(core::vector2df(0.5, 0.5));
+	btnPSDU->setImageSize(core::dimension2di(CARD_IMG_WIDTH * 0.5f, CARD_IMG_HEIGHT * 0.5f));
 	btnPSDU->setImageRotation(270);
 	btnPSDD = irr::gui::CGUIImageButton::addImageButton(env, rect<s32>(445, 45, 585, 185), wPosSelect, BUTTON_POS_DD);
-	btnPSDD->setImageScale(core::vector2df(0.5, 0.5));
+	btnPSDD->setImageSize(core::dimension2di(CARD_IMG_WIDTH * 0.5f, CARD_IMG_HEIGHT * 0.5f));
 	btnPSDD->setImageRotation(270);
 	btnPSDD->setImage(imageManager.tCover[2]);
 	//card select
@@ -434,7 +434,7 @@ bool Game::Initialize() {
 		stCardPos[i]->setBackgroundColor(0xffffffff);
 		stCardPos[i]->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
 		btnCardSelect[i] = irr::gui::CGUIImageButton::addImageButton(env, rect<s32>(30 + 125 * i, 55, 150 + 125 * i, 225), wCardSelect, BUTTON_CARD_0 + i);
-		btnCardSelect[i]->setImageScale(core::vector2df(0.6f, 0.6f));
+		btnCardSelect[i]->setImageSize(core::dimension2di(CARD_IMG_WIDTH * 0.6f, CARD_IMG_HEIGHT * 0.6f));
 	}
 	scrCardList = env->addScrollBar(true, rect<s32>(30, 235, 650, 255), wCardSelect, SCROLL_CARD_SELECT);
 	btnSelectOK = env->addButton(rect<s32>(300, 265, 380, 290), wCardSelect, BUTTON_CARD_SEL_OK, dataManager.GetSysString(1211));
@@ -447,7 +447,7 @@ bool Game::Initialize() {
 		stDisplayPos[i]->setBackgroundColor(0xffffffff);
 		stDisplayPos[i]->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
 		btnCardDisplay[i] = irr::gui::CGUIImageButton::addImageButton(env, rect<s32>(30 + 125 * i, 55, 150 + 125 * i, 225), wCardDisplay, BUTTON_DISPLAY_0 + i);
-		btnCardDisplay[i]->setImageScale(core::vector2df(0.6f, 0.6f));
+		btnCardDisplay[i]->setImageSize(core::dimension2di(CARD_IMG_WIDTH * 0.6f, CARD_IMG_HEIGHT * 0.6f));
 	}
 	scrDisplayList = env->addScrollBar(true, rect<s32>(30, 235, 650, 255), wCardDisplay, SCROLL_CARD_DISPLAY);
 	btnDisplayOK = env->addButton(rect<s32>(300, 265, 380, 290), wCardDisplay, BUTTON_CARD_DISP_OK, dataManager.GetSysString(1211));


### PR DESCRIPTION
Fix this: The size of image in `CGUIImageButton` may be wrong when `use_image_scale` is disabled and the card pics aren't in the standard size.
![image](https://user-images.githubusercontent.com/13391795/59145882-98df5000-8a1c-11e9-8f3a-281fe2dabb26.png)
