### PR TITLE
 check return value of sscanf() 

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -87,7 +87,7 @@ using namespace io;
 using namespace gui;
 
 extern const unsigned short PRO_VERSION;
-extern int enable_log;
+extern unsigned int enable_log;
 extern bool exit_on_return;
 extern bool open_file;
 extern wchar_t open_file_name[256];

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -139,24 +139,30 @@ bool DataManager::LoadStrings(IReadFile* reader) {
 void DataManager::ReadStringConfLine(const char* linebuf) {
 	if(linebuf[0] != '!')
 		return;
-	char strbuf[256];
-	int value;
-	wchar_t strBuffer[4096];
-	sscanf(linebuf, "!%s", strbuf);
+	char strbuf[256]{};
+	int value{};
+	wchar_t strBuffer[4096]{};
+	if (sscanf(linebuf, "!%63s", strbuf) != 1)
+		return;
 	if(!strcmp(strbuf, "system")) {
-		sscanf(&linebuf[7], "%d %240[^\n]", &value, strbuf);
+		if (sscanf(&linebuf[7], "%d %240[^\n]", &value, strbuf) != 2)
+			return;
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_sysStrings[value] = strBuffer;
 	} else if(!strcmp(strbuf, "victory")) {
-		sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf);
+		if (sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2)
+			return;
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_victoryStrings[value] = strBuffer;
 	} else if(!strcmp(strbuf, "counter")) {
-		sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf);
+		if (sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2)
+			return;
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_counterStrings[value] = strBuffer;
 	} else if(!strcmp(strbuf, "setname")) {
-		sscanf(&linebuf[8], "%x %240[^\t\n]", &value, strbuf);//using tab for comment
+		//using tab for comment
+		if (sscanf(&linebuf[8], "%x %240[^\t\n]", &value, strbuf) != 2)
+			return;
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_setnameStrings[value] = strBuffer;
 	}

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -11,15 +11,16 @@ DeckManager deckManager;
 void DeckManager::LoadLFListSingle(const char* path) {
 	LFList* cur = nullptr;
 	FILE* fp = fopen(path, "r");
-	char linebuf[256];
-	wchar_t strBuffer[256];
+	char linebuf[256]{};
+	wchar_t strBuffer[256]{};
 	if(fp) {
 		while(fgets(linebuf, 256, fp)) {
 			if(linebuf[0] == '#')
 				continue;
 			if(linebuf[0] == '!') {
 				int sa = BufferIO::DecodeUTF8(&linebuf[1], strBuffer);
-				while(strBuffer[sa - 1] == L'\r' || strBuffer[sa - 1] == L'\n' ) sa--;
+				while(strBuffer[sa - 1] == L'\r' || strBuffer[sa - 1] == L'\n' )
+					sa--;
 				strBuffer[sa] = 0;
 				LFList newlist;
 				_lfList.push_back(newlist);
@@ -28,20 +29,18 @@ void DeckManager::LoadLFListSingle(const char* path) {
 				cur->hash = 0x7dfcee6a;
 				continue;
 			}
-			int p = 0;
-			while(linebuf[p] != ' ' && linebuf[p] != '\t' && linebuf[p] != 0) p++;
-			if(linebuf[p] == 0)
+			if(linebuf[0] == 0)
 				continue;
-			linebuf[p++] = 0;
-			int sa = p;
-			int code = atoi(linebuf);
-			if(code == 0)
+			int code = 0;
+			int count = -1;
+			if (sscanf(linebuf, "%d %d", &code, &count) != 2)
 				continue;
-			while(linebuf[p] == ' ' || linebuf[p] == '\t') p++;
-			while(linebuf[p] != ' ' && linebuf[p] != '\t' && linebuf[p] != 0) p++;
-			linebuf[p] = 0;
-			int count = atoi(&linebuf[sa]);
-			if(!cur) continue;
+			if (code <= 0 || code > 99999999)
+				continue;
+			if (count < 0 || count > 2)
+				continue;
+			if (!cur)
+				continue;
 			cur->content[code] = count;
 			cur->hash = cur->hash ^ ((code << 18) | (code >> 14)) ^ ((code << (27 + count)) | (code >> (5 - count)));
 		}

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1259,23 +1259,29 @@ void Game::RefreshBot() {
 		return;
 	botInfo.clear();
 	FILE* fp = fopen("bot.conf", "r");
-	char linebuf[256];
-	char strbuf[256];
+	char linebuf[256]{};
+	char strbuf[256]{};
 	if(fp) {
 		while(fgets(linebuf, 256, fp)) {
 			if(linebuf[0] == '#')
 				continue;
 			if(linebuf[0] == '!') {
 				BotInfo newinfo;
-				sscanf(linebuf, "!%240[^\n]", strbuf);
+				if (sscanf(linebuf, "!%240[^\n]", strbuf) != 1)
+					continue;
 				BufferIO::DecodeUTF8(strbuf, newinfo.name);
-				fgets(linebuf, 256, fp);
-				sscanf(linebuf, "%240[^\n]", strbuf);
+				if (!fgets(linebuf, 256, fp))
+					break;
+				if (sscanf(linebuf, "%240[^\n]", strbuf) != 1)
+					continue;
 				BufferIO::DecodeUTF8(strbuf, newinfo.command);
-				fgets(linebuf, 256, fp);
-				sscanf(linebuf, "%240[^\n]", strbuf);
+				if (!fgets(linebuf, 256, fp))
+					break;
+				if (sscanf(linebuf, "%240[^\n]", strbuf) != 1)
+					continue;
 				BufferIO::DecodeUTF8(strbuf, newinfo.desc);
-				fgets(linebuf, 256, fp);
+				if (!fgets(linebuf, 256, fp))
+					break;
 				newinfo.support_master_rule_3 = !!strstr(linebuf, "SUPPORT_MASTER_RULE_3");
 				newinfo.support_new_master_rule = !!strstr(linebuf, "SUPPORT_NEW_MASTER_RULE");
 				newinfo.support_master_rule_2020 = !!strstr(linebuf, "SUPPORT_MASTER_RULE_2020");
@@ -1308,12 +1314,13 @@ void Game::LoadConfig() {
 	FILE* fp = fopen("system.conf", "r");
 	if(!fp)
 		return;
-	char linebuf[256];
-	char strbuf[32];
-	char valbuf[256];
-	wchar_t wstr[256];
+	char linebuf[256]{};
+	char strbuf[64]{};
+	char valbuf[256]{};
+	wchar_t wstr[256]{};
 	while(fgets(linebuf, 256, fp)) {
-		sscanf(linebuf, "%s = %s", strbuf, valbuf);
+		if (sscanf(linebuf, "%63s = %255s", strbuf, valbuf) != 2)
+			continue;
 		if(!strcmp(strbuf, "antialias")) {
 			gameConf.antialias = atoi(valbuf);
 		} else if(!strcmp(strbuf, "use_d3d")) {
@@ -1323,10 +1330,11 @@ void Game::LoadConfig() {
 		} else if(!strcmp(strbuf, "errorlog")) {
 			enable_log = atoi(valbuf);
 		} else if(!strcmp(strbuf, "textfont")) {
-			BufferIO::DecodeUTF8(valbuf, wstr);
 			int textfontsize = gameConf.textfontsize;
-			sscanf(linebuf, "%s = %s %d", strbuf, valbuf, &textfontsize);
+			if (sscanf(linebuf, "%s = %s %d", strbuf, valbuf, &textfontsize) != 3)
+				continue;
 			gameConf.textfontsize = textfontsize;
+			BufferIO::DecodeUTF8(valbuf, wstr);
 			BufferIO::CopyWStr(wstr, gameConf.textfont, 256);
 		} else if(!strcmp(strbuf, "numfont")) {
 			BufferIO::DecodeUTF8(valbuf, wstr);
@@ -1418,7 +1426,8 @@ void Game::LoadConfig() {
 #endif
 		} else {
 			// options allowing multiple words
-			sscanf(linebuf, "%s = %240[^\n]", strbuf, valbuf);
+			if (sscanf(linebuf, "%63s = %240[^\n]", strbuf, valbuf) != 2)
+				continue;
 			if (!strcmp(strbuf, "nickname")) {
 				BufferIO::DecodeUTF8(valbuf, wstr);
 				BufferIO::CopyWStr(wstr, gameConf.nickname, 20);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1328,7 +1328,8 @@ void Game::LoadConfig() {
 		} else if(!strcmp(strbuf, "use_image_scale")) {
 			gameConf.use_image_scale = strtol(valbuf, nullptr, 10) > 0;
 		} else if(!strcmp(strbuf, "errorlog")) {
-			enable_log = strtol(valbuf, nullptr, 10);
+			unsigned int val = strtol(valbuf, nullptr, 10);
+			enable_log = val & 0xff;
 		} else if(!strcmp(strbuf, "textfont")) {
 			int textfontsize = 0;
 			if (sscanf(linebuf, "%63s = %255s %d", strbuf, valbuf, &textfontsize) != 3)
@@ -1465,7 +1466,7 @@ void Game::SaveConfig() {
 	fprintf(fp, "use_d3d = %d\n", gameConf.use_d3d ? 1 : 0);
 	fprintf(fp, "use_image_scale = %d\n", gameConf.use_image_scale ? 1 : 0);
 	fprintf(fp, "antialias = %d\n", gameConf.antialias);
-	fprintf(fp, "errorlog = %d\n", enable_log);
+	fprintf(fp, "errorlog = %u\n", enable_log);
 	BufferIO::CopyWStr(ebNickName->getText(), gameConf.nickname, 20);
 	BufferIO::EncodeUTF8(gameConf.nickname, linebuf);
 	fprintf(fp, "nickname = %s\n", linebuf);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1322,16 +1322,16 @@ void Game::LoadConfig() {
 		if (sscanf(linebuf, "%63s = %255s", strbuf, valbuf) != 2)
 			continue;
 		if(!strcmp(strbuf, "antialias")) {
-			gameConf.antialias = atoi(valbuf);
+			gameConf.antialias = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "use_d3d")) {
-			gameConf.use_d3d = atoi(valbuf) > 0;
+			gameConf.use_d3d = strtol(valbuf, nullptr, 10) > 0;
 		} else if(!strcmp(strbuf, "use_image_scale")) {
-			gameConf.use_image_scale = atoi(valbuf) > 0;
+			gameConf.use_image_scale = strtol(valbuf, nullptr, 10) > 0;
 		} else if(!strcmp(strbuf, "errorlog")) {
-			enable_log = atoi(valbuf);
+			enable_log = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "textfont")) {
-			int textfontsize = gameConf.textfontsize;
-			if (sscanf(linebuf, "%s = %s %d", strbuf, valbuf, &textfontsize) != 3)
+			int textfontsize = 0;
+			if (sscanf(linebuf, "%63s = %255s %d", strbuf, valbuf, &textfontsize) != 3)
 				continue;
 			gameConf.textfontsize = textfontsize;
 			BufferIO::DecodeUTF8(valbuf, wstr);
@@ -1340,7 +1340,7 @@ void Game::LoadConfig() {
 			BufferIO::DecodeUTF8(valbuf, wstr);
 			BufferIO::CopyWStr(wstr, gameConf.numfont, 256);
 		} else if(!strcmp(strbuf, "serverport")) {
-			gameConf.serverport = atoi(valbuf);
+			gameConf.serverport = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "lasthost")) {
 			BufferIO::DecodeUTF8(valbuf, wstr);
 			BufferIO::CopyWStr(wstr, gameConf.lasthost, 100);
@@ -1351,78 +1351,88 @@ void Game::LoadConfig() {
 			BufferIO::DecodeUTF8(valbuf, wstr);
 			BufferIO::CopyWStr(wstr, gameConf.roompass, 20);
 		} else if(!strcmp(strbuf, "automonsterpos")) {
-			gameConf.chkMAutoPos = atoi(valbuf);
+			gameConf.chkMAutoPos = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "autospellpos")) {
-			gameConf.chkSTAutoPos = atoi(valbuf);
+			gameConf.chkSTAutoPos = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "randompos")) {
-			gameConf.chkRandomPos = atoi(valbuf);
+			gameConf.chkRandomPos = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "autochain")) {
-			gameConf.chkAutoChain = atoi(valbuf);
+			gameConf.chkAutoChain = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "waitchain")) {
-			gameConf.chkWaitChain = atoi(valbuf);
+			gameConf.chkWaitChain = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "showchain")) {
-			gameConf.chkDefaultShowChain = atoi(valbuf);
+			gameConf.chkDefaultShowChain = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "mute_opponent")) {
-			gameConf.chkIgnore1 = atoi(valbuf);
+			gameConf.chkIgnore1 = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "mute_spectators")) {
-			gameConf.chkIgnore2 = atoi(valbuf);
+			gameConf.chkIgnore2 = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "use_lflist")) {
-			gameConf.use_lflist = atoi(valbuf);
+			gameConf.use_lflist = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "default_lflist")) {
-			gameConf.default_lflist = atoi(valbuf);
+			gameConf.default_lflist = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "default_rule")) {
-			gameConf.default_rule = atoi(valbuf);
+			gameConf.default_rule = strtol(valbuf, nullptr, 10);
 			if(gameConf.default_rule <= 0)
 				gameConf.default_rule = DEFAULT_DUEL_RULE;
 		} else if(!strcmp(strbuf, "hide_setname")) {
-			gameConf.hide_setname = atoi(valbuf);
+			gameConf.hide_setname = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "hide_hint_button")) {
-			gameConf.hide_hint_button = atoi(valbuf);
+			gameConf.hide_hint_button = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "control_mode")) {
-			gameConf.control_mode = atoi(valbuf);
+			gameConf.control_mode = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "draw_field_spell")) {
-			gameConf.draw_field_spell = atoi(valbuf);
+			gameConf.draw_field_spell = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "separate_clear_button")) {
-			gameConf.separate_clear_button = atoi(valbuf);
+			gameConf.separate_clear_button = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "auto_search_limit")) {
-			gameConf.auto_search_limit = atoi(valbuf);
+			gameConf.auto_search_limit = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "search_multiple_keywords")) {
-			gameConf.search_multiple_keywords = atoi(valbuf);
+			gameConf.search_multiple_keywords = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "ignore_deck_changes")) {
-			gameConf.chkIgnoreDeckChanges = atoi(valbuf);
+			gameConf.chkIgnoreDeckChanges = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "default_ot")) {
-			gameConf.defaultOT = atoi(valbuf);
+			gameConf.defaultOT = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "enable_bot_mode")) {
-			gameConf.enable_bot_mode = atoi(valbuf);
+			gameConf.enable_bot_mode = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "quick_animation")) {
-			gameConf.quick_animation = atoi(valbuf);
+			gameConf.quick_animation = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "auto_save_replay")) {
-			gameConf.auto_save_replay = atoi(valbuf);
+			gameConf.auto_save_replay = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "draw_single_chain")) {
-			gameConf.draw_single_chain = atoi(valbuf);
+			gameConf.draw_single_chain = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "hide_player_name")) {
-			gameConf.hide_player_name = atoi(valbuf);
+			gameConf.hide_player_name = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "prefer_expansion_script")) {
-			gameConf.prefer_expansion_script = atoi(valbuf);
+			gameConf.prefer_expansion_script = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "window_maximized")) {
-			gameConf.window_maximized = atoi(valbuf) > 0;
+			gameConf.window_maximized = strtol(valbuf, nullptr, 10) > 0;
 		} else if(!strcmp(strbuf, "window_width")) {
-			gameConf.window_width = atoi(valbuf);
+			gameConf.window_width = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "window_height")) {
-			gameConf.window_height = atoi(valbuf);
+			gameConf.window_height = strtol(valbuf, nullptr, 10);
 		} else if(!strcmp(strbuf, "resize_popup_menu")) {
-			gameConf.resize_popup_menu = atoi(valbuf) > 0;
+			gameConf.resize_popup_menu = strtol(valbuf, nullptr, 10) > 0;
 #ifdef YGOPRO_USE_IRRKLANG
 		} else if(!strcmp(strbuf, "enable_sound")) {
-			gameConf.enable_sound = atoi(valbuf) > 0;
+			gameConf.enable_sound = strtol(valbuf, nullptr, 10) > 0;
 		} else if(!strcmp(strbuf, "sound_volume")) {
-			gameConf.sound_volume = atof(valbuf) / 100;
+			int vol = strtol(valbuf, nullptr, 10);
+			if (vol < 0)
+				vol = 0;
+			else if (vol > 100)
+				vol = 100;
+			gameConf.sound_volume = (double)vol / 100;
 		} else if(!strcmp(strbuf, "enable_music")) {
-			gameConf.enable_music = atoi(valbuf) > 0;
+			gameConf.enable_music = strtol(valbuf, nullptr, 10) > 0;
 		} else if(!strcmp(strbuf, "music_volume")) {
-			gameConf.music_volume = atof(valbuf) / 100;
+			int vol = strtol(valbuf, nullptr, 10);
+			if (vol < 0)
+				vol = 0;
+			else if (vol > 100)
+				vol = 100;
+			gameConf.music_volume = (double)vol / 100;
 		} else if(!strcmp(strbuf, "music_mode")) {
-			gameConf.music_mode = atoi(valbuf);
+			gameConf.music_mode = strtol(valbuf, nullptr, 10);
 #endif
 		} else {
 			// options allowing multiple words
@@ -1515,10 +1525,8 @@ void Game::SaveConfig() {
 	fprintf(fp, "enable_music = %d\n", (chkEnableMusic->isChecked() ? 1 : 0));
 	fprintf(fp, "#Volume of sound and music, between 0 and 100\n");
 	int vol = gameConf.sound_volume * 100;
-	if(vol < 0) vol = 0; else if(vol > 100) vol = 100;
 	fprintf(fp, "sound_volume = %d\n", vol);
 	vol = gameConf.music_volume * 100;
-	if(vol < 0) vol = 0; else if(vol > 100) vol = 100;
 	fprintf(fp, "music_volume = %d\n", vol);
 	fprintf(fp, "music_mode = %d\n", (chkMusicMode->isChecked() ? 1 : 0));
 #endif

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -7,7 +7,7 @@
 #import <CoreFoundation/CoreFoundation.h>
 #endif
 
-int enable_log = 0x3;
+unsigned int enable_log = 0x3;
 bool exit_on_return = false;
 bool open_file = false;
 wchar_t open_file_name[256] = L"";

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -7,7 +7,7 @@
 #import <CoreFoundation/CoreFoundation.h>
 #endif
 
-int enable_log = 0;
+int enable_log = 0x3;
 bool exit_on_return = false;
 bool open_file = false;
 wchar_t open_file_name[256] = L"";


### PR DESCRIPTION
![圖片](https://github.com/Fluorohydride/ygopro/assets/2851577/530fa2e1-2717-49bb-843b-1e8c9b023d41)
It will happen if the string 1200 in `system.conf` is changed into
```
!system 1200 

```
C99
7.20.1 Numeric conversion functions
> The functions atof, atoi, atol, and atoll need not affect the value of the integer expression errno on an error. 
> If the value of the result cannot be represented, the behavior is undefined.


- We should check if the entire row in `system.conf` and `bot.conf` matches the string format.
- The default value of `enable_log` is set to 0x3 according to `system.conf` in master branch.
- replace atoi  with strtol to avoid undefined behaviour

@mercury233
@purerosefallen 