### PR TITLE
fix ClientField::ClearSelect

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -371,6 +371,18 @@ void ClientField::ClearSelect() {
 		(*cit)->is_selectable = false;
 		(*cit)->is_selected = false;
 	}
+	for(auto cit = selected_cards.begin(); cit != selected_cards.end(); ++cit) {
+		(*cit)->is_selectable = false;
+		(*cit)->is_selected = false;
+	}
+	for(auto cit = selectsum_all.begin(); cit != selectsum_all.end(); ++cit) {
+		(*cit)->is_selectable = false;
+		(*cit)->is_selected = false;
+	}
+	for(auto cit = selectsum_cards.begin(); cit != selectsum_cards.end(); ++cit) {
+		(*cit)->is_selectable = false;
+		(*cit)->is_selected = false;
+	}
 }
 void ClientField::ClearChainSelect() {
 	for(auto cit = activatable_cards.begin(); cit != activatable_cards.end(); ++cit) {

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -3902,30 +3902,15 @@ void DuelClient::SendResponse() {
 		break;
 	}
 	case MSG_SELECT_CARD:
-	case MSG_SELECT_UNSELECT_CARD: {
+	case MSG_SELECT_UNSELECT_CARD:
+	case MSG_SELECT_TRIBUTE:
+	case MSG_SELECT_SUM:
+	case MSG_SELECT_COUNTER: {
 		mainGame->dField.ClearSelect();
 		break;
 	}
 	case MSG_SELECT_CHAIN: {
 		mainGame->dField.ClearChainSelect();
-		break;
-	}
-	case MSG_SELECT_TRIBUTE: {
-		mainGame->dField.ClearSelect();
-		break;
-	}
-	case MSG_SELECT_COUNTER: {
-		mainGame->dField.ClearSelect();
-		break;
-	}
-	case MSG_SELECT_SUM: {
-		for(int i = 0; i < mainGame->dField.must_select_count; ++i) {
-			mainGame->dField.selected_cards[i]->is_selected = false;
-		}
-		for(size_t i = 0; i < mainGame->dField.selectsum_all.size(); ++i) {
-			mainGame->dField.selectsum_all[i]->is_selectable = false;
-			mainGame->dField.selectsum_all[i]->is_selected = false;
-		}
 		break;
 	}
 	}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13391795/118093598-3eb54980-b400-11eb-9199-b46360247d86.png)
Fix the selected and selectable status didn't reset after tribute summon.