### PR TITLE
update selecting tributes

### DIFF
--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -106,10 +106,14 @@ public:
 	void FadeCard(ClientCard* pcard, int alpha, int frame);
 	bool ShowSelectSum(bool panelmode);
 	bool CheckSelectSum();
+	bool CheckSelectTribute();
 	bool check_min(const std::set<ClientCard*>& left, std::set<ClientCard*>::const_iterator index, int min, int max);
 	bool check_sel_sum_s(const std::set<ClientCard*>& left, int index, int acc);
 	void check_sel_sum_t(const std::set<ClientCard*>& left, int acc);
 	bool check_sum(std::set<ClientCard*>::const_iterator index, std::set<ClientCard*>::const_iterator end, int acc, int count);
+	bool check_sel_sum_trib_s(const std::set<ClientCard*>& left, int index, int acc);
+	void check_sel_sum_trib_t(const std::set<ClientCard*>& left, int acc);
+	bool check_sum_trib(std::set<ClientCard*>::const_iterator index, std::set<ClientCard*>::const_iterator end, int acc);
 
 	void UpdateDeclarableList();
 

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1818,6 +1818,8 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		int count = BufferIO::ReadInt8(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
+		mainGame->dField.selectsum_all.clear();
+		mainGame->dField.selectsum_cards.clear();
 		mainGame->dField.select_panalmode = false;
 		int c, l, s, t;
 		unsigned int code;
@@ -1833,10 +1835,12 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 			if (code && pcard->code != code)
 				pcard->SetCode(code);
 			mainGame->dField.selectable_cards.push_back(pcard);
-			pcard->opParam = t;
+			mainGame->dField.selectsum_all.push_back(pcard);
+			pcard->opParam = t << 16 | 1;
 			pcard->select_seq = i;
 			pcard->is_selectable = true;
 		}
+		mainGame->dField.CheckSelectTribute();
 		if(select_hint)
 			myswprintf(textBuffer, L"%ls(%d-%d)", dataManager.GetDesc(select_hint),
 			           mainGame->dField.select_min, mainGame->dField.select_max);


### PR DESCRIPTION
The former handling will allow select cards with `opParam` sum above `select_max`.
For example, select _God Slime_(`opParam 3`) and a normal monster as tribute of a God.