### PR TITLE
fix panelmode compile problems

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1468,7 +1468,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		int c, l, s, ss;
 		unsigned int code;
 		bool panelmode = false;
-		int hand_count[2] = { mainGame->dField.hand[0].size(), mainGame->dField.hand[1].size() };
+		size_t hand_count[2] = { mainGame->dField.hand[0].size(), mainGame->dField.hand[1].size() };
 		int select_count_in_hand[2] = { 0, 0 };
 		bool select_ready = mainGame->dField.select_min == 0;
 		mainGame->dField.select_ready = select_ready;
@@ -1533,7 +1533,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 		int c, l, s, ss;
 		unsigned int code;
 		bool panelmode = false;
-		int hand_count[2] = { mainGame->dField.hand[0].size(), mainGame->dField.hand[1].size() };
+		size_t hand_count[2] = { mainGame->dField.hand[0].size(), mainGame->dField.hand[1].size() };
 		int select_count_in_hand[2] = { 0, 0 };
 		mainGame->dField.select_ready = false;
 		ClientCard* pcard;


### PR DESCRIPTION
Fixed the following error when compile on Linux *It is an error on macOS build*

```
../gframe/duelclient.cpp: In static member function ‘static int ygo::DuelClient::ClientAnalyze(char*, unsigned int)’:
../gframe/duelclient.cpp:1774:54: warning: narrowing conversion of ‘ygo::mainGame->ygo::Game::dField.ygo::ClientField::hand[0].std::vector<ygo::ClientCard*>::size()’ from ‘std::vector<ygo::ClientCard*>::size_type’ {aka ‘long unsigned int’} to ‘int’ [-Wnarrowing]
 1774 |   int hand_count[2] = { mainGame->dField.hand[0].size(), mainGame->dField.hand[1].size() };
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
../gframe/duelclient.cpp:1774:87: warning: narrowing conversion of ‘ygo::mainGame->ygo::Game::dField.ygo::ClientField::hand[1].std::vector<ygo::ClientCard*>::size()’ from ‘std::vector<ygo::ClientCard*>::size_type’ {aka ‘long unsigned int’} to ‘int’ [-Wnarrowing]
 1774 |   int hand_count[2] = { mainGame->dField.hand[0].size(), mainGame->dField.hand[1].size() };
      |
```