### PR TITLE
Use environment variables instead of working directory

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -54,7 +54,6 @@ template<size_t N, typename... TR>
 inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 	return swprintf(buf, N, fmt, args...);
 }
-
 #include <irrlicht.h>
 #ifdef __APPLE__
 #include <OpenGL/gl.h>
@@ -66,6 +65,7 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 #include "CGUITTFont.h"
 #include "CGUIImageButton.h"
 #include <iostream>
+#include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <memory.h>
@@ -73,11 +73,21 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 #include <thread>
 #include <mutex>
 #include <algorithm>
+#include <functional>
 #include "bufferio.h"
 #include "myfilesystem.h"
 #include "mysignal.h"
 #include "../ocgcore/ocgapi.h"
 #include "../ocgcore/common.h"
+
+template<typename CharT>
+inline void path_foreach(const std::basic_string<CharT>& path, CharT pathSep,
+						 const std::function<void(const std::basic_string<CharT>&)>& cb) {
+	std::basic_istringstream<CharT> path_(path);
+	std::basic_string<CharT> dir;
+	while(std::getline(path_, dir, pathSep))
+		cb(dir);
+}
 
 using namespace irr;
 using namespace core;

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -365,6 +365,19 @@ int DataManager::CardReader(int code, void* pData) {
 	return 0;
 }
 byte* DataManager::ScriptReaderEx(const char* script_name, int* slen) {
+#ifdef YGOPRO_ENVIRONMENT_PATHS
+	// default script name: ./script/c%d.lua -> /c%d.lua
+	std::string file_name(script_name + 8);
+	const char* _script_path = getenv("YGOPRO_SCRIPT_PATH");
+	if (!_script_path) return NULL;
+	byte* res = NULL;
+	path_foreach<char>(std::string(_script_path), ':',
+					   [&](const std::string& prefix) {
+						   std::string full_path = prefix + file_name;
+						   res = res ? res : ScriptReader(full_path.c_str(), slen);
+					   });
+	return res;
+#else
 	// default script name: ./script/c%d.lua
 	char first[256];
 	char second[256];
@@ -379,6 +392,7 @@ byte* DataManager::ScriptReaderEx(const char* script_name, int* slen) {
 		return scriptBuffer;
 	else
 		return ScriptReader(second, slen);
+#endif
 }
 byte* DataManager::ScriptReader(const char* script_name, int* slen) {
 #ifdef _WIN32

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -10,6 +10,17 @@ byte DataManager::scriptBuffer[0x20000];
 IFileSystem* DataManager::FileSystem;
 DataManager dataManager;
 
+bool DataManager::LoadDB(const char* file) {
+#ifdef _WIN32
+	char wfile[256];
+	BufferIO::DecodeUTF8(file, wfile);
+	IReadFile* reader = FileSystem->createAndOpenFile(wfile);
+#else
+	IReadFile* reader = FileSystem->createAndOpenFile(file);
+#endif
+	return LoadDB(file, reader);
+}
+
 bool DataManager::LoadDB(const wchar_t* wfile) {
 	char file[256];
 	BufferIO::EncodeUTF8(wfile, file);
@@ -18,6 +29,10 @@ bool DataManager::LoadDB(const wchar_t* wfile) {
 #else
 	IReadFile* reader = FileSystem->createAndOpenFile(file);
 #endif
+	return LoadDB(file, reader);
+}
+
+bool DataManager::LoadDB(const char* file, IReadFile* reader) {
 	if(reader == NULL)
 		return false;
 	spmemvfs_db_t db;

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -365,6 +365,8 @@ int DataManager::CardReader(int code, void* pData) {
 	return 0;
 }
 byte* DataManager::ScriptReaderEx(const char* script_name, int* slen) {
+	if (script_name[0] == '/') // absolute path
+		return ScriptReader(script_name, slen);
 #ifdef YGOPRO_ENVIRONMENT_PATHS
 	// default script name: ./script/c%d.lua -> /c%d.lua
 	std::string file_name(script_name + 8);

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -10,8 +10,11 @@
 namespace ygo {
 
 class DataManager {
+private:
+	bool LoadDB(const char* file, IReadFile* reader);
 public:
 	DataManager(): _datas(8192), _strings(8192) {}
+	bool LoadDB(const char* file);
 	bool LoadDB(const wchar_t* wfile);
 	bool LoadStrings(const char* file);
 	bool LoadStrings(IReadFile* reader);

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -48,8 +48,10 @@ void DeckManager::LoadLFListSingle(const char* path) {
 	}
 }
 void DeckManager::LoadLFList() {
+#ifndef YGOPRO_DATA_PATH
 	LoadLFListSingle("expansions/lflist.conf");
 	LoadLFListSingle("lflist.conf");
+#endif
 	LFList nolimit;
 	nolimit.listName = L"N/A";
 	nolimit.hash = 0;

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1106,10 +1106,23 @@ void Game::RefreshDeck(irr::gui::IGUIComboBox* cbDeck) {
 }
 void Game::RefreshReplay() {
 	lstReplayList->clear();
+#ifdef XDG_ENVIRONMENT
+	std::string replay_dir = DATA_HOME + "/replay";
+	FileSystem::TraversalDir(replay_dir.c_str(), [this](const char* name, bool isdir) {
+		if(!isdir && strchr(name, '.') && !strncmp(strchr(name, '.'), ".yrp", 4)) {
+			size_t len = strlen(name);
+			wchar_t replay[256];
+			BufferIO::DecodeUTF8(name, replay);
+			if (Replay::CheckReplay(replay))
+				lstReplayList->addItem(replay);
+		}
+	});
+#else
 	FileSystem::TraversalDir(L"./replay", [this](const wchar_t* name, bool isdir) {
 		if(!isdir && wcsrchr(name, '.') && !mywcsncasecmp(wcsrchr(name, '.'), L".yrp", 4) && Replay::CheckReplay(name))
 			lstReplayList->addItem(name);
 	});
+#endif
 }
 void Game::RefreshSingleplay() {
 	lstSinglePlayList->clear();

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1075,6 +1075,18 @@ void Game::LoadExpansions() {
 #endif // USE_ENVIRONMENT_PATHS
 void Game::RefreshDeck(irr::gui::IGUIComboBox* cbDeck) {
 	cbDeck->clear();
+#ifdef XDG_ENVIRONMENT
+	std::string deck_dir = DATA_HOME + "/deck";
+	FileSystem::TraversalDir(deck_dir.c_str(), [cbDeck](const char* name, bool isdir) {
+		if(!isdir && strchr(name, '.') && !strncmp(strchr(name, '.'), ".ydk", 4)) {
+			size_t len = strlen(name);
+			wchar_t deckname[256];
+			BufferIO::DecodeUTF8(name, deckname);
+			deckname[wcslen(deckname) - 4] = 0;
+			cbDeck->addItem(deckname);
+		}
+	});
+#else
 	FileSystem::TraversalDir(L"./deck", [cbDeck](const wchar_t* name, bool isdir) {
 		if(!isdir && wcsrchr(name, '.') && !mywcsncasecmp(wcsrchr(name, '.'), L".ydk", 4)) {
 			size_t len = wcslen(name);
@@ -1084,6 +1096,7 @@ void Game::RefreshDeck(irr::gui::IGUIComboBox* cbDeck) {
 			cbDeck->addItem(deckname);
 		}
 	});
+#endif
 	for(size_t i = 0; i < cbDeck->getItemCount(); ++i) {
 		if(!wcscmp(cbDeck->getItem(i), gameConf.lastdeck)) {
 			cbDeck->setSelected(i);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1127,10 +1127,22 @@ void Game::RefreshReplay() {
 void Game::RefreshSingleplay() {
 	lstSinglePlayList->clear();
 	stSinglePlayInfo->setText(L"");
+#ifdef XDG_ENVIRONMENT
+	std::string single_dir = DATA_HOME + "/single";
+	FileSystem::TraversalDir(single_dir.c_str(), [this](const char* name, bool isdir) {
+		if(!isdir && strchr(name, '.') && !strncmp(strchr(name, '.'), ".lua", 4)) {
+			size_t len = strlen(name);
+			wchar_t single[256];
+			BufferIO::DecodeUTF8(name, single);
+			lstSinglePlayList->addItem(single);
+		}
+	});
+#else
 	FileSystem::TraversalDir(L"./single", [this](const wchar_t* name, bool isdir) {
 		if(!isdir && wcsrchr(name, '.') && !mywcsncasecmp(wcsrchr(name, '.'), L".lua", 4))
 			lstSinglePlayList->addItem(name);
 	});
+#endif
 }
 void Game::RefreshBot() {
 	if(!gameConf.enable_bot_mode)

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -107,7 +107,6 @@ struct FadingUnit {
 };
 
 class Game {
-
 public:
 	bool Initialize();
 	void MainLoop();
@@ -180,6 +179,16 @@ public:
 	void SetWindowsScale(float scale);
 	void FlashWindow();
 	void SetCursor(ECURSOR_ICON icon);
+
+#ifdef XDG_ENVIRONMENT
+	std::string FindConfigFile(const std::string& file, bool existing = true);
+	std::string FindDataFile(const std::string& file, bool existing = true);
+
+	constexpr static const char* sysconfdir = "/etc/ygopro";
+	constexpr static const char* sysdatadir = "/usr/share/ygopro";
+	std::string CONFIG_HOME;
+	std::string DATA_HOME;
+#endif
 
 	std::mutex gMutex;
 	Signal frameSignal;

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -114,7 +114,11 @@ public:
 	void BuildProjectionMatrix(irr::core::matrix4& mProjection, f32 left, f32 right, f32 bottom, f32 top, f32 znear, f32 zfar);
 	void InitStaticText(irr::gui::IGUIStaticText* pControl, u32 cWidth, u32 cHeight, irr::gui::CGUITTFont* font, const wchar_t* text);
 	void SetStaticText(irr::gui::IGUIStaticText* pControl, u32 cWidth, irr::gui::CGUITTFont* font, const wchar_t* text, u32 pos = 0);
+#ifdef YGOPRO_ENVIRONMENT_PATHS
+	bool LoadDataDirs();
+#else
 	void LoadExpansions();
+#endif
 	void RefreshDeck(irr::gui::IGUIComboBox* cbDeck);
 	void RefreshReplay();
 	void RefreshSingleplay();

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -1,6 +1,12 @@
 #include "image_manager.h"
 #include "game.h"
 
+#ifdef XDG_ENVIRONMENT
+#define DATA(x) mainGame->FindDataFile(x).c_str()
+#else
+#define DATA(x) x
+#endif
+
 namespace ygo {
 
 ImageManager imageManager;
@@ -12,36 +18,36 @@ bool ImageManager::Initial() {
 #endif
 	tCover[0] = NULL;
 	tCover[1] = NULL;
-	tCover[2] = GetTextureFromFile("textures/cover.jpg", CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
-	tCover[3] = GetTextureFromFile("textures/cover2.jpg", CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
+	tCover[2] = GetTextureFromFile(DATA("textures/cover.jpg"), CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
+	tCover[3] = GetTextureFromFile(DATA("textures/cover2.jpg"), CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
 	if(!tCover[3])
 		tCover[3] = tCover[2];
 	tUnknown = NULL;
 	tUnknownFit = NULL;
 	tUnknownThumb = NULL;
-	tAct = driver->getTexture("textures/act.png");
-	tAttack = driver->getTexture("textures/attack.png");
-	tChain = driver->getTexture("textures/chain.png");
-	tNegated = driver->getTexture("textures/negated.png");
-	tNumber = driver->getTexture("textures/number.png");
-	tLPBar = driver->getTexture("textures/lp.png");
-	tLPFrame = driver->getTexture("textures/lpf.png");
-	tMask = driver->getTexture("textures/mask.png");
-	tEquip = driver->getTexture("textures/equip.png");
-	tTarget = driver->getTexture("textures/target.png");
-	tChainTarget = driver->getTexture("textures/chaintarget.png");
-	tLim = driver->getTexture("textures/lim.png");
-	tOT = driver->getTexture("textures/ot.png");
-	tHand[0] = driver->getTexture("textures/f1.jpg");
-	tHand[1] = driver->getTexture("textures/f2.jpg");
-	tHand[2] = driver->getTexture("textures/f3.jpg");
+	tAct = driver->getTexture(DATA("textures/act.png"));
+	tAttack = driver->getTexture(DATA("textures/attack.png"));
+	tChain = driver->getTexture(DATA("textures/chain.png"));
+	tNegated = driver->getTexture(DATA("textures/negated.png"));
+	tNumber = driver->getTexture(DATA("textures/number.png"));
+	tLPBar = driver->getTexture(DATA("textures/lp.png"));
+	tLPFrame = driver->getTexture(DATA("textures/lpf.png"));
+	tMask = driver->getTexture(DATA("textures/mask.png"));
+	tEquip = driver->getTexture(DATA("textures/equip.png"));
+	tTarget = driver->getTexture(DATA("textures/target.png"));
+	tChainTarget = driver->getTexture(DATA("textures/chaintarget.png"));
+	tLim = driver->getTexture(DATA("textures/lim.png"));
+	tOT = driver->getTexture(DATA("textures/ot.png"));
+	tHand[0] = driver->getTexture(DATA("textures/f1.jpg"));
+	tHand[1] = driver->getTexture(DATA("textures/f2.jpg"));
+	tHand[2] = driver->getTexture(DATA("textures/f3.jpg"));
 	tBackGround = NULL;
 	tBackGround_menu = NULL;
 	tBackGround_deck = NULL;
-	tField[0] = driver->getTexture("textures/field2.png");
-	tFieldTransparent[0] = driver->getTexture("textures/field-transparent2.png");
-	tField[1] = driver->getTexture("textures/field3.png");
-	tFieldTransparent[1] = driver->getTexture("textures/field-transparent3.png");
+	tField[0] = driver->getTexture(DATA("textures/field2.png"));
+	tFieldTransparent[0] = driver->getTexture(DATA("textures/field-transparent2.png"));
+	tField[1] = driver->getTexture(DATA("textures/field3.png"));
+	tFieldTransparent[1] = driver->getTexture(DATA("textures/field-transparent3.png"));
 	ResizeTexture();
 	return true;
 }
@@ -93,24 +99,24 @@ void ImageManager::ResizeTexture() {
 	irr::s32 bgHeight = 640 * mainGame->yScale;
 	driver->removeTexture(tCover[0]);
 	driver->removeTexture(tCover[1]);
-	tCover[0] = GetTextureFromFile("textures/cover.jpg", imgWidth, imgHeight);
-	tCover[1] = GetTextureFromFile("textures/cover2.jpg", imgWidth, imgHeight);
+	tCover[0] = GetTextureFromFile(DATA("textures/cover.jpg"), imgWidth, imgHeight);
+	tCover[1] = GetTextureFromFile(DATA("textures/cover2.jpg"), imgWidth, imgHeight);
 	if(!tCover[1])
 		tCover[1] = tCover[0];
 	driver->removeTexture(tUnknown);
 	driver->removeTexture(tUnknownFit);
 	driver->removeTexture(tUnknownThumb);
-	tUnknown = GetTextureFromFile("textures/unknown.jpg", CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
-	tUnknownFit = GetTextureFromFile("textures/unknown.jpg", imgWidthFit, imgHeightFit);
-	tUnknownThumb = GetTextureFromFile("textures/unknown.jpg", imgWidthThumb, imgHeightThumb);
+	tUnknown = GetTextureFromFile(DATA("textures/unknown.jpg"), CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
+	tUnknownFit = GetTextureFromFile(DATA("textures/unknown.jpg"), imgWidthFit, imgHeightFit);
+	tUnknownThumb = GetTextureFromFile(DATA("textures/unknown.jpg"), imgWidthThumb, imgHeightThumb);
 	driver->removeTexture(tBackGround);
-	tBackGround = GetTextureFromFile("textures/bg.jpg", bgWidth, bgHeight);
+	tBackGround = GetTextureFromFile(DATA("textures/bg.jpg"), bgWidth, bgHeight);
 	driver->removeTexture(tBackGround_menu);
-	tBackGround_menu = GetTextureFromFile("textures/bg_menu.jpg", bgWidth, bgHeight);
+	tBackGround_menu = GetTextureFromFile(DATA("textures/bg_menu.jpg"), bgWidth, bgHeight);
 	if(!tBackGround_menu)
 		tBackGround_menu = tBackGround;
 	driver->removeTexture(tBackGround_deck);
-	tBackGround_deck = GetTextureFromFile("textures/bg_deck.jpg", bgWidth, bgHeight);
+	tBackGround_deck = GetTextureFromFile(DATA("textures/bg_deck.jpg"), bgWidth, bgHeight);
 	if(!tBackGround_deck)
 		tBackGround_deck = tBackGround;
 }
@@ -341,3 +347,5 @@ irr::video::ITexture* ImageManager::GetTextureField(int code) {
 		return NULL;
 }
 }
+
+#undef DATA

--- a/gframe/image_manager.h
+++ b/gframe/image_manager.h
@@ -8,6 +8,10 @@
 namespace ygo {
 
 class ImageManager {
+#ifdef YGOPRO_ENVIRONMENT_PATHS
+private:
+	std::string image_path;
+#endif
 public:
 	bool Initial();
 	void SetDevice(irr::IrrlichtDevice* dev);
@@ -15,6 +19,9 @@ public:
 	void RemoveTexture(int code);
 	void ResizeTexture();
 	irr::video::ITexture* GetTextureFromFile(const char* file, s32 width, s32 height);
+#ifdef YGOPRO_ENVIRONMENT_PATHS
+	irr::video::ITexture* GetTextureFromImagePath(const char* file, s32 width, s32 height);
+#endif
 	irr::video::ITexture* GetTexture(int code, bool fit = false);
 	irr::video::ITexture* GetTextureThumb(int code);
 	irr::video::ITexture* GetTextureField(int code);

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -4,6 +4,12 @@
 #include "../ocgcore/common.h"
 #include "../ocgcore/mtrandom.h"
 
+#ifdef XDG_ENVIRONMENT
+#define DATA(x) mainGame->FindDataFile(x).c_str()
+#else
+#define DATA(x) x
+#endif
+
 namespace ygo {
 
 long SingleMode::pduel = 0;
@@ -59,7 +65,7 @@ int SingleMode::SinglePlayThread() {
 			wchar_t fname[256];
 			myswprintf(fname, L"./single/%ls", open_file_name);
 			slen = BufferIO::EncodeUTF8(fname, filename);
-			if(!preload_script(pduel, filename, 0))
+			if(!preload_script(pduel, DATA(filename), 0))
 				slen = 0;
 		}
 	} else {
@@ -67,7 +73,7 @@ int SingleMode::SinglePlayThread() {
 		wchar_t fname[256];
 		myswprintf(fname, L"./single/%ls", name);
 		slen = BufferIO::EncodeUTF8(fname, filename);
-		if(!preload_script(pduel, filename, 0))
+		if(!preload_script(pduel, DATA(filename), 0))
 			slen = 0;
 	}
 	if(slen == 0) {

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -3,6 +3,12 @@
 #include "../ikpmp3/ikpMP3.h"
 #endif
 
+#ifdef XDG_ENVIRONMENT
+#define DATA(x) mainGame->FindDataFile(x).c_str()
+#else
+#define DATA(x) "./" x
+#endif
+
 namespace ygo {
 
 SoundManager soundManager;
@@ -26,6 +32,15 @@ bool SoundManager::Init() {
 	return false;
 }
 void SoundManager::RefreshBGMList() {
+#ifdef XDG_ENVIRONMENT
+	RefreshBGMDir("duel", BGM_DUEL);
+	RefreshBGMDir("menu", BGM_MENU);
+	RefreshBGMDir("deck", BGM_DECK);
+	RefreshBGMDir("advantage", BGM_ADVANTAGE);
+	RefreshBGMDir("disadvantage", BGM_DISADVANTAGE);
+	RefreshBGMDir("win", BGM_WIN);
+	RefreshBGMDir("lose", BGM_LOSE);
+#else
 	RefershBGMDir(L"", BGM_DUEL);
 	RefershBGMDir(L"duel", BGM_DUEL);
 	RefershBGMDir(L"menu", BGM_MENU);
@@ -34,7 +49,29 @@ void SoundManager::RefreshBGMList() {
 	RefershBGMDir(L"disadvantage", BGM_DISADVANTAGE);
 	RefershBGMDir(L"win", BGM_WIN);
 	RefershBGMDir(L"lose", BGM_LOSE);
+#endif
 }
+#ifdef XDG_ENVIRONMENT
+void SoundManager::RefreshBGMDir1(std::string path, int scene) {
+	FileSystem::TraversalDir(path.c_str(), [this, &path, scene](const char* name, bool isdir)
+	{
+		if (isdir || !strchr(name, '.'))
+			return;
+		const char* suffix = strchr(name, '.');
+		if (!strncmp(suffix, ".mp3", 4) || !strncmp(suffix, ".ogg", 4)) {
+			std::string full_path = path + "/" + name;
+			BGMList[BGM_ALL].push_back(full_path);
+			BGMList[scene].push_back(full_path);
+		}
+
+	});
+}
+
+void SoundManager::RefreshBGMDir(std::string path, int scene) {
+	RefreshBGMDir1(mainGame->DATA_HOME + "/bgm/" + path, scene);
+	RefreshBGMDir1(std::string(mainGame->sysdatadir) + "/bgm/" + path, scene);
+}
+#else
 void SoundManager::RefershBGMDir(std::wstring path, int scene) {
 	std::wstring search = L"./sound/BGM/" + path;
 	FileSystem::TraversalDir(search.c_str(), [this, &path, scene](const wchar_t* name, bool isdir) {
@@ -45,6 +82,7 @@ void SoundManager::RefershBGMDir(std::wstring path, int scene) {
 		}
 	});
 }
+#endif
 void SoundManager::PlaySoundEffect(int sound) {
 #ifdef YGOPRO_USE_IRRKLANG
 	if(!mainGame->chkEnableSound->isChecked())
@@ -52,123 +90,123 @@ void SoundManager::PlaySoundEffect(int sound) {
 	engineSound->setSoundVolume(mainGame->gameConf.sound_volume);
 	switch(sound) {
 	case SOUND_SUMMON: {
-		engineSound->play2D("./sound/summon.wav");
+		engineSound->play2D(DATA("sound/summon.wav"));
 		break;
 	}
 	case SOUND_SPECIAL_SUMMON: {
-		engineSound->play2D("./sound/specialsummon.wav");
+		engineSound->play2D(DATA("sound/specialsummon.wav"));
 		break;
 	}
 	case SOUND_ACTIVATE: {
-		engineSound->play2D("./sound/activate.wav");
+		engineSound->play2D(DATA("sound/activate.wav"));
 		break;
 	}
 	case SOUND_SET: {
-		engineSound->play2D("./sound/set.wav");
+		engineSound->play2D(DATA("sound/set.wav"));
 		break;
 	}
 	case SOUND_FILP: {
-		engineSound->play2D("./sound/flip.wav");
+		engineSound->play2D(DATA("sound/flip.wav"));
 		break;
 	}
 	case SOUND_REVEAL: {
-		engineSound->play2D("./sound/reveal.wav");
+		engineSound->play2D(DATA("sound/reveal.wav"));
 		break;
 	}
 	case SOUND_EQUIP: {
-		engineSound->play2D("./sound/equip.wav");
+		engineSound->play2D(DATA("sound/equip.wav"));
 		break;
 	}
 	case SOUND_DESTROYED: {
-		engineSound->play2D("./sound/destroyed.wav");
+		engineSound->play2D(DATA("sound/destroyed.wav"));
 		break;
 	}
 	case SOUND_BANISHED: {
-		engineSound->play2D("./sound/banished.wav");
+		engineSound->play2D(DATA("sound/banished.wav"));
 		break;
 	}
 	case SOUND_TOKEN: {
-		engineSound->play2D("./sound/token.wav");
+		engineSound->play2D(DATA("sound/token.wav"));
 		break;
 	}
 	case SOUND_ATTACK: {
-		engineSound->play2D("./sound/attack.wav");
+		engineSound->play2D(DATA("sound/attack.wav"));
 		break;
 	}
 	case SOUND_DIRECT_ATTACK: {
-		engineSound->play2D("./sound/directattack.wav");
+		engineSound->play2D(DATA("sound/directattack.wav"));
 		break;
 	}
 	case SOUND_DRAW: {
-		engineSound->play2D("./sound/draw.wav");
+		engineSound->play2D(DATA("sound/draw.wav"));
 		break;
 	}
 	case SOUND_SHUFFLE: {
-		engineSound->play2D("./sound/shuffle.wav");
+		engineSound->play2D(DATA("sound/shuffle.wav"));
 		break;
 	}
 	case SOUND_DAMAGE: {
-		engineSound->play2D("./sound/damage.wav");
+		engineSound->play2D(DATA("sound/damage.wav"));
 		break;
 	}
 	case SOUND_RECOVER: {
-		engineSound->play2D("./sound/gainlp.wav");
+		engineSound->play2D(DATA("sound/gainlp.wav"));
 		break;
 	}
 	case SOUND_COUNTER_ADD: {
-		engineSound->play2D("./sound/addcounter.wav");
+		engineSound->play2D(DATA("sound/addcounter.wav"));
 		break;
 	}
 	case SOUND_COUNTER_REMOVE: {
-		engineSound->play2D("./sound/removecounter.wav");
+		engineSound->play2D(DATA("sound/removecounter.wav"));
 		break;
 	}
 	case SOUND_COIN: {
-		engineSound->play2D("./sound/coinflip.wav");
+		engineSound->play2D(DATA("sound/coinflip.wav"));
 		break;
 	}
 	case SOUND_DICE: {
-		engineSound->play2D("./sound/diceroll.wav");
+		engineSound->play2D(DATA("sound/diceroll.wav"));
 		break;
 	}
 	case SOUND_NEXT_TURN: {
-		engineSound->play2D("./sound/nextturn.wav");
+		engineSound->play2D(DATA("sound/nextturn.wav"));
 		break;
 	}
 	case SOUND_PHASE: {
-		engineSound->play2D("./sound/phase.wav");
+		engineSound->play2D(DATA("sound/phase.wav"));
 		break;
 	}
 	case SOUND_MENU: {
-		engineSound->play2D("./sound/menu.wav");
+		engineSound->play2D(DATA("sound/menu.wav"));
 		break;
 	}
 	case SOUND_BUTTON: {
-		engineSound->play2D("./sound/button.wav");
+		engineSound->play2D(DATA("sound/button.wav"));
 		break;
 	}
 	case SOUND_INFO: {
-		engineSound->play2D("./sound/info.wav");
+		engineSound->play2D(DATA("sound/info.wav"));
 		break;
 	}
 	case SOUND_QUESTION: {
-		engineSound->play2D("./sound/question.wav");
+		engineSound->play2D(DATA("sound/question.wav"));
 		break;
 	}
 	case SOUND_CARD_PICK: {
-		engineSound->play2D("./sound/cardpick.wav");
+		engineSound->play2D(DATA("sound/cardpick.wav"));
 		break;
 	}
 	case SOUND_CARD_DROP: {
-		engineSound->play2D("./sound/carddrop.wav");
+		engineSound->play2D(DATA("sound/carddrop.wav"));
 		break;
 	}
 	case SOUND_PLAYER_ENTER: {
-		engineSound->play2D("./sound/playerenter.wav");
+		engineSound->play2D(DATA("sound/playerenter.wav"));
 		break;
 	}
 	case SOUND_CHAT: {
-		engineSound->play2D("./sound/chatmessage.wav");
+		engineSound->play2D(DATA("sound/chatmessage.wav"));
 		break;
 	}
 	default:
@@ -224,10 +262,14 @@ void SoundManager::PlayBGM(int scene) {
 		bgm_scene = scene;
 		int bgm = rand() % count;
 		auto name = BGMList[scene][bgm].c_str();
+#ifdef XDG_ENVIRONMENT
+		PlayMusic(name.c_str(), false);
+#else
 		wchar_t fname[1024];
 		myswprintf(fname, L"./sound/BGM/%ls", name);
 		BufferIO::EncodeUTF8(fname, BGMName);
 		PlayMusic(BGMName, false);
+#endif
 	}
 #endif
 }

--- a/gframe/sound_manager.h
+++ b/gframe/sound_manager.h
@@ -10,14 +10,23 @@ namespace ygo {
 
 class SoundManager {
 private:
+#ifdef XDG_ENVIRONMENT
+	std::vector<std::string> BGMList[8];
+#else
 	std::vector<std::wstring> BGMList[8];
+#endif
 	int bgm_scene;
 #ifdef YGOPRO_USE_IRRKLANG
 	irrklang::ISoundEngine* engineSound;
 	irrklang::ISoundEngine* engineMusic;
 	irrklang::ISound* soundBGM;
 #endif
+#ifdef XDG_ENVIRONMENT
+	void RefreshBGMDir(std::string path, int scene);
+	void RefreshBGMDir1(std::string path, int scene);
+#else
 	void RefershBGMDir(std::wstring path, int scene);
+#endif
 
 public:
 	bool Init();

--- a/premake4.lua
+++ b/premake4.lua
@@ -28,6 +28,14 @@ solution "ygo"
         if _OPTIONS["environment-paths"] then
             defines { "YGOPRO_ENVIRONMENT_PATHS" }
         end
+        newoption
+        {
+            trigger = "xdg-environment",
+            description = "Read config and data from XDG directories"
+        }
+        if _OPTIONS["xdg-environment"] then
+            defines { "XDG_ENVIRONMENT" }
+        end
 
     configuration "vs*"
         flags "EnableSSE2"

--- a/premake4.lua
+++ b/premake4.lua
@@ -20,6 +20,14 @@ solution "ygo"
 
     configuration "linux"
         defines { "LUA_USE_LINUX" }
+        newoption
+        {
+            trigger = "environment-paths",
+            description = "Read databases, scripts and images from YGOPRO_*_PATH"
+        }
+        if _OPTIONS["environment-paths"] then
+            defines { "YGOPRO_ENVIRONMENT_PATHS" }
+        end
 
     configuration "vs*"
         flags "EnableSSE2"


### PR DESCRIPTION
Currently, all YGOPRO builds load data from the working directory, irrespective of the OS they run in.  This patch adds environment variable support mostly for Linux builds, so that the binary can be run anywhere (especially `$prefix/bin`) while still loading files from well-known locations.

`--environment-paths` enables
1. loading card databases, lflists, etc. from `YGOPRO_DATA_PATH`,
2. loading images from `YGOPRO_IMAGE_PATH`, and
3. loading scripts from `YGOPRO_SCRIPT_PATH`.

`--xdg-environment` enables 
1. loading user configuration from `$XDG_CONFIG_HOME/ygopro (~/.config/ygopro)` or `$prefix/etc/ygopro`, and
2. loading decks, images, sounds, replays and singles from `$XDG_CONFIG_HOME/ygopro (~/.local/share/ygopro)` or `$prefix/share/ygopro`.

A variant of this patch was sent to mycard as https://github.com/mycard/ygopro/pull/9.