### PR TITLE
fix problems with building on macOS

### DIFF
--- a/gframe/CMakeLists.txt
+++ b/gframe/CMakeLists.txt
@@ -44,6 +44,12 @@ else ()
     target_link_libraries (ygopro ${CMAKE_THREAD_LIBS_INIT} ${DL_LIBRARIES})
 endif ()
 
+if (APPLE)
+    find_library(COCOA_LIBRARY Cocoa)
+    find_library(IOKIT_LIBRARY IOKit)
+    target_link_libraries(ygopro ${COCOA_LIBRARY} ${IOKIT_LIBRARY})
+endif ()
+
 if (USE_IRRKLANG)
     add_definitions ( "-DYGOPRO_USE_IRRKLANG" )
     if (MSVC)

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -56,8 +56,6 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 }
 
 #include <irrlicht.h>
-#include <GL/gl.h>
-#include <GL/glu.h>
 #include "CGUITTFont.h"
 #include "CGUIImageButton.h"
 #include <iostream>
@@ -72,6 +70,16 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 #include "mysignal.h"
 #include "../ocgcore/ocgapi.h"
 #include "../ocgcore/common.h"
+
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+
+#else //__APPLE__
+#include <GL/gl.h>
+#include <GL/glu.h>
+
+#endif //__APPLE__
 
 using namespace irr;
 using namespace core;


### PR DESCRIPTION
1. Change "GL" prefix in include path to "OpenGL" for macOS.
2. Include Cocoa and IOKit in external libraries list as they are required by Irrlicht engine on macos.
Built successfully with cmake on macOS 10.15.1. However, premake scripts have not been modified, 
so corresponding tweaks need to be made in order to allow build with premake.