### PR TITLE
Clean up broadcasting code

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -3809,45 +3809,24 @@ void DuelClient::BeginRefreshHost() {
 	if(!host)
 		return;
 	SOCKET reply = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	sockaddr_in reply_addr;
-	memset(&reply_addr, 0, sizeof(reply_addr));
-	reply_addr.sin_family = AF_INET;
-	reply_addr.sin_port = htons(7921);
-	reply_addr.sin_addr.s_addr = 0;
-	if(bind(reply, (sockaddr*)&reply_addr, sizeof(reply_addr)) == SOCKET_ERROR) {
-		closesocket(reply);
-		return;
-	}
+	BOOL opt = TRUE;
+	setsockopt(reply, SOL_SOCKET, SO_BROADCAST, (const char*)&opt, sizeof(BOOL));
 	timeval timeout = {3, 0};
 	resp_event = event_new(broadev, reply, EV_TIMEOUT | EV_READ | EV_PERSIST, BroadcastReply, broadev);
 	event_add(resp_event, &timeout);
 	Thread::NewThread(RefreshThread, broadev);
 	//send request
-	SOCKADDR_IN local;
-	local.sin_family = AF_INET;
-	local.sin_port = htons(7922);
-	SOCKADDR_IN sockTo;
-	sockTo.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+	SOCKADDR_IN sockTo = {};
 	sockTo.sin_family = AF_INET;
-	sockTo.sin_port = htons(7920);
+	sockTo.sin_port = htons(7911);
 	HostRequest hReq;
 	hReq.identifier = NETWORK_CLIENT_ID;
 	for(int i = 0; i < 8; ++i) {
 		if(host->h_addr_list[i] == 0)
 			break;
 		unsigned int local_addr = *(unsigned int*)host->h_addr_list[i];
-		local.sin_addr.s_addr = local_addr;
-		SOCKET sSend = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-		if(sSend == INVALID_SOCKET)
-			break;
-		BOOL opt = TRUE;
-		setsockopt(sSend, SOL_SOCKET, SO_BROADCAST, (const char*)&opt, sizeof(BOOL));
-		if(bind(sSend, (sockaddr*)&local, sizeof(sockaddr)) == SOCKET_ERROR) {
-			closesocket(sSend);
-			break;
-		}
-		sendto(sSend, (const char*)&hReq, sizeof(HostRequest), 0, (sockaddr*)&sockTo, sizeof(sockaddr));
-		closesocket(sSend);
+		sockTo.sin_addr.s_addr = local_addr;
+		sendto(reply, (const char*)&hReq, sizeof(HostRequest), 0, (sockaddr*)&sockTo, sizeof(sockaddr));
 	}
 }
 int DuelClient::RefreshThread(void * arg) {

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -40,13 +40,11 @@ bool NetServer::StartBroadcast() {
 	if(!net_evbase)
 		return false;
 	SOCKET udp = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	BOOL opt = TRUE;
-	setsockopt(udp, SOL_SOCKET, SO_BROADCAST, (const char*)&opt, sizeof(BOOL));
 	sockaddr_in addr;
 	memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
-	addr.sin_port = htons(7920);
-	addr.sin_addr.s_addr = 0;
+	addr.sin_port = htons(7911);
+	addr.sin_addr.s_addr = htonl(INADDR_ANY);
 	if(bind(udp, (sockaddr*)&addr, sizeof(addr)) == SOCKET_ERROR) {
 		closesocket(udp);
 		return false;
@@ -85,17 +83,13 @@ void NetServer::BroadcastEvent(evutil_socket_t fd, short events, void* arg) {
 		return;
 	HostRequest* pHR = (HostRequest*)buf;
 	if(pHR->identifier == NETWORK_CLIENT_ID) {
-		SOCKADDR_IN sockTo;
-		sockTo.sin_addr.s_addr = bc_addr.sin_addr.s_addr;
-		sockTo.sin_family = AF_INET;
-		sockTo.sin_port = htons(7921);
 		HostPacket hp;
 		hp.identifier = NETWORK_SERVER_ID;
 		hp.port = server_port;
 		hp.version = PRO_VERSION;
 		hp.host = duel_mode->host_info;
 		BufferIO::CopyWStr(duel_mode->name, hp.name, 20);
-		sendto(fd, (const char*)&hp, sizeof(HostPacket), 0, (sockaddr*)&sockTo, sizeof(sockTo));
+		sendto(fd, (const char*)&hp, sizeof(HostPacket), 0, (sockaddr*)&bc_addr, sz);
 	}
 }
 void NetServer::ServerAccept(evconnlistener* listener, evutil_socket_t fd, sockaddr* address, int socklen, void* ctx) {


### PR DESCRIPTION
Now when hosting a game with the client, the server will no longer use 3 ports to send the duel info when breadcasting, but will do everything on the port the duel is currently hosted on, also some redoundancies have been removed.