### PR TITLE
fix hiding element

### DIFF
--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -989,6 +989,7 @@ void Game::ShowElement(irr::gui::IGUIElement * win, int autoframe) {
 			btnCardDisplay[i]->setDrawImage(false);
 	}
 	win->setRelativePosition(irr::core::recti(center.X, center.Y, 0, 0));
+	win->setVisible(true);
 	fadingList.push_back(fu);
 }
 void Game::HideElement(irr::gui::IGUIElement * win, bool set_action) {


### PR DESCRIPTION
If one element is showed and then hided before be drawn once (eg. join watch from command), it won't be hided due to https://github.com/Fluorohydride/ygopro/pull/2295/files#diff-c9a20f8f3b4aec346d3b29f2c9151519R995