### PR TITLE
remove usage of std::unary_function in irrUString.h

### DIFF
--- a/gframe/irrUString.h
+++ b/gframe/irrUString.h
@@ -3052,7 +3052,7 @@ namespace unicode {
 
 //! Hashing algorithm for hashing a ustring.  Used for things like unordered_maps.
 //! Algorithm taken from std::hash<std::string>.
-class hash : public std::unary_function<core::ustring, size_t> {
+class hash {
 public:
 	size_t operator()(const core::ustring& s) const {
 		size_t ret = 2166136261U;


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/utility/functional/unary_function
https://stackoverflow.com/questions/63577103/what-is-an-equivalent-replacement-for-stdunary-function-in-c17

It is deprecated in C++11 and removed in C++17

With this code, YGOPro can't build in VS2022 17.7.0. The error is C2039 `'unary_function' : is not a member of 'std'`

Even through I doubt it is a bug because I had `/std:c++14` on, this code seems can be removed.
