### PR TITLE
drop device on exit

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1067,7 +1067,7 @@ void Game::MainLoop() {
 		SingleMode::StopPlay(true);
 	std::this_thread::sleep_for(std::chrono::milliseconds(500));
 	SaveConfig();
-//	device->drop();
+	device->drop();
 }
 void Game::BuildProjectionMatrix(irr::core::matrix4& mProjection, f32 left, f32 right, f32 bottom, f32 top, f32 znear, f32 zfar) {
 	for(int i = 0; i < 16; ++i)


### PR DESCRIPTION
@mercury233 
https://irrlicht.sourceforge.io/docu/classirr_1_1_i_reference_counted.html#afb169a857e0d2cdb96b8821cb9bff17a
> When you create an object in the Irrlicht engine, calling a method which starts with 'create', an object is created, and you get a pointer to the new object. If you no longer need the object, you have to call [drop()](https://irrlicht.sourceforge.io/docu/classirr_1_1_i_reference_counted.html#afb169a857e0d2cdb96b8821cb9bff17a). This will destroy the object, if [grab()](https://irrlicht.sourceforge.io/docu/classirr_1_1_i_reference_counted.html#a2b7a035532e5f409ca9482dab79185f4) was not called in another part of you program, because this part still needs the object. Note, that you only need to call [drop()](https://irrlicht.sourceforge.io/docu/classirr_1_1_i_reference_counted.html#afb169a857e0d2cdb96b8821cb9bff17a) to the object, if you created it, and the method had a 'create' in it.

https://github.com/Fluorohydride/ygopro/blob/4c0ca0f1b9b8c9b0389ca43f67bc8070801509fd/gframe/game.cpp#L60

It is created by ygopro and should be dropped on exit.
The exe built by this commit still works.
