### PR TITLE
Add initial support for build.zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Zig files
+zig-cache/
+zig-out/

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    const target = b.standardTargetOptions(.{});
+    const mode = b.standardReleaseOptions();
+
+    const c_flags = [_][]const u8{
+        // https://github.com/ziglang/zig/wiki/FAQ#why-do-i-get-illegal-instruction-when-using-with-zig-cc-to-build-c-code
+        // Currently required because the codebase seems to contain some UB.
+        // Can be commented out for debugging.
+        "-fno-sanitize=undefined",
+
+        "-DNDEBUG",
+        "-Wno-format-security",
+        "-fexceptions",
+        "-fno-strict-aliasing",
+        "-fomit-frame-pointer",
+    };
+
+    const cxx_flags = c_flags ++ [_][]const u8{
+        "-fno-rtti",
+        "-std=c++14",
+    };
+
+    const lzma = b.addStaticLibrary("lzma", null);
+    lzma.addCSourceFiles(&.{
+        "gframe/lzma/Alloc.c",
+        "gframe/lzma/LzFind.c",
+        "gframe/lzma/LzmaDec.c",
+        "gframe/lzma/LzmaEnc.c",
+        "gframe/lzma/LzmaLib.c",
+    }, &c_flags);
+
+    lzma.linkLibC();
+
+    const ocgcore = b.addStaticLibrary("ocgcore", null);
+    ocgcore.addCSourceFiles(&.{
+        "ocgcore/card.cpp",
+        "ocgcore/duel.cpp",
+        "ocgcore/effect.cpp",
+        "ocgcore/field.cpp",
+        "ocgcore/group.cpp",
+        "ocgcore/interpreter.cpp",
+        "ocgcore/libcard.cpp",
+        "ocgcore/libdebug.cpp",
+        "ocgcore/libduel.cpp",
+        "ocgcore/libeffect.cpp",
+        "ocgcore/libgroup.cpp",
+        "ocgcore/mem.cpp",
+        "ocgcore/ocgapi.cpp",
+        "ocgcore/operations.cpp",
+        "ocgcore/playerop.cpp",
+        "ocgcore/processor.cpp",
+        "ocgcore/scriptlib.cpp",
+    }, &cxx_flags);
+
+    ocgcore.addIncludeDir("lua-5.3.5/src");
+
+    ocgcore.linkLibCpp();
+
+    const exe = b.addExecutable("ygopro", null);
+    exe.addCSourceFile("gframe/spmemvfs/spmemvfs.c", &c_flags);
+
+    exe.addCSourceFiles(&.{
+        "gframe/CGUIImageButton.cpp",
+        "gframe/CGUITTFont.cpp",
+        "gframe/client_card.cpp",
+        "gframe/client_field.cpp",
+        "gframe/data_manager.cpp",
+        "gframe/deck_con.cpp",
+        "gframe/deck_manager.cpp",
+        "gframe/drawing.cpp",
+        "gframe/duelclient.cpp",
+        "gframe/event_handler.cpp",
+        "gframe/game.cpp",
+        "gframe/gframe.cpp",
+        "gframe/image_manager.cpp",
+        "gframe/materials.cpp",
+        "gframe/menu_handler.cpp",
+        "gframe/netserver.cpp",
+        "gframe/replay.cpp",
+        "gframe/replay_mode.cpp",
+        "gframe/single_duel.cpp",
+        "gframe/single_mode.cpp",
+        "gframe/sound_manager.cpp",
+        "gframe/tag_duel.cpp",
+    }, &cxx_flags);
+
+    exe.addLibPath("lua-5.3.5/src");
+
+    exe.linkLibCpp();
+    exe.linkLibrary(lzma);
+    exe.linkLibrary(ocgcore);
+    exe.linkSystemLibrary("GL");
+    exe.linkSystemLibrary("Irrlicht");
+    exe.linkSystemLibrary("event");
+    exe.linkSystemLibrary("event_pthreads");
+    exe.linkSystemLibrary("freetype");
+    exe.linkSystemLibrary("lua");
+    exe.linkSystemLibrary("sqlite3");
+
+    exe.setTarget(target);
+    exe.setBuildMode(mode);
+
+    exe.install();
+
+    const run_cmd = exe.run();
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/gframe/CGUIButton.h
+++ b/gframe/CGUIButton.h
@@ -5,12 +5,12 @@
 #ifndef __C_GUI_BUTTON_H_INCLUDED__
 #define __C_GUI_BUTTON_H_INCLUDED__
 
-#include "IrrCompileConfig.h"
+#include "irrlicht/IrrCompileConfig.h"
 #ifdef _IRR_COMPILE_WITH_GUI_
 
-#include "IGUIButton.h"
-#include "IGUISpriteBank.h"
-#include "SColor.h"
+#include "irrlicht/IGUIButton.h"
+#include "irrlicht/IGUISpriteBank.h"
+#include "irrlicht/SColor.h"
 
 namespace irr
 {
@@ -140,4 +140,3 @@ namespace gui
 #endif // _IRR_COMPILE_WITH_GUI_
 
 #endif // __C_GUI_BUTTON_H_INCLUDED__
-

--- a/gframe/CGUIImageButton.h
+++ b/gframe/CGUIImageButton.h
@@ -1,7 +1,7 @@
 #ifndef _C_GUI_IMAGE_BUTTON_H_
 #define _C_GUI_IMAGE_BUTTON_H_
 
-#include <irrlicht.h>
+#include <irrlicht/irrlicht.h>
 #include "CGUIButton.h"
 
 namespace irr {

--- a/gframe/CGUITTFont.cpp
+++ b/gframe/CGUITTFont.cpp
@@ -28,7 +28,7 @@
    john@suckerfreegames.com
 */
 
-#include <irrlicht.h>
+#include <irrlicht/irrlicht.h>
 #include "CGUITTFont.h"
 
 namespace irr {

--- a/gframe/CGUITTFont.h
+++ b/gframe/CGUITTFont.h
@@ -31,7 +31,7 @@
 #ifndef __C_GUI_TTFONT_H_INCLUDED__
 #define __C_GUI_TTFONT_H_INCLUDED__
 
-#include <irrlicht.h>
+#include <irrlicht/irrlicht.h>
 #include <ft2build.h>
 #include "irrUString.h"
 #include FT_FREETYPE_H

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -56,7 +56,7 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 	return swprintf(buf, N, fmt, args...);
 }
 
-#include <irrlicht.h>
+#include <irrlicht/irrlicht.h>
 #ifdef __APPLE__
 #include <OpenGL/gl.h>
 #include <OpenGL/glu.h>

--- a/gframe/irrUString.h
+++ b/gframe/irrUString.h
@@ -53,12 +53,12 @@
 #	include <ostream>
 #endif
 
-#include "irrTypes.h"
-#include "irrAllocator.h"
-#include "irrArray.h"
-#include "irrMath.h"
-#include "irrString.h"
-#include "path.h"
+#include "irrlicht/irrTypes.h"
+#include "irrlicht/irrAllocator.h"
+#include "irrlicht/irrArray.h"
+#include "irrlicht/irrMath.h"
+#include "irrlicht/irrString.h"
+#include "irrlicht/path.h"
 
 //! UTF-16 surrogate start values.
 static const irr::u16 UTF16_HI_SURROGATE = 0xD800;


### PR DESCRIPTION
Proposal
---
I was wondering if this project would be willing to look into the [Zig build system](https://ziglang.org/learn/overview/#zig-build-system).

The idea is that, theoretically, a person can install Zig and the relevant dependencies and build this project for [any of the target supported by Zig](https://ziglang.org/download/0.9.0/release-notes.html#Support-Table).

It also enables stuff such as UBSAN by default, which seems to have spotted some undefined behaviors for this project already.

TODO:
---

- [ ] Get the build to work on all relevant platforms. (Currently only supports `x86_64-linux`)
- [ ] Resolve what to do with `irrlicht` headers. 
I renamed `irrlicht.h` -> `irrlicht/irrlicht.h` for example. Curious why it currently is that way.
- [ ] Get the build working on Debian-based distros that seem to expect `lua-c++` instead of `lua`.
- [ ] Figure out how to handle the files described in https://github.com/Fluorohydride/ygopro/wiki#running.