### PR TITLE
Fix: xyz material drawing

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -848,6 +848,9 @@ void ClientField::GetCardLocation(ClientCard* pcard, irr::core::vector3df* t, ir
 	int sequence = pcard->sequence;
 	int location = pcard->location;
 	int rule = (mainGame->dInfo.duel_rule >= 4) ? 1 : 0;
+	const float overlay_buttom = 0.0f;
+	const float material_height = 0.003f;
+	const float mzone_buttom = 0.020f;
 	switch (location) {
 	case LOCATION_DECK: {
 		t->X = (matManager.vFieldDeck[controler][0].Pos.X + matManager.vFieldDeck[controler][1].Pos.X) / 2;
@@ -927,7 +930,7 @@ void ClientField::GetCardLocation(ClientCard* pcard, irr::core::vector3df* t, ir
 	case LOCATION_MZONE: {
 		t->X = (matManager.vFieldMzone[controler][sequence][0].Pos.X + matManager.vFieldMzone[controler][sequence][1].Pos.X) / 2;
 		t->Y = (matManager.vFieldMzone[controler][sequence][0].Pos.Y + matManager.vFieldMzone[controler][sequence][2].Pos.Y) / 2;
-		t->Z = 0.01f;
+		t->Z = mzone_buttom;
 		if (controler == 0) {
 			if (pcard->position & POS_DEFENSE) {
 				r->X = 0.0f;
@@ -1040,21 +1043,22 @@ void ClientField::GetCardLocation(ClientCard* pcard, irr::core::vector3df* t, ir
 		break;
 	}
 	case LOCATION_OVERLAY: {
-		if (pcard->overlayTarget->location != 0x4) {
+		if (pcard->overlayTarget->location != LOCATION_MZONE) {
 			return;
 		}
 		int oseq = pcard->overlayTarget->sequence;
+		int mseq = (sequence < MAX_LAYER_COUNT) ? sequence : (MAX_LAYER_COUNT - 1);
 		if (pcard->overlayTarget->controler == 0) {
-			t->X = (matManager.vFieldMzone[0][oseq][0].Pos.X + matManager.vFieldMzone[0][oseq][1].Pos.X) / 2 - 0.12f + 0.06f * sequence;
+			t->X = (matManager.vFieldMzone[0][oseq][0].Pos.X + matManager.vFieldMzone[0][oseq][1].Pos.X) / 2 - 0.12f + 0.06f * mseq;
 			t->Y = (matManager.vFieldMzone[0][oseq][0].Pos.Y + matManager.vFieldMzone[0][oseq][2].Pos.Y) / 2 + 0.05f;
-			t->Z = 0.005f + pcard->sequence * 0.0001f;
+			t->Z = overlay_buttom + mseq * material_height;
 			r->X = 0.0f;
 			r->Y = 0.0f;
 			r->Z = 0.0f;
 		} else {
-			t->X = (matManager.vFieldMzone[1][oseq][0].Pos.X + matManager.vFieldMzone[1][oseq][1].Pos.X) / 2 + 0.12f - 0.06f * sequence;
+			t->X = (matManager.vFieldMzone[1][oseq][0].Pos.X + matManager.vFieldMzone[1][oseq][1].Pos.X) / 2 + 0.12f - 0.06f * mseq;
 			t->Y = (matManager.vFieldMzone[1][oseq][0].Pos.Y + matManager.vFieldMzone[1][oseq][2].Pos.Y) / 2 - 0.05f;
-			t->Z = 0.005f + pcard->sequence * 0.0001f;
+			t->Z = overlay_buttom + mseq * material_height;
 			r->X = 0.0f;
 			r->Y = 0.0f;
 			r->Z = 3.1415926f;

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -318,8 +318,21 @@ void Game::DrawCards() {
 		for(auto it = dField.extra[p].begin(); it != dField.extra[p].end(); ++it)
 			DrawCard(*it);
 	}
-	for(auto cit = dField.overlay_cards.begin(); cit != dField.overlay_cards.end(); ++cit)
-		DrawCard(*cit);
+	for (auto cit = dField.overlay_cards.begin(); cit != dField.overlay_cards.end(); ++cit) {
+		auto pcard = (*cit);
+		auto olcard = pcard->overlayTarget;
+		if (pcard->aniFrame) {
+			DrawCard(pcard);
+		}
+		else if (olcard && olcard->location == LOCATION_MZONE) {
+			if (pcard->sequence < MAX_LAYER_COUNT) {
+				DrawCard(pcard);
+			}
+		}
+		else {
+			DrawCard(pcard);
+		}
+	}
 }
 void Game::DrawCard(ClientCard* pcard) {
 	if(pcard->aniFrame) {

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2650,7 +2650,7 @@ int DuelClient::ClientAnalyze(char * msg, unsigned int len) {
 					pcard->overlayTarget = olcard;
 					pcard->location = LOCATION_OVERLAY;
 					pcard->sequence = olcard->overlayed.size() - 1;
-					if (olcard->location == 0x4) {
+					if (olcard->location == LOCATION_MZONE) {
 						mainGame->gMutex.lock();
 						mainGame->dField.MoveCard(pcard, 10);
 						if (pl == 0x2)

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -807,7 +807,8 @@ extern Game* mainGame;
 #define AVAIL_SC					0x8
 #define AVAIL_OCGTCG				(AVAIL_OCG|AVAIL_TCG)
 
-#define DEFAULT_DUEL_RULE			5
+#define DEFAULT_DUEL_RULE	5
 
 #define CARD_ARTWORK_VERSIONS_OFFSET	10
+#define MAX_LAYER_COUNT	6
 #endif // GAME_H


### PR DESCRIPTION
@mercury233 
# Problem
![50_material](https://github.com/Fluorohydride/ygopro/assets/2851577/b9c6da36-7d9c-4940-8d18-0a29ca404f93)
The test replay is generated by modifying the 1st effect of クロノダイバー・リダン/Time Thief Redoer to 50 cards.

The xyz material drawing has multiple problems.

## Z-coordinate and Xyz material height
Let 1 unit = 0.001f
The height of a normal card: 10 unit
The height of a material: 0.1 unit (1% of a normal card)

The texture is corrupted because the distance of each texture is way too short.

## X-coordinate
The X-coordinate is outside the zone of the Xyz monster.

# Solution
Add MAX_LAYER_COUNT
```cpp
#define MAX_LAYER_COUNT	6
```
1. The moving cards are always displayed, so the animation is unchanged.
2. If the Xyz materials are ready, the number of displayed Xyz materials is capped at `MAX_LAYER_COUNT`.

## Z-coordinate and Xyz material height
Let 1 unit = 0.001f
The height of a normal card: 10 unit
The bottom of LOCATION_MZONE: 10 unit -> 20 unit (The height of 2 normal cards)
The bottom of LOCATION_OVERLAY: 5 unit -> 0 unit

Xyz material, Sequence 0 ~ Sequence 5:
Height: 3 unit (30% of a normal card)
Max height: 0+3*5=15 unit

Xyz material, Sequence 6 ~ ... :
Height: 0 unit, invisible


# Test
![圖片](https://github.com/Fluorohydride/ygopro/assets/2851577/4e80d39b-4665-44f7-8b72-e118b4fc2a9a)

[xyz_material.zip](https://github.com/Fluorohydride/ygopro/files/13437990/xyz_material.zip)
c55285840.lua
Modified Time Thief Redoer.



