### PR TITLE
Support multple lan clients from the same IP

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -4031,9 +4031,9 @@ void DuelClient::BroadcastReply(evutil_socket_t fd, short events, void * arg) {
 		socklen_t sz = sizeof(sockaddr_in);
 		char buf[256];
 		/*int ret = */recvfrom(fd, buf, 256, 0, (sockaddr*)&bc_addr, &sz);
-		if(is_closing || pHP->identifier == NETWORK_SERVER_ID)
-			return;
 		HostPacket* pHP = (HostPacket*)buf;
+		if(is_closing || pHP->identifier != NETWORK_SERVER_ID)
+			return;
 		if(pHP->version != PRO_VERSION)
 			return;
 		unsigned int ipaddr = bc_addr.sin_addr.s_addr;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -34,7 +34,7 @@ mt19937 DuelClient::rnd;
 bool DuelClient::is_refreshing = false;
 int DuelClient::match_kill = 0;
 std::vector<HostPacket> DuelClient::hosts;
-std::set<unsigned int> DuelClient::remotes;
+std::set<std::pair<unsigned int, unsigned short>> DuelClient::remotes;
 event* DuelClient::resp_event = 0;
 
 bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_game) {
@@ -4031,11 +4031,16 @@ void DuelClient::BroadcastReply(evutil_socket_t fd, short events, void * arg) {
 		socklen_t sz = sizeof(sockaddr_in);
 		char buf[256];
 		/*int ret = */recvfrom(fd, buf, 256, 0, (sockaddr*)&bc_addr, &sz);
-		unsigned int ipaddr = bc_addr.sin_addr.s_addr;
+		if(is_closing || pHP->identifier == NETWORK_SERVER_ID)
+			return;
 		HostPacket* pHP = (HostPacket*)buf;
-		if(!is_closing && pHP->identifier == NETWORK_SERVER_ID && pHP->version == PRO_VERSION && remotes.find(ipaddr) == remotes.end() ) {
+		if(pHP->version != PRO_VERSION)
+			return;
+		unsigned int ipaddr = bc_addr.sin_addr.s_addr;
+		const auto remote = std::make_pair(ipaddr, pHP->port);
+		if(remotes.find(remote) == remotes.end()) {
 			mainGame->gMutex.lock();
-			remotes.insert(ipaddr);
+			remotes.insert(remote);
 			pHP->ipaddr = ipaddr;
 			hosts.push_back(*pHP);
 			std::wstring hoststr;

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -4,6 +4,7 @@
 #include "config.h"
 #include <vector>
 #include <set>
+#include <utility>
 #include <event2/event.h>
 #include <event2/listener.h>
 #include <event2/bufferevent.h>
@@ -76,7 +77,7 @@ protected:
 	static bool is_refreshing;
 	static int match_kill;
 	static event* resp_event;
-	static std::set<unsigned int> remotes;
+	static std::set<std::pair<unsigned int, unsigned short>> remotes;
 public:
 	static std::vector<HostPacket> hosts;
 	static void BeginRefreshHost();

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -42,6 +42,7 @@ bool NetServer::StartBroadcast() {
 	SOCKET udp = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	BOOL opt = TRUE;
 	setsockopt(udp, SOL_SOCKET, SO_BROADCAST, (const char*)&opt, sizeof(BOOL));
+	setsockopt(udp, SOL_SOCKET, SO_REUSEADDR, (const char*)&opt, sizeof(BOOL));
 	sockaddr_in addr;
 	memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;


### PR DESCRIPTION
Currently if 2 clients host a lan room on a single machine, only one of the 2 rooms will be able to answer to broadcast messages, use ``SO_REUSEADDR`` so that multiple sockets can be bound to the same port (7920 in this case).
Also update the duelclient part to no longer filter the existing answer based off the ip but also on the port.