### PR TITLE
fix CardNameContains

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1069,6 +1069,7 @@ bool DeckBuilder::CardNameContains(const wchar_t *haystack, const wchar_t *needl
 				return true;
 			}
 		} else {
+			i -= j;
 			j = 0;
 		}
 		i++;


### PR DESCRIPTION
Fix: When you search `黑炎龙` you won't found `暗黑黑炎龙` due to a logic bug.