### PR TITLE
update class Replay

### DIFF
--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -5,11 +5,13 @@
 
 namespace ygo {
 
-Replay::Replay() {
-	is_recording = false;
-	is_replaying = false;
-	replay_data = new unsigned char[0x20000];
-	comp_data = new unsigned char[0x2000];
+Replay::Replay()
+	: fp(nullptr), pheader(), pdata(nullptr), replay_size(0), comp_size(0), is_recording(false), is_replaying(false) {
+	#ifdef _WIN32
+		recording_fp = nullptr;
+	#endif
+	replay_data = new unsigned char[MAX_REPLAY_SIZE];
+	comp_data = new unsigned char[MAX_COMP_SIZE];
 }
 Replay::~Replay() {
 	delete[] replay_data;
@@ -32,6 +34,9 @@ void Replay::BeginRecord() {
 		return;
 #endif
 	pdata = replay_data;
+	replay_size = 0;
+	comp_size = 0;
+	is_replaying = false;
 	is_recording = true;
 }
 void Replay::WriteHeader(ReplayHeader& header) {
@@ -44,8 +49,10 @@ void Replay::WriteHeader(ReplayHeader& header) {
 	fflush(fp);
 #endif
 }
-void Replay::WriteData(const void* data, unsigned int length, bool flush) {
+void Replay::WriteData(const void* data, int length, bool flush) {
 	if(!is_recording)
+		return;
+	if (length < 0 || (pdata - replay_data) + length > MAX_REPLAY_SIZE)
 		return;
 	memcpy(pdata, data, length);
 	pdata += length;
@@ -61,6 +68,8 @@ void Replay::WriteData(const void* data, unsigned int length, bool flush) {
 void Replay::WriteInt32(int data, bool flush) {
 	if(!is_recording)
 		return;
+	if ((pdata - replay_data) + 4 > MAX_REPLAY_SIZE)
+		return;
 	*((int*)(pdata)) = data;
 	pdata += 4;
 #ifdef _WIN32
@@ -75,6 +84,8 @@ void Replay::WriteInt32(int data, bool flush) {
 void Replay::WriteInt16(short data, bool flush) {
 	if(!is_recording)
 		return;
+	if ((pdata - replay_data) + 2 > MAX_REPLAY_SIZE)
+		return;
 	*((short*)(pdata)) = data;
 	pdata += 2;
 #ifdef _WIN32
@@ -88,6 +99,8 @@ void Replay::WriteInt16(short data, bool flush) {
 }
 void Replay::WriteInt8(char data, bool flush) {
 	if(!is_recording)
+		return;
+	if ((pdata - replay_data) + 1 > MAX_REPLAY_SIZE)
 		return;
 	*pdata = data;
 	pdata++;
@@ -116,11 +129,19 @@ void Replay::EndRecord() {
 #else
 	fclose(fp);
 #endif
-	pheader.datasize = pdata - replay_data;
+	if(pdata - replay_data > 0 && pdata - replay_data <= MAX_REPLAY_SIZE)
+		replay_size = pdata - replay_data;
+	else
+		replay_size = 0;
+	pheader.datasize = replay_size;
 	pheader.flag |= REPLAY_COMPRESSED;
 	size_t propsize = 5;
-	comp_size = 0x1000;
-	LzmaCompress(comp_data, &comp_size, replay_data, pdata - replay_data, pheader.props, &propsize, 5, 1 << 24, 3, 0, 2, 32, 1);
+	comp_size = MAX_COMP_SIZE;
+	int ret = LzmaCompress(comp_data, &comp_size, replay_data, replay_size, pheader.props, &propsize, 5, 1 << 24, 3, 0, 2, 32, 1);
+	if (ret != SZ_OK) {
+		*((int*)(comp_data)) = ret;
+		comp_size = sizeof(ret);
+	}
 	is_recording = false;
 }
 void Replay::SaveReplay(const wchar_t* name) {
@@ -196,7 +217,7 @@ bool Replay::CheckReplay(const wchar_t* name) {
 	ReplayHeader rheader;
 	size_t count = fread(&rheader, sizeof(ReplayHeader), 1, rfp);
 	fclose(rfp);
-	return count == 1 && rheader.id == 0x31707279 && rheader.version >= 0x12d0;
+	return count == 1 && rheader.id == 0x31707279 && rheader.version >= 0x12d0u;
 }
 bool Replay::DeleteReplay(const wchar_t* name) {
 	wchar_t fname[256];
@@ -245,7 +266,7 @@ void Replay::ReadName(wchar_t* data) {
 	ReadData(buffer, 40);
 	BufferIO::CopyWStr(buffer, data, 20);
 }
-void Replay::ReadData(void* data, unsigned int length) {
+void Replay::ReadData(void* data, int length) {
 	if(!is_replaying)
 		return;
 	memcpy(data, pdata, length);

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -6,10 +6,15 @@
 
 namespace ygo {
 
+// replay flag
 #define REPLAY_COMPRESSED	0x1
 #define REPLAY_TAG			0x2
 #define REPLAY_DECODED		0x4
 #define REPLAY_SINGLE_MODE	0x8
+
+// max size
+#define MAX_REPLAY_SIZE	0x20000
+#define MAX_COMP_SIZE	0x2000
 
 struct ReplayHeader {
 	unsigned int id;
@@ -19,21 +24,28 @@ struct ReplayHeader {
 	unsigned int datasize;
 	unsigned int hash;
 	unsigned char props[8];
+
+	ReplayHeader()
+		: id(0), version(0), flag(0), seed(0), datasize(0), hash(0), props{ 0 } {}
 };
 
 class Replay {
 public:
 	Replay();
 	~Replay();
+
+	// record
 	void BeginRecord();
 	void WriteHeader(ReplayHeader& header);
-	void WriteData(const void* data, unsigned int length, bool flush = true);
+	void WriteData(const void* data, int length, bool flush = true);
 	void WriteInt32(int data, bool flush = true);
 	void WriteInt16(short data, bool flush = true);
 	void WriteInt8(char data, bool flush = true);
 	void Flush();
 	void EndRecord();
 	void SaveReplay(const wchar_t* name);
+
+	// play
 	bool OpenReplay(const wchar_t* name);
 	static bool CheckReplay(const wchar_t* name);
 	static bool DeleteReplay(const wchar_t* name);
@@ -41,22 +53,25 @@ public:
 	bool ReadNextResponse(unsigned char resp[64]);
 	void ReadName(wchar_t* data);
 	void ReadHeader(ReplayHeader& header);
-	void ReadData(void* data, unsigned int length);
+	void ReadData(void* data, int length);
 	int ReadInt32();
 	short ReadInt16();
 	char ReadInt8();
 	void Rewind();
 
 	FILE* fp;
-	ReplayHeader pheader;
 #ifdef _WIN32
 	HANDLE recording_fp;
 #endif
+
+	ReplayHeader pheader;
 	unsigned char* replay_data;
 	unsigned char* comp_data;
-	unsigned char* pdata;
 	size_t replay_size;
 	size_t comp_size;
+
+private:
+	unsigned char* pdata;
 	bool is_recording;
 	bool is_replaying;
 };


### PR DESCRIPTION
@mercury233 

# Problem
The c;lass Replay does not have initialization and bounds checking.

# Solution
class Replay
pdata, is_recording, is_replaying
changed into private member

Replay()
BeginRecord()
add initialization

write functions
add boundary checking

EndRecord()
add boundary checking
save the return value if LzmaCompress() fails


OpenReplay()
There are 2 types of replay file.
1. Compressed version
It is the replay file created by SaveReplay().
`pheader.datasize` will record the original size.
After `LzmaUncompress()` completes, we should check if `pheader.datasize` is correct.

2. Original version
It is `_LastReplay.yrp` recorded by the server side.
It does not have `pheader.datasize`, `comp_data`, so the `comp_size` should be set to 0.
