### PR TITLE
update RNG and uniform distribution, part 2

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -8,6 +8,7 @@
 #ifdef _WIN32
 
 #include <WinSock2.h>
+#define NOMINMAX
 #include <windows.h>
 #include <ws2tcpip.h>
 

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -79,6 +79,7 @@ void DeckBuilder::Initialize() {
 	mainGame->btnSideReload->setVisible(false);
 	filterList = &deckManager._lfList[mainGame->gameConf.use_lflist ? mainGame->gameConf.default_lflist : deckManager._lfList.size() - 1].content;
 	ClearSearch();
+	rnd.reset((unsigned int)time(nullptr));
 	mouse_pos.set(0, 0);
 	hovered_code = 0;
 	hovered_pos = 0;
@@ -167,7 +168,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_SHUFFLE_DECK: {
-				std::random_shuffle(deckManager.current_deck.main.begin(), deckManager.current_deck.main.end());
+				rnd.shuffle_vector(deckManager.current_deck.main);
 				break;
 			}
 			case BUTTON_SAVE_DECK: {

--- a/gframe/deck_con.h
+++ b/gframe/deck_con.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 #include "client_card.h"
+#include "../ocgcore/mtrandom.h"
 
 namespace ygo {
 
@@ -76,6 +77,7 @@ public:
 	int prev_sel;
 	bool is_modified;
 	bool readonly;
+	mt19937 rnd;
 
 	const std::unordered_map<int, int>* filterList;
 	std::vector<code_pointer> results;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -681,7 +681,12 @@ void DuelClient::HandleSTOCPacketLan(char* data, unsigned int len) {
 		char* prep = pdata;
 		Replay new_replay;
 		memcpy(&new_replay.pheader, prep, sizeof(ReplayHeader));
-		time_t starttime = new_replay.pheader.seed;
+		time_t starttime;
+		if (new_replay.pheader.flag & REPLAY_UNIFORM)
+			starttime = new_replay.pheader.start_time;
+		else
+			starttime = new_replay.pheader.seed;
+		
 		tm* localedtime = localtime(&starttime);
 		wchar_t timetext[40];
 		wcsftime(timetext, 40, L"%Y-%m-%d %H-%M-%S", localedtime);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -29,7 +29,7 @@ int DuelClient::last_select_hint = 0;
 char DuelClient::last_successful_msg[0x2000];
 unsigned int DuelClient::last_successful_msg_length = 0;
 wchar_t DuelClient::event_string[256];
-mtrandom DuelClient::rnd;
+mt19937 DuelClient::rnd;
 
 bool DuelClient::is_refreshing = false;
 int DuelClient::match_kill = 0;
@@ -58,7 +58,7 @@ bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_g
 		return false;
 	}
 	connect_state = 0x1;
-	rnd.reset(time(0));
+	rnd.reset((unsigned int)time(nullptr));
 	if(!create_game) {
 		timeval timeout = {5, 0};
 		event* resp_event = event_new(client_base, 0, EV_TIMEOUT, ConnectTimeout, 0);
@@ -1656,7 +1656,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 			SetResponseI(-1);
 			mainGame->dField.ClearChainSelect();
 			if(mainGame->chkWaitChain->isChecked() && !mainGame->ignore_chain) {
-				mainGame->WaitFrameSignal(rnd.real() * 20 + 20);
+				mainGame->WaitFrameSignal(rnd.get_random_integer(20, 40));
 			}
 			DuelClient::SendResponse();
 			return true;
@@ -1756,7 +1756,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 			if(!pzone) {
 				if(mainGame->chkRandomPos->isChecked()) {
 					do {
-						respbuf[2] = rnd.real() * 7;
+						respbuf[2] = rnd.get_random_integer(0, 6);
 					} while(!(filter & (1 << respbuf[2])));
 				} else {
 					if (filter & 0x40) respbuf[2] = 6;

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -36,7 +36,7 @@ private:
 	static char last_successful_msg[0x2000];
 	static unsigned int last_successful_msg_length;
 	static wchar_t event_string[256];
-	static mtrandom rnd;
+	static mt19937 rnd;
 public:
 	static bool StartClient(unsigned int ip, unsigned short port, bool create_game = true);
 	static void ConnectTimeout(evutil_socket_t fd, short events, void* arg);

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -465,7 +465,11 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					break;
 				wchar_t infobuf[256];
 				std::wstring repinfo;
-				time_t curtime = ReplayMode::cur_replay.pheader.seed;
+				time_t curtime;
+				if(ReplayMode::cur_replay.pheader.flag & REPLAY_UNIFORM)
+					curtime = ReplayMode::cur_replay.pheader.start_time;
+				else
+					curtime = ReplayMode::cur_replay.pheader.seed;
 				tm* st = localtime(&curtime);
 				wcsftime(infobuf, 256, L"%Y/%m/%d %H:%M:%S\n", st);
 				repinfo.append(infobuf);

--- a/gframe/myfilesystem.h
+++ b/gframe/myfilesystem.h
@@ -14,6 +14,7 @@
 
 #ifdef _WIN32
 
+#define NOMINMAX
 #include <Windows.h>
 
 class FileSystem {

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -11,6 +11,7 @@ namespace ygo {
 #define REPLAY_TAG			0x2
 #define REPLAY_DECODED		0x4
 #define REPLAY_SINGLE_MODE	0x8
+#define REPLAY_UNIFORM		0x10
 
 // max size
 #define MAX_REPLAY_SIZE	0x20000
@@ -22,11 +23,11 @@ struct ReplayHeader {
 	unsigned int flag;
 	unsigned int seed;
 	unsigned int datasize;
-	unsigned int hash;
+	unsigned int start_time;
 	unsigned char props[8];
 
 	ReplayHeader()
-		: id(0), version(0), flag(0), seed(0), datasize(0), hash(0), props{ 0 } {}
+		: id(0), version(0), flag(0), seed(0), datasize(0), start_time(0), props{ 0 } {}
 };
 
 class Replay {

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -4,7 +4,6 @@
 #include "single_mode.h"
 #include "../ocgcore/common.h"
 #include "../ocgcore/mtrandom.h"
-#include <random>
 
 namespace ygo {
 

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -225,7 +225,10 @@ bool ReplayMode::StartDuel() {
 		}
 	} else {
 		char filename[256];
-		size_t slen = cur_replay.ReadInt16();
+		int slen = cur_replay.ReadInt16();
+		if (slen < 0 || slen > 255) {
+			return false;
+		}
 		cur_replay.ReadData(filename, slen);
 		filename[slen] = 0;
 		if(!preload_script(pduel, filename, 0)) {

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -4,6 +4,7 @@
 #include "single_mode.h"
 #include "../ocgcore/common.h"
 #include "../ocgcore/mtrandom.h"
+#include <random>
 
 namespace ygo {
 
@@ -153,9 +154,8 @@ int ReplayMode::ReplayThread() {
 }
 bool ReplayMode::StartDuel() {
 	const ReplayHeader& rh = cur_replay.pheader;
-	mtrandom rnd;
-	int seed = rh.seed;
-	rnd.reset(seed);
+	unsigned int seed = rh.seed;
+	std::mt19937 rnd(seed);
 	if(mainGame->dInfo.isTag) {
 		cur_replay.ReadName(mainGame->dInfo.hostname);
 		cur_replay.ReadName(mainGame->dInfo.hostname_tag);
@@ -165,7 +165,7 @@ bool ReplayMode::StartDuel() {
 		cur_replay.ReadName(mainGame->dInfo.hostname);
 		cur_replay.ReadName(mainGame->dInfo.clientname);
 	}
-	pduel = create_duel(rnd.rand());
+	pduel = create_duel(rnd());
 	int start_lp = cur_replay.ReadInt32();
 	int start_hand = cur_replay.ReadInt32();
 	int draw_count = cur_replay.ReadInt32();
@@ -235,6 +235,8 @@ bool ReplayMode::StartDuel() {
 			return false;
 		}
 	}
+	if (!(rh.flag & REPLAY_UNIFORM))
+		opt |= DUEL_OLD_REPLAY;
 	start_duel(pduel, opt);
 	return true;
 }

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -396,7 +396,6 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 		return;
 	duel_stage = DUEL_STAGE_DUELING;
 	bool swapped = false;
-	mtrandom rnd;
 	pplayer[0] = players[0];
 	pplayer[1] = players[1];
 	if((tp && dp->type == 1) || (!tp && dp->type == 0)) {
@@ -411,34 +410,30 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 		swapped = true;
 	}
 	dp->state = CTOS_RESPONSE;
+	std::random_device rd;
+	unsigned int seed = rd();
+	mt19937 rnd(seed);
+	unsigned int duel_seed = rnd.rand();
 	ReplayHeader rh;
 	rh.id = 0x31707279;
 	rh.version = PRO_VERSION;
-	rh.flag = 0;
-	time_t seed = time(0);
+	rh.flag = REPLAY_UNIFORM;
 	rh.seed = seed;
+	rh.start_time = (unsigned int)time(nullptr);
 	last_replay.BeginRecord();
 	last_replay.WriteHeader(rh);
-	rnd.reset(seed);
 	last_replay.WriteData(players[0]->name, 40, false);
 	last_replay.WriteData(players[1]->name, 40, false);
 	if(!host_info.no_shuffle_deck) {
-		for(size_t i = pdeck[0].main.size() - 1; i > 0; --i) {
-			int swap = rnd.real() * (i + 1);
-			std::swap(pdeck[0].main[i], pdeck[0].main[swap]);
-		}
-		for(size_t i = pdeck[1].main.size() - 1; i > 0; --i) {
-			int swap = rnd.real() * (i + 1);
-			std::swap(pdeck[1].main[i], pdeck[1].main[swap]);
-		}
+		rnd.shuffle_vector(pdeck[0].main);
+		rnd.shuffle_vector(pdeck[1].main);
 	}
 	time_limit[0] = host_info.time_limit;
 	time_limit[1] = host_info.time_limit;
 	set_script_reader((script_reader)DataManager::ScriptReaderEx);
 	set_card_reader((card_reader)DataManager::CardReader);
 	set_message_handler((message_handler)SingleDuel::MessageHandler);
-	rnd.reset(seed);
-	pduel = create_duel(rnd.rand());
+	pduel = create_duel(duel_seed);
 	set_player_info(pduel, 0, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	set_player_info(pduel, 1, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	int opt = (int)host_info.duel_rule << 16;

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -33,9 +33,9 @@ int SingleMode::SinglePlayThread() {
 	const int start_hand = 5;
 	const int draw_count = 1;
 	const int opt = 0;
-	mtrandom rnd;
-	time_t seed = time(0);
-	rnd.reset(seed);
+	std::random_device rd;
+	unsigned int seed = rd();
+	mt19937 rnd(seed);
 	set_script_reader((script_reader)DataManager::ScriptReaderEx);
 	set_card_reader((card_reader)DataManager::CardReader);
 	set_message_handler((message_handler)MessageHandler);
@@ -77,8 +77,9 @@ int SingleMode::SinglePlayThread() {
 	ReplayHeader rh;
 	rh.id = 0x31707279;
 	rh.version = PRO_VERSION;
-	rh.flag = REPLAY_SINGLE_MODE;
+	rh.flag = REPLAY_UNIFORM | REPLAY_SINGLE_MODE;
 	rh.seed = seed;
+	rh.start_time = (unsigned int)time(nullptr);
 	mainGame->gMutex.lock();
 	mainGame->HideElement(mainGame->wSinglePlay);
 	mainGame->ClearCardInfo();

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -356,7 +356,6 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 		return;
 	duel_stage = DUEL_STAGE_DUELING;
 	bool swapped = false;
-	mtrandom rnd;
 	pplayer[0] = players[0];
 	pplayer[1] = players[1];
 	pplayer[2] = players[2];
@@ -376,44 +375,34 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	cur_player[0] = players[0];
 	cur_player[1] = players[3];
 	dp->state = CTOS_RESPONSE;
+	std::random_device rd;
+	unsigned int seed = rd();
+	mt19937 rnd(seed);
+	unsigned int duel_seed = rnd.rand();
 	ReplayHeader rh;
 	rh.id = 0x31707279;
 	rh.version = PRO_VERSION;
-	rh.flag = REPLAY_TAG;
-	time_t seed = time(0);
+	rh.flag = REPLAY_UNIFORM | REPLAY_TAG;
 	rh.seed = seed;
+	rh.start_time = (unsigned int)time(nullptr);
 	last_replay.BeginRecord();
 	last_replay.WriteHeader(rh);
-	rnd.reset(seed);
 	last_replay.WriteData(players[0]->name, 40, false);
 	last_replay.WriteData(players[1]->name, 40, false);
 	last_replay.WriteData(players[2]->name, 40, false);
 	last_replay.WriteData(players[3]->name, 40, false);
 	if(!host_info.no_shuffle_deck) {
-		for(size_t i = pdeck[0].main.size() - 1; i > 0; --i) {
-			int swap = rnd.real() * (i + 1);
-			std::swap(pdeck[0].main[i], pdeck[0].main[swap]);
-		}
-		for(size_t i = pdeck[1].main.size() - 1; i > 0; --i) {
-			int swap = rnd.real() * (i + 1);
-			std::swap(pdeck[1].main[i], pdeck[1].main[swap]);
-		}
-		for(size_t i = pdeck[2].main.size() - 1; i > 0; --i) {
-			int swap = rnd.real() * (i + 1);
-			std::swap(pdeck[2].main[i], pdeck[2].main[swap]);
-		}
-		for(size_t i = pdeck[3].main.size() - 1; i > 0; --i) {
-			int swap = rnd.real() * (i + 1);
-			std::swap(pdeck[3].main[i], pdeck[3].main[swap]);
-		}
+		rnd.shuffle_vector(pdeck[0].main);
+		rnd.shuffle_vector(pdeck[1].main);
+		rnd.shuffle_vector(pdeck[2].main);
+		rnd.shuffle_vector(pdeck[3].main);
 	}
 	time_limit[0] = host_info.time_limit;
 	time_limit[1] = host_info.time_limit;
 	set_script_reader((script_reader)DataManager::ScriptReaderEx);
 	set_card_reader((card_reader)DataManager::CardReader);
 	set_message_handler((message_handler)TagDuel::MessageHandler);
-	rnd.reset(seed);
-	pduel = create_duel(rnd.rand());
+	pduel = create_duel(duel_seed);
 	set_player_info(pduel, 0, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	set_player_info(pduel, 1, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	int opt = (int)host_info.duel_rule << 16;


### PR DESCRIPTION
@mercury233 
# Problem
1. The seed of RNG is the start time of the duel.
![seed](https://user-images.githubusercontent.com/2851577/129568570-3f7d09b6-55b8-4ea6-a1a0-f2ba29fca997.png)
These are 2 different games start at the same second.
All games start at the same second will have the same seeds because the unit of `time()` is second.
In other words, the starting hand is almost predictable.

2. The seed of `duel` is the first random number used in initial shuffle

Initial shuffle:
```c++
rnd.reset(seed);
for(size_t i = pdeck[0].main.size() - 1; i > 0; --i) {
	int swap = rnd.real() * (i + 1);
	std::swap(pdeck[0].main[i], pdeck[0].main[swap]);
}
```

Create duel:
```c++
rnd.reset(seed);
pduel = create_duel(rnd.rand());
```
Let {a_n} be the sequence generated by seed.

Initial shuffle:
a1, a2, a3, ...

duel seed:
a1

One can get some information about `a1` by observing `pdeck[0].main[n-1]`.


3. The "Shuffle" button in Deck Edit page uses `void random_shuffle( RandomIt first, RandomIt last )`
(In VS2019)
```c++
// FUNCTION TEMPLATE random_shuffle
template <class _RanIt>
void random_shuffle(_RanIt _First, _RanIt _Last) { // shuffle [_First, _Last) using rand()
    _Rand_urng_from_func _Func;
    _STD shuffle(_First, _Last, _Func);
}
```
`void random_shuffle( RandomIt first, RandomIt last )` is deprecated in c++14.
It should not be used anymore.


see  Fluorohydride/ygopro-core#391, #2352 

# Solution
Require #2362 

## Seed
Now the start time and seed are stored in different sections of the header.
The 2 seeds:
1. seed
Now it is generated by `std::random_device` rather than `time(nullptr)`.

2. duel_seed
Let {a_n} be the sequence generated by seed.

duel seed:
a1

Initial shuffle:
a2, a3, a4, ...,

## Shuffle
Now every shuffling uses `void mt19937::shuffle_vector(std::vector<T>& v)`.

