### PR TITLE
blur deck combobox after selecting

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -471,6 +471,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					break;
 				}
 				}
+				mainGame->env->setFocus(0);
 				InstantSearch();
 				break;
 			}
@@ -488,13 +489,16 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 						mainGame->ebDefense->setEnabled(true);
 					}
 				}
+				mainGame->env->setFocus(0);
 				InstantSearch();
 				break;
 			}
 			case COMBOBOX_ATTRIBUTE:
 			case COMBOBOX_RACE:
 			case COMBOBOX_LIMIT:
+				mainGame->env->setFocus(0);
 				InstantSearch();
+				break;
 			}
 		}
 		default: break;


### PR DESCRIPTION
![GIF](https://user-images.githubusercontent.com/13391795/79880875-23f1ea80-8423-11ea-8281-c7affce02370.gif)
It is annoying when you try to navigate search result with mouse wheel but switched the combobox option wrongly, so the comboboxes should automatic lose focus.