### PR TITLE
remove _ITERATOR_DEBUG_LEVEL=0 in debug mode

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -203,7 +203,6 @@ workspace "YGOPro"
         end
 
     filter { "configurations:Debug", "action:vs*" }
-        defines { "_ITERATOR_DEBUG_LEVEL=0" }
         disablewarnings { "4819", "4828", "6031", "6054", "6262" }
 
     filter "action:vs*"


### PR DESCRIPTION
It was added in https://github.com/Fluorohydride/ygopro/commit/b48e4f5f08c5826819a3c48ef9117e39e2a12110#diff-62cf2df6793ada1c92492fe0da650b4d905c3d5ab1ce1e9f9cba8f1dbc5194a5R44 and once removed in https://github.com/Fluorohydride/ygopro/commit/7680c3c33b00cbdf60097d41432d5fae8474bd37

https://docs.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170

Removing the define will set the value of this flag to 2, enable the [checked iterators](https://docs.microsoft.com/en-us/cpp/standard-library/checked-iterators?view=msvc-170). In my test it won't affect the running and performance of the debug mode of ygopro.