### PR TITLE
read japanese font

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -93,6 +93,9 @@ bool Game::Initialize() {
 	textFont = irr::gui::CGUITTFont::createTTFont(env, gameConf.textfont, gameConf.textfontsize);
 	if(!textFont) {
 		const wchar_t* textFontPaths[] = {
+			L"C:/Windows/Fonts/YuGothM.ttc",
+			L"C:/Windows/Fonts/meiryo.ttc",
+			L"C:/Windows/Fonts/msgothic.ttc",
 			L"C:/Windows/Fonts/msyh.ttc",
 			L"C:/Windows/Fonts/msyh.ttf",
 			L"C:/Windows/Fonts/simsun.ttc",


### PR DESCRIPTION
Basically, japanese user use **YuGothic**(Win 8.1 or more), **Meiryo**(Win Vista or more), and **MS Gothic**(old font).
So, these fonts can read by default.