### PR TITLE
fix after change side chat reverse

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -210,6 +210,7 @@ void DuelClient::ClientEvent(bufferevent *bev, short events, void *ctx) {
 					mainGame->closeDoneSignal.Wait();
 					mainGame->gMutex.lock();
 					mainGame->dInfo.isStarted = false;
+					mainGame->dInfo.isInDuel = false;
 					mainGame->dInfo.isFinished = false;
 					mainGame->is_building = false;
 					mainGame->device->setEventReceiver(&mainGame->menuHandler);
@@ -371,6 +372,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 	case STOC_CHANGE_SIDE: {
 		mainGame->gMutex.lock();
 		mainGame->dInfo.isStarted = false;
+		mainGame->dInfo.isInDuel = false;
 		mainGame->dField.Clear();
 		mainGame->is_building = true;
 		mainGame->is_siding = true;
@@ -663,6 +665,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		mainGame->closeDoneSignal.Wait();
 		mainGame->gMutex.lock();
 		mainGame->dInfo.isStarted = false;
+		mainGame->dInfo.isInDuel = false;
 		mainGame->dInfo.isFinished = true;
 		mainGame->is_building = false;
 		mainGame->wDeckEdit->setVisible(false);
@@ -745,10 +748,10 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 			if(mainGame->chkIgnore1->isChecked())
 				break;
 			if(!mainGame->dInfo.isTag) {
-				if(mainGame->dInfo.isStarted)
+				if(mainGame->dInfo.isInDuel)
 					player = mainGame->LocalPlayer(player);
 			} else {
-				if(mainGame->dInfo.isStarted && !mainGame->dInfo.isFirst)
+				if(mainGame->dInfo.isInDuel && !mainGame->dInfo.isFirst)
 					player ^= 2;
 				if(player == 0)
 					player = 0;
@@ -984,6 +987,7 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 			mainGame->closeDoneSignal.Wait();
 			mainGame->gMutex.lock();
 			mainGame->dInfo.isStarted = false;
+			mainGame->dInfo.isInDuel = false;
 			mainGame->dInfo.isFinished = false;
 			mainGame->btnCreateHost->setEnabled(true);
 			mainGame->btnJoinHost->setEnabled(true);
@@ -1190,6 +1194,7 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 		mainGame->showcard = 0;
 		mainGame->gMutex.lock();
 		mainGame->dField.Clear();
+		mainGame->dInfo.isInDuel = true;
 		int playertype = BufferIO::ReadUInt8(pbuf);
 		mainGame->dInfo.isFirst =  (playertype & 0xf) ? false : true;
 		if(playertype & 0xf0)

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -127,6 +127,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				if(mainGame->dInfo.player_type == 7) {
 					DuelClient::StopClient();
 					mainGame->dInfo.isStarted = false;
+					mainGame->dInfo.isInDuel = false;
 					mainGame->dInfo.isFinished = false;
 					mainGame->device->setEventReceiver(&mainGame->menuHandler);
 					mainGame->CloseDuelWindow();

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -18,6 +18,7 @@ Game* mainGame;
 
 void DuelInfo::Clear() {
 	isStarted = false;
+	isInDuel = false;
 	isFinished = false;
 	isReplay = false;
 	isReplaySkiping = false;

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -69,7 +69,8 @@ struct Config {
 
 struct DuelInfo {
 	bool isStarted{ false };
-	bool isFinished{ false };
+	bool isInDuel{ false };
+	bool isFinished{false};
 	bool isReplay{ false };
 	bool isReplaySkiping{ false };
 	bool isFirst{ false };

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -254,6 +254,7 @@ void ReplayMode::EndDuel() {
 		mainGame->actionSignal.Wait();
 		mainGame->gMutex.lock();
 		mainGame->dInfo.isStarted = false;
+		mainGame->dInfo.isInDuel = false;
 		mainGame->dInfo.isFinished = true;
 		mainGame->dInfo.isReplay = false;
 		mainGame->dInfo.isSingleMode = false;
@@ -272,7 +273,9 @@ void ReplayMode::EndDuel() {
 }
 void ReplayMode::Restart(bool refresh) {
 	end_duel(pduel);
+	mainGame->dInfo.isInDuel = false;
 	mainGame->dInfo.isStarted = false;
+	mainGame->dInfo.isInDuel = false;
 	mainGame->dInfo.isFinished = true;
 	mainGame->dField.Clear();
 	//mainGame->device->setEventReceiver(&mainGame->dField);

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -159,6 +159,7 @@ int SingleMode::SinglePlayThread() {
 	if(!is_closing) {
 		mainGame->gMutex.lock();
 		mainGame->dInfo.isStarted = false;
+		mainGame->dInfo.isInDuel = false;
 		mainGame->dInfo.isFinished = true;
 		mainGame->dInfo.isSingleMode = false;
 		mainGame->gMutex.unlock();


### PR DESCRIPTION
Fixed this: if the first player goes second (isFirst = false) then after changing side waiting for opponent change side, the player name of chat message would be incorrect.