### PR TITLE
fix EncodeUTF8,  DecodeUTF8

### DIFF
--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -61,34 +61,31 @@ public:
 	static int EncodeUTF8(const wchar_t * wsrc, char * str) {
 		char* pstr = str;
 		while(*wsrc != 0) {
-			if(*wsrc < 0x80) {
-				*str = (char)*wsrc;
+			unsigned cur = *wsrc;
+			if(cur < 0x80) {
+				*str = (char)cur;
 				++str;
-			} else if(*wsrc < 0x800) {
-				str[0] = ((*wsrc >> 6) & 0x1f) | 0xc0;
-				str[1] = ((*wsrc) & 0x3f) | 0x80;
+			} else if(cur < 0x800) {
+				str[0] = ((cur >> 6) & 0x1f) | 0xc0;
+				str[1] = (cur & 0x3f) | 0x80;
 				str += 2;
-			} else if(*wsrc < 0x10000 && (*wsrc < 0xd800 || *wsrc > 0xdfff)) {
-				str[0] = ((*wsrc >> 12) & 0xf) | 0xe0;
-				str[1] = ((*wsrc >> 6) & 0x3f) | 0x80;
-				str[2] = ((*wsrc) & 0x3f) | 0x80;
+			} else if(cur < 0x10000 && (cur < 0xd800 || cur > 0xdfff)) {
+				str[0] = ((cur >> 12) & 0xf) | 0xe0;
+				str[1] = ((cur >> 6) & 0x3f) | 0x80;
+				str[2] = (cur & 0x3f) | 0x80;
 				str += 3;
 			} else {
 				if (sizeof(wchar_t) == 2) {
-					unsigned unicode = 0;
-					unicode |= (*wsrc++ & 0x3ff) << 10;
-					unicode |= *wsrc & 0x3ff;
-					unicode += 0x10000;
-					str[0] = ((unicode >> 18) & 0x7) | 0xf0;
-					str[1] = ((unicode >> 12) & 0x3f) | 0x80;
-					str[2] = ((unicode >> 6) & 0x3f) | 0x80;
-					str[3] = ((unicode) & 0x3f) | 0x80;
-				} else {
-					str[0] = ((*wsrc >> 18) & 0x7) | 0xf0;
-					str[1] = ((*wsrc >> 12) & 0x3f) | 0x80;
-					str[2] = ((*wsrc >> 6) & 0x3f) | 0x80;
-					str[3] = ((*wsrc) & 0x3f) | 0x80;
+					cur = 0;
+					cur |= ((unsigned)*wsrc & 0x3ff) << 10;
+					++wsrc;
+					cur |= (unsigned)*wsrc & 0x3ff;
+					cur += 0x10000;
 				}
+				str[0] = ((cur >> 18) & 0x7) | 0xf0;
+				str[1] = ((cur >> 12) & 0x3f) | 0x80;
+				str[2] = ((cur >> 6) & 0x3f) | 0x80;
+				str[3] = (cur & 0x3f) | 0x80;
 				str += 4;
 			}
 			wsrc++;

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -74,21 +74,21 @@ public:
 				str[2] = ((*wsrc) & 0x3f) | 0x80;
 				str += 3;
 			} else {
-#ifdef _WIN32
-				unsigned unicode = 0;
-				unicode |= (*wsrc++ & 0x3ff) << 10;
-				unicode |= *wsrc & 0x3ff;
-				unicode += 0x10000;
-				str[0] = ((unicode >> 18) & 0x7) | 0xf0;
-				str[1] = ((unicode >> 12) & 0x3f) | 0x80;
-				str[2] = ((unicode >> 6) & 0x3f) | 0x80;
-				str[3] = ((unicode) & 0x3f) | 0x80;
-#else
-				str[0] = ((*wsrc >> 18) & 0x7) | 0xf0;
-				str[1] = ((*wsrc >> 12) & 0x3f) | 0x80;
-				str[2] = ((*wsrc >> 6) & 0x3f) | 0x80;
-				str[3] = ((*wsrc) & 0x3f) | 0x80;
-#endif // _WIN32
+				if (sizeof(wchar_t) == 2) {
+					unsigned unicode = 0;
+					unicode |= (*wsrc++ & 0x3ff) << 10;
+					unicode |= *wsrc & 0x3ff;
+					unicode += 0x10000;
+					str[0] = ((unicode >> 18) & 0x7) | 0xf0;
+					str[1] = ((unicode >> 12) & 0x3f) | 0x80;
+					str[2] = ((unicode >> 6) & 0x3f) | 0x80;
+					str[3] = ((unicode) & 0x3f) | 0x80;
+				} else {
+					str[0] = ((*wsrc >> 18) & 0x7) | 0xf0;
+					str[1] = ((*wsrc >> 12) & 0x3f) | 0x80;
+					str[2] = ((*wsrc >> 6) & 0x3f) | 0x80;
+					str[3] = ((*wsrc) & 0x3f) | 0x80;
+				}
 				str += 4;
 			}
 			wsrc++;
@@ -111,14 +111,14 @@ public:
 				*wp = (((unsigned)p[0] & 0xf) << 12) | (((unsigned)p[1] & 0x3f) << 6) | ((unsigned)p[2] & 0x3f);
 				p += 3;
 			} else if((*p & 0xf8) == 0xf0) {
-#ifdef _WIN32
-				unsigned unicode = (((unsigned)p[0] & 0x7) << 18) | (((unsigned)p[1] & 0x3f) << 12) | (((unsigned)p[2] & 0x3f) << 6) | ((unsigned)p[3] & 0x3f);
-				unicode -= 0x10000;
-				*wp++ = (unicode >> 10) | 0xd800;
-				*wp = (unicode & 0x3ff) | 0xdc00;
-#else
-				*wp = (((unsigned)p[0] & 0x7) << 18) | (((unsigned)p[1] & 0x3f) << 12) | (((unsigned)p[2] & 0x3f) << 6) | ((unsigned)p[3] & 0x3f);
-#endif // _WIN32
+				if (sizeof(wchar_t) == 2) {
+					unsigned unicode = (((unsigned)p[0] & 0x7) << 18) | (((unsigned)p[1] & 0x3f) << 12) | (((unsigned)p[2] & 0x3f) << 6) | ((unsigned)p[3] & 0x3f);
+					unicode -= 0x10000;
+					*wp++ = (unicode >> 10) | 0xd800;
+					*wp = (unicode & 0x3ff) | 0xdc00;
+				} else {
+					*wp = (((unsigned)p[0] & 0x7) << 18) | (((unsigned)p[1] & 0x3f) << 12) | (((unsigned)p[2] & 0x3f) << 6) | ((unsigned)p[3] & 0x3f);
+				}
 				p += 4;
 			} else
 				p++;

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -98,16 +98,16 @@ public:
 		const char* p = src;
 		wchar_t* wp = wstr;
 		while(*p != 0) {
-			if((*p & 0x80) == 0) {
+			if(((unsigned)*p & 0x80) == 0) {
 				*wp = *p;
 				p++;
-			} else if((*p & 0xe0) == 0xc0) {
+			} else if(((unsigned)*p & 0xe0) == 0xc0) {
 				*wp = (((unsigned)p[0] & 0x1f) << 6) | ((unsigned)p[1] & 0x3f);
 				p += 2;
-			} else if((*p & 0xf0) == 0xe0) {
+			} else if(((unsigned)*p & 0xf0) == 0xe0) {
 				*wp = (((unsigned)p[0] & 0xf) << 12) | (((unsigned)p[1] & 0x3f) << 6) | ((unsigned)p[2] & 0x3f);
 				p += 3;
-			} else if((*p & 0xf8) == 0xf0) {
+			} else if(((unsigned)*p & 0xf8) == 0xf0) {
 				if (sizeof(wchar_t) == 2) {
 					unsigned unicode = (((unsigned)p[0] & 0x7) << 18) | (((unsigned)p[1] & 0x3f) << 12) | (((unsigned)p[2] & 0x3f) << 6) | ((unsigned)p[3] & 0x3f);
 					unicode -= 0x10000;

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -397,11 +397,11 @@ byte* DataManager::ScriptReaderEx(const char* script_name, int* slen) {
 	char first[256];
 	char second[256];
 	if(mainGame->gameConf.prefer_expansion_script) {
-		sprintf(first, "expansions/%s", script_name + 2);
-		sprintf(second, "%s", script_name + 2);
+		snprintf(first, sizeof first, "expansions/%s", script_name + 2);
+		snprintf(second, sizeof second, "%s", script_name + 2);
 	} else {
-		sprintf(first, "%s", script_name + 2);
-		sprintf(second, "expansions/%s", script_name + 2);
+		snprintf(first, sizeof first, "%s", script_name + 2);
+		snprintf(second, sizeof second, "expansions/%s", script_name + 2);
 	}
 	if(ScriptReader(first, slen))
 		return scriptBuffer;

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -394,8 +394,8 @@ uint32 DataManager::CardReader(uint32 code, card_data* pData) {
 }
 byte* DataManager::ScriptReaderEx(const char* script_name, int* slen) {
 	// default script name: ./script/c%d.lua
-	char first[256];
-	char second[256];
+	char first[256]{};
+	char second[256]{};
 	if(mainGame->gameConf.prefer_expansion_script) {
 		snprintf(first, sizeof first, "expansions/%s", script_name + 2);
 		snprintf(second, sizeof second, "%s", script_name + 2);
@@ -410,7 +410,7 @@ byte* DataManager::ScriptReaderEx(const char* script_name, int* slen) {
 }
 byte* DataManager::ScriptReader(const char* script_name, int* slen) {
 #ifdef _WIN32
-	wchar_t fname[256];
+	wchar_t fname[256]{};
 	BufferIO::DecodeUTF8(script_name, fname);
 	IReadFile* reader = FileSystem->createAndOpenFile(fname);
 #else

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1696,7 +1696,7 @@ void Game::AddDebugMsg(const char* msg) {
 	}
 	if (enable_log & 0x2) {
 		char msgbuf[1040];
-		sprintf(msgbuf, "[Script Error]: %s", msg);
+		snprintf(msgbuf, sizeof msgbuf, "[Script Error]: %s", msg);
 		ErrorLog(msgbuf);
 	}
 }

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -233,10 +233,10 @@ irr::video::ITexture* ImageManager::GetTexture(int code, bool fit) {
 	auto tit = tMap[fit ? 1 : 0].find(code);
 	if(tit == tMap[fit ? 1 : 0].end()) {
 		char file[256];
-		sprintf(file, "expansions/pics/%d.jpg", code);
+		snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
 		irr::video::ITexture* img = GetTextureFromFile(file, width, height);
 		if(img == NULL) {
-			sprintf(file, "pics/%d.jpg", code);
+			snprintf(file, sizeof file, "pics/%d.jpg", code);
 			img = GetTextureFromFile(file, width, height);
 		}
 		if(img == NULL && !mainGame->gameConf.use_image_scale) {
@@ -260,10 +260,10 @@ irr::video::ITexture* ImageManager::GetBigPicture(int code, float zoom) {
 	}
 	irr::video::ITexture* texture;
 	char file[256];
-	sprintf(file, "expansions/pics/%d.jpg", code);
+	snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
 	irr::video::IImage* srcimg = driver->createImageFromFile(file);
 	if(srcimg == NULL) {
-		sprintf(file, "pics/%d.jpg", code);
+		snprintf(file, sizeof file, "pics/%d.jpg", code);
 		srcimg = driver->createImageFromFile(file);
 	}
 	if(srcimg == NULL) {
@@ -289,18 +289,18 @@ int ImageManager::LoadThumbThread() {
 		imageManager.tThumbLoadingCodes.pop();
 		imageManager.tThumbLoadingMutex.unlock();
 		char file[256];
-		sprintf(file, "expansions/pics/thumbnail/%d.jpg", code);
+		snprintf(file, sizeof file, "expansions/pics/thumbnail/%d.jpg", code);
 		irr::video::IImage* img = imageManager.driver->createImageFromFile(file);
 		if(img == NULL) {
-			sprintf(file, "pics/thumbnail/%d.jpg", code);
+			snprintf(file, sizeof file, "pics/thumbnail/%d.jpg", code);
 			img = imageManager.driver->createImageFromFile(file);
 		}
 		if(img == NULL && mainGame->gameConf.use_image_scale) {
-			sprintf(file, "expansions/pics/%d.jpg", code);
+			snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
 			img = imageManager.driver->createImageFromFile(file);
 		}
 		if(img == NULL && mainGame->gameConf.use_image_scale) {
-			sprintf(file, "pics/%d.jpg", code);
+			snprintf(file, sizeof file, "pics/%d.jpg", code);
 			img = imageManager.driver->createImageFromFile(file);
 		}
 		if(img != NULL) {
@@ -345,7 +345,7 @@ irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 	if(lit != tThumbLoading.end()) {
 		if(lit->second != NULL) {
 			char file[256];
-			sprintf(file, "pics/thumbnail/%d.jpg", code);
+			snprintf(file, sizeof file, "pics/thumbnail/%d.jpg", code);
 			irr::video::ITexture* texture = driver->addTexture(file, lit->second); // textures must be added in the main thread due to OpenGL
 			lit->second->drop();
 			tThumb[code] = texture;
@@ -378,18 +378,18 @@ irr::video::ITexture* ImageManager::GetTextureField(int code) {
 	auto tit = tFields.find(code);
 	if(tit == tFields.end()) {
 		char file[256];
-		sprintf(file, "expansions/pics/field/%d.png", code);
+		snprintf(file, sizeof file, "expansions/pics/field/%d.png", code);
 		irr::video::ITexture* img = GetTextureFromFile(file, 512 * mainGame->xScale, 512 * mainGame->yScale);
 		if(img == NULL) {
-			sprintf(file, "expansions/pics/field/%d.jpg", code);
+			snprintf(file, sizeof file, "expansions/pics/field/%d.jpg", code);
 			img = GetTextureFromFile(file, 512 * mainGame->xScale, 512 * mainGame->yScale);
 		}
 		if(img == NULL) {
-			sprintf(file, "pics/field/%d.png", code);
+			snprintf(file, sizeof file, "pics/field/%d.png", code);
 			img = GetTextureFromFile(file, 512 * mainGame->xScale, 512 * mainGame->yScale);
 		}
 		if(img == NULL) {
-			sprintf(file, "pics/field/%d.jpg", code);
+			snprintf(file, sizeof file, "pics/field/%d.jpg", code);
 			img = GetTextureFromFile(file, 512 * mainGame->xScale, 512 * mainGame->yScale);
 			if(img == NULL) {
 				tFields[code] = NULL;

--- a/gframe/irrUString.h
+++ b/gframe/irrUString.h
@@ -31,12 +31,8 @@
 #ifndef __IRR_USTRING_H_INCLUDED__
 #define __IRR_USTRING_H_INCLUDED__
 
-#if (__cplusplus > 199711L) || (_MSC_VER >= 1600) || defined(__GXX_EXPERIMENTAL_CXX0X__)
-#	define USTRING_CPP0X
-#	if defined(__GXX_EXPERIMENTAL_CXX0X__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 5)))
-#		define USTRING_CPP0X_NEWLITERALS
-#	endif
-#endif
+#define USTRING_CPP0X
+#define USTRING_CPP0X_NEWLITERALS
 
 #include <stdio.h>
 #include <string.h>

--- a/gframe/lzma/Types.h
+++ b/gframe/lzma/Types.h
@@ -74,15 +74,9 @@ typedef unsigned long UInt64;
 
 #else
 
-#if defined(_MSC_VER) || defined(__BORLANDC__)
-typedef __int64 Int64;
-typedef unsigned __int64 UInt64;
-#define UINT64_CONST(n) n
-#else
 typedef long long int Int64;
 typedef unsigned long long int UInt64;
 #define UINT64_CONST(n) n ## ULL
-#endif
 
 #endif
 

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -388,9 +388,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					int flag = 0;
 					flag += (mainGame->chkBotHand->isChecked() ? 0x1 : 0);
 					char arg2[8];
-					sprintf(arg2, "%d", flag);
+					snprintf(arg2, sizeof arg2, "%d", flag);
 					char arg3[8];
-					sprintf(arg3, "%d", mainGame->gameConf.serverport);
+					snprintf(arg3, sizeof arg3, "%d", mainGame->gameConf.serverport);
 					execl("./bot", "bot", arg1, arg2, arg3, NULL);
 					exit(0);
 				} else {

--- a/gframe/myfilesystem.h
+++ b/gframe/myfilesystem.h
@@ -176,7 +176,7 @@ public:
 		bool success = true;
 		TraversalDir(dir, [dir, &success](const char *name, bool isdir) {
 			char full_path[256];
-			sprintf(full_path, "%s/%s", dir, name);
+			snprintf(full_path, sizeof full_path, "%s/%s", dir, name);
 			if (isdir)
 			{
 				if(!DeleteDir(full_path))


### PR DESCRIPTION
# Problem
EncodeUTF8
DecodeUTF8
These functions did not check the size of output array.
If the source string is too long, it will pass the boundary of the output array.

Example:
Create a file in `./single`
```
五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二一五四三二.lua
```
The filename is about 692 bytes in UTF-8.
The process will crash when trying to open this file.

# Solution
- The macros can be replaced by sizeof(wchar_t) 
- The size is deduced by the template
- Convert char/wchar_t to unsigned before bitwise operation
- Replace `sprintf` with `snprintf`

# Reference
https://github.com/edo9300/edopro/blob/master/gframe/bufferio.h


@edo9300 
My revision:
C++11
4.5 Integral promotions 
> A prvalue of an integer type other than bool, char16_t, char32_t, or wchar_t whose integer conversion rank (4.13) is less than the rank of int can be converted to a prvalue of type int if int can represent all the values of the source type; otherwise, the source prvalue can be converted to a prvalue of type unsigned int.

```cpp
char x=0xff;
x<<16; //promoted to int
```
The operand of bitwise operator should be unsigned type, so I think char/wchar_t should be cast to unsigned int first.

@mercury233 
@purerosefallen 
