### PR TITLE
Feature: Add a checkbox to control whether to change BGM by LP

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -446,7 +446,10 @@ bool Game::Initialize() {
 	posY += 30;
 	chkMusicMode = env->addCheckBox(false, rect<s32>(posX, posY, posX + 260, posY + 25), tabSystem, -1, dataManager.GetSysString(1281));
 	chkMusicMode->setChecked(gameConf.music_mode != 0);
-	elmTabSystemLast = chkMusicMode;
+	posY += 30;
+	chkMusicLpMode = env->addCheckBox(false, rect<s32>(posX, posY, posX + 260, posY + 25), tabSystem, -1, dataManager.GetSysString(2000));
+	chkMusicLpMode->setChecked(gameConf.music_lp_mode);
+	elmTabSystemLast = chkMusicLpMode;
 	//
 	wHand = env->addWindow(rect<s32>(500, 450, 825, 605), false, L"");
 	wHand->getCloseButton()->setVisible(false);
@@ -920,6 +923,8 @@ bool Game::Initialize() {
 		scrMusicVolume->setVisible(false);
 		chkMusicMode->setEnabled(false);
 		chkMusicMode->setVisible(false);
+		chkMusicLpMode->setEnabled(false);
+		chkMusicLpMode->setVisible(false);
 	}
 	env->getSkin()->setFont(guiFont);
 	env->setFocus(wMainMenu);
@@ -1326,6 +1331,7 @@ void Game::LoadConfig() {
 	gameConf.enable_music = true;
 	gameConf.music_volume = 0.5;
 	gameConf.music_mode = 1;
+	gameConf.music_lp_mode = 0;
 	gameConf.window_maximized = false;
 	gameConf.window_width = 1024;
 	gameConf.window_height = 640;
@@ -1431,6 +1437,8 @@ void Game::LoadConfig() {
 			gameConf.music_volume = atof(valbuf) / 100;
 		} else if(!strcmp(strbuf, "music_mode")) {
 			gameConf.music_mode = atoi(valbuf);
+		} else if (!strcmp(strbuf, "music_lp_mode")) {
+			gameConf.music_lp_mode = atoi(valbuf);
 #endif
 		} else {
 			// options allowing multiple words
@@ -1527,6 +1535,7 @@ void Game::SaveConfig() {
 	if(vol < 0) vol = 0; else if(vol > 100) vol = 100;
 	fprintf(fp, "music_volume = %d\n", vol);
 	fprintf(fp, "music_mode = %d\n", (chkMusicMode->isChecked() ? 1 : 0));
+	fprintf(fp, "music_lp_mode = %d\n", (chkMusicLpMode->isChecked() ? 1 : 0));
 #endif
 	fclose(fp);
 }

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -58,6 +58,7 @@ struct Config {
 	double sound_volume;
 	double music_volume;
 	int music_mode;
+	int music_lp_mode;
 	bool window_maximized;
 	int window_width;
 	int window_height;
@@ -310,6 +311,7 @@ public:
 	irr::gui::IGUIScrollBar* scrSoundVolume;
 	irr::gui::IGUIScrollBar* scrMusicVolume;
 	irr::gui::IGUICheckBox* chkMusicMode;
+	irr::gui::IGUICheckBox* chkMusicLpMode;
 	irr::gui::IGUIButton* btnWinResizeS;
 	irr::gui::IGUIButton* btnWinResizeM;
 	irr::gui::IGUIButton* btnWinResizeL;

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -36,6 +36,10 @@ void SoundManager::RefreshBGMList() {
 	RefershBGMDir(L"win", BGM_WIN);
 	RefershBGMDir(L"lose", BGM_LOSE);
 }
+inline static bool IsDuelScene(int scene)
+{
+	return scene == BGM_DUEL || scene == BGM_ADVANTAGE || scene == BGM_DISADVANTAGE;
+}
 void SoundManager::RefershBGMDir(std::wstring path, int scene) {
 	std::wstring search = L"./sound/BGM/" + path;
 	FileSystem::TraversalDir(search.c_str(), [this, &path, scene](const wchar_t* name, bool isdir) {
@@ -43,6 +47,9 @@ void SoundManager::RefershBGMDir(std::wstring path, int scene) {
 			std::wstring filename = path + L"/" + name;
 			BGMList[BGM_ALL].push_back(filename);
 			BGMList[scene].push_back(filename);
+			if (IsDuelScene(scene)) {
+				BGMList[BGM_DUEL_ALL].push_back(filename);
+			}
 		}
 	});
 }
@@ -217,6 +224,8 @@ void SoundManager::PlayBGM(int scene) {
 		return;
 	if(!mainGame->chkMusicMode->isChecked())
 		scene = BGM_ALL;
+	if (IsDuelScene(scene) && !mainGame->chkMusicLpMode->isChecked())
+		scene = BGM_DUEL_ALL;
 	char BGMName[1024];
 	if(scene != bgm_scene || (soundBGM && soundBGM->isFinished())) {
 		int count = BGMList[scene].size();

--- a/gframe/sound_manager.h
+++ b/gframe/sound_manager.h
@@ -11,7 +11,7 @@ namespace ygo {
 
 class SoundManager {
 private:
-	std::vector<std::wstring> BGMList[8];
+	std::vector<std::wstring> BGMList[9];
 	int bgm_scene;
 	mt19937 rnd;
 #ifdef YGOPRO_USE_IRRKLANG
@@ -76,6 +76,7 @@ extern SoundManager soundManager;
 #define BGM_DISADVANTAGE			5
 #define BGM_WIN						6
 #define BGM_LOSE					7
+#define BGM_DUEL_ALL				8
 
 }
 

--- a/strings.conf
+++ b/strings.conf
@@ -526,6 +526,7 @@
 !system 1622 [%ls]错过时点
 !system 1623 投掷硬币结果：
 !system 1624 投掷骰子结果：
+!system 2000 按LP切换音乐
 #tips
 !system 1700 可以用鼠标右键%ls
 #victory reason

--- a/system.conf
+++ b/system.conf
@@ -52,3 +52,4 @@ enable_music = 1
 sound_volume = 50
 music_volume = 50
 music_mode = 1
+music_lp_mode = 1


### PR DESCRIPTION
Add a checkbox to control whether to change BGM by LP.

In duel, changing BGM by LP is cool feature. But sometimes I want play the same BGM regardless of the LP.

I am not sure which number should be used for "按LP切换音乐" in strings.conf, so I use 2000 temporarily...Maybe you could choose a more reasonable number.

And I'm not sure whether we should play all musics under "duel", "adventage", and "disadventage" folder for this checkbox. Currenlty, I play all songs under those 3 folders.

就是加一个"按LP切换音乐"的选项啦，因为很多时候打一拳就切歌，或者对面是血量少但是场子大的局面，和BGM就不太搭，所以我加了个这个选项……
不太确定字符串的编号是多少，就先用2000代替了。
还有就是不确实是否要播放"duel", "adventage", "disadventage" 下的所有音乐。目前我是设计成播放这三个文件夹下的所有音乐的……

![3](https://user-images.githubusercontent.com/51704722/233776041-a9958844-5f40-4ee4-ab41-7345827f6af8.png)
