### PR TITLE
ignore STOC_GAME_MSG outside duel

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -238,6 +238,8 @@ void DuelClient::HandleSTOCPacketLan(char* data, unsigned int len) {
 	unsigned char pktType = BufferIO::ReadUInt8(pdata);
 	switch(pktType) {
 	case STOC_GAME_MSG: {
+		if(!mainGame->dInfo.isStarted)
+			break;
 		ClientAnalyze(pdata, len - 1);
 		break;
 	}


### PR DESCRIPTION
Sometimes the client still receive `STOC_GAME_MSG` when changing side, and processing that message may crash the client because the field is cleared.