### PR TITLE
fix show pendulum scale

### DIFF
--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -1604,7 +1604,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 									myswprintf(formatBuffer, L"\n(%ls)", dataManager.GetName(mcard->alias));
 									str.append(formatBuffer);
 								}
-								if(mcard->location == LOCATION_SZONE && mcard->lscale) {
+								if(mcard->location == LOCATION_SZONE && (mcard->type & TYPE_PENDULUM)) {
 									myswprintf(formatBuffer, L"\n%d/%d", mcard->lscale, mcard->rscale);
 									str.append(formatBuffer);
 								}


### PR DESCRIPTION
fix: if pendulum monster has spell&trap zone(not activate in pendulum zone), pendulum scale is shown.
(this problem many will happen ヴァリアンツ.)