### PR TITLE
fix Game::DrawGUI()

### DIFF
--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -685,10 +685,10 @@ void Game::DrawStatus(ClientCard* pcard, int x1, int y1, int x2, int y2) {
 	}
 }
 void Game::DrawGUI() {
-	if(imageLoading.size()) {
-		for(auto mit = imageLoading.begin(); mit != imageLoading.end(); ++mit)
-			mit->first->setImage(imageManager.GetTexture(mit->second));
-		imageLoading.clear();
+	while (imageLoading.size()) {
+		auto mit = imageLoading.cbegin();
+		mit->first->setImage(imageManager.GetTexture(mit->second));
+		imageLoading.erase(imageLoading.begin());
 	}
 	for(auto fit = fadingList.begin(); fit != fadingList.end();) {
 		auto fthis = fit++;


### PR DESCRIPTION
@mercury233 

# Problem
![bug](https://user-images.githubusercontent.com/2851577/191664012-99fde47b-75df-4dfa-ad32-a9e11db4f8a8.png)

Replay:
[bug_texture.zip](https://github.com/Fluorohydride/ygopro/files/9622419/bug_texture.zip)

Fusion Summon ティアラメンツ・キトカロス
Link Summon I：Pマスカレーナ
Activated the 2nd effect of ティアラメンツ・キトカロス (target: ティアラメンツ・キトカロス)
Special Summon ティアラメンツ・メイルゥ 
Selecting position (The bug occurs.)

# Reason
The image on the defense position button is ティアラメンツ・キトカロス.
It is probably because some buttons in `imageLoading` are unprocessed.

# Solution
Remove all buttons in `imageLoading`.

