### PR TITLE
fix ClientField::SetResponseSelectedOption()

### DIFF
--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -42,6 +42,7 @@ public:
 	std::vector<ClientCard*> conti_cards;
 	std::vector<std::pair<int,int>> activatable_descs;
 	std::vector<int> select_options;
+	std::vector<int> select_options_index;
 	std::vector<ChainInfo> chains;
 	int extra_p_count[2];
 

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -364,22 +364,23 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				mainGame->wCmdMenu->setVisible(false);
 				ShowCancelOrFinishButton(0);
 				if(!list_command) {
-					int index = -1;
 					select_options.clear();
+					select_options_index.clear();
 					for (size_t i = 0; i < activatable_cards.size(); ++i) {
 						if (activatable_cards[i] == clicked_card) {
 							if(activatable_descs[i].second == EDESC_OPERATION)
 								continue;
-							if(activatable_descs[i].second == EDESC_RESET) {
+							else if(activatable_descs[i].second == EDESC_RESET) {
 								if(id == BUTTON_CMD_ACTIVATE) continue;
 							} else {
 								if(id == BUTTON_CMD_RESET) continue;
 							}
 							select_options.push_back(activatable_descs[i].first);
-							if (index == -1) index = i;
+							select_options_index.push_back(i);
 						}
 					}
 					if (select_options.size() == 1) {
+						int index = select_options_index[0];
 						if (mainGame->dInfo.curMsg == MSG_SELECT_IDLECMD) {
 							DuelClient::SetResponseI((index << 16) + 5);
 						} else if (mainGame->dInfo.curMsg == MSG_SELECT_BATTLECMD) {
@@ -648,9 +649,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						break;
 					}
 					if(list_command == COMMAND_ACTIVATE || list_command == COMMAND_OPERATION) {
-						int index = -1;
 						command_card = selectable_cards[id - BUTTON_CARD_0 + mainGame->scrCardList->getPos() / 10];
 						select_options.clear();
+						select_options_index.clear();
 						for (size_t i = 0; i < activatable_cards.size(); ++i) {
 							if (activatable_cards[i] == command_card) {
 								if(activatable_descs[i].second == EDESC_OPERATION) {
@@ -659,10 +660,11 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 									if(list_command == COMMAND_OPERATION) continue;
 								}
 								select_options.push_back(activatable_descs[i].first);
-								if (index == -1) index = i;
+								select_options_index.push_back(i);
 							}
 						}
 						if (select_options.size() == 1) {
+							int index = select_options_index[0];
 							if (mainGame->dInfo.curMsg == MSG_SELECT_IDLECMD) {
 								DuelClient::SetResponseI((index << 16) + 5);
 							} else if (mainGame->dInfo.curMsg == MSG_SELECT_BATTLECMD) {
@@ -2412,8 +2414,7 @@ void ClientField::SetResponseSelectedOption() const {
 	if(mainGame->dInfo.curMsg == MSG_SELECT_OPTION) {
 		DuelClient::SetResponseI(selected_option);
 	} else {
-		int index = 0;
-		while(activatable_cards[index] != command_card || activatable_descs[index].first != select_options[selected_option]) index++;
+		int index = select_options_index[selected_option];
 		if(mainGame->dInfo.curMsg == MSG_SELECT_IDLECMD) {
 			DuelClient::SetResponseI((index << 16) + 5);
 		} else if(mainGame->dInfo.curMsg == MSG_SELECT_BATTLECMD) {


### PR DESCRIPTION
@mercury233 
Problem
Suppose that the trigger effect of (2nd) 驚楽園の支配人 ＜∀rlechino＞ is triggered 2 times in one chain.
After the chain ends, I can activate the effect of 驚楽園の支配人 ＜∀rlechino＞.

When I click the activate button of 驚楽園の支配人 ＜∀rlechino＞, there are 2 options since the 2nd effect is triggered twice.
That is, there are 2 chain object in core.select_chains, which are:
2nd effect(triggered by event group 1)
2nd effect(triggered by event group 2)

However, no matter which option I choose, I will always activate "2nd effect(triggered by event group 1)".

Reason
current ClientField::SetResponseSelectedOption()
The activatable_cards is a copy of core.select_chains in ocgcore.
It only compares the handler card and effect description when finding the response index.

In this case, the 2 chain object have the same triggering_effect, so the handler card and description are identical.
If the card and description are identical, it will always return the first chain object.

Solution
Require  Fluorohydride/ygopro-core#370
Now the index related to each option is stored in select_options_index.
ClientField::SetResponseSelectedOption() can find the correct index of the selected option.


Test replays
[replays.zip](https://github.com/Fluorohydride/ygopro/files/6212815/replays.zip)
bug_select.yrp
I choose the second option, but 2nd effect(triggered by event group 1) is activated.
correct_select.yrp
I choose the second option, and 2nd effect(triggered by event group 2) is activated as expected.
