### PR TITLE
add constant MAX_STRING_ID, MIN_CARD_ID

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -224,7 +224,7 @@ const wchar_t* DataManager::GetText(unsigned int code) {
 	return unknown_string;
 }
 const wchar_t* DataManager::GetDesc(unsigned int strCode) {
-	if(strCode < 10000u)
+	if (strCode < (MIN_CARD_ID << 4))
 		return GetSysString(strCode);
 	unsigned int code = (strCode >> 4) & 0x0fffffff;
 	unsigned int offset = strCode & 0xf;
@@ -236,7 +236,7 @@ const wchar_t* DataManager::GetDesc(unsigned int strCode) {
 	return unknown_string;
 }
 const wchar_t* DataManager::GetSysString(int code) {
-	if(code < 0 || code >= 2048)
+	if (code < 0 || code > MAX_STRING_ID)
 		return unknown_string;
 	auto csit = _sysStrings.find(code);
 	if(csit == _sysStrings.end())

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -8,6 +8,8 @@
 #include <unordered_map>
 
 namespace ygo {
+	constexpr int MAX_STRING_ID = 0x7ff;
+	constexpr unsigned int MIN_CARD_ID = (unsigned int)(MAX_STRING_ID + 1) >> 4;
 
 class DataManager {
 public:


### PR DESCRIPTION
- If x <= MAX_STRING_ID
x is a system string id

- otherwise
x is a card string id

The MAX_STRING_ID is 0x7ff (2047) now.
The MIN_CARD_ID should be 0x80 (128), and the minimal card string id is 0x800.

@mercury233 
@purerosefallen 