### PR TITLE
 disconnect when the packet is too large 

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -61,7 +61,7 @@ bool DataManager::LoadDB(const wchar_t* wfile) {
 					if (len > SIZE_SETCODE)
 						len = SIZE_SETCODE;
 					if (len)
-						memcpy(cd.setcode, it->second.data(), len * sizeof(uint16_t));
+						std::memcpy(cd.setcode, it->second.data(), len * sizeof(uint16_t));
 				}
 				else
 					cd.set_setcode(setcode);
@@ -184,7 +184,7 @@ bool DataManager::GetData(unsigned int code, CardData* pData) {
 	if (pData) {
 		pData->code = data.code;
 		pData->alias = data.alias;
-		memcpy(pData->setcode, data.setcode, SIZE_SETCODE);
+		std::memcpy(pData->setcode, data.setcode, SIZE_SETCODE);
 		pData->type = data.type;
 		pData->level = data.level;
 		pData->attribute = data.attribute;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1757,7 +1757,7 @@ bool DeckBuilder::push_main(code_pointer pointer, int seq) {
 	if(pointer->second.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK))
 		return false;
 	auto& container = deckManager.current_deck.main;
-	int maxc = mainGame->is_siding ? 64 : DECK_MAX_SIZE;
+	int maxc = mainGame->is_siding ? DECK_MAX_SIZE + 4 : DECK_MAX_SIZE;
 	if((int)container.size() >= maxc)
 		return false;
 	if(seq >= 0 && seq < (int)container.size())
@@ -1772,7 +1772,7 @@ bool DeckBuilder::push_extra(code_pointer pointer, int seq) {
 	if(!(pointer->second.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK)))
 		return false;
 	auto& container = deckManager.current_deck.extra;
-	int maxc = mainGame->is_siding ? 20 : EXTRA_MAX_SIZE;
+	int maxc = mainGame->is_siding ? EXTRA_MAX_SIZE + 5 : EXTRA_MAX_SIZE;
 	if((int)container.size() >= maxc)
 		return false;
 	if(seq >= 0 && seq < (int)container.size())
@@ -1785,7 +1785,7 @@ bool DeckBuilder::push_extra(code_pointer pointer, int seq) {
 }
 bool DeckBuilder::push_side(code_pointer pointer, int seq) {
 	auto& container = deckManager.current_deck.side;
-	int maxc = mainGame->is_siding ? 20 : SIDE_MAX_SIZE;
+	int maxc = mainGame->is_siding ? SIDE_MAX_SIZE + 5 : SIDE_MAX_SIZE;
 	if((int)container.size() >= maxc)
 		return false;
 	if(seq >= 0 && seq < (int)container.size())

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1249,7 +1249,7 @@ void DeckBuilder::GetHoveredCard() {
 		} else if(y >= 164 && y <= 435) {
 			int lx = 10, px, py = (y - 164) / 68;
 			hovered_pos = 1;
-			if(deckManager.current_deck.main.size() > 40)
+			if(deckManager.current_deck.main.size() > DECK_MIN_SIZE)
 				lx = (deckManager.current_deck.main.size() - 41) / 4 + 11;
 			if(x >= 750)
 				px = lx - 1;
@@ -1757,7 +1757,7 @@ bool DeckBuilder::push_main(code_pointer pointer, int seq) {
 	if(pointer->second.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK))
 		return false;
 	auto& container = deckManager.current_deck.main;
-	int maxc = mainGame->is_siding ? 64 : 60;
+	int maxc = mainGame->is_siding ? 64 : DECK_MAX_SIZE;
 	if((int)container.size() >= maxc)
 		return false;
 	if(seq >= 0 && seq < (int)container.size())
@@ -1772,7 +1772,7 @@ bool DeckBuilder::push_extra(code_pointer pointer, int seq) {
 	if(!(pointer->second.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK)))
 		return false;
 	auto& container = deckManager.current_deck.extra;
-	int maxc = mainGame->is_siding ? 20 : 15;
+	int maxc = mainGame->is_siding ? 20 : EXTRA_MAX_SIZE;
 	if((int)container.size() >= maxc)
 		return false;
 	if(seq >= 0 && seq < (int)container.size())
@@ -1785,7 +1785,7 @@ bool DeckBuilder::push_extra(code_pointer pointer, int seq) {
 }
 bool DeckBuilder::push_side(code_pointer pointer, int seq) {
 	auto& container = deckManager.current_deck.side;
-	int maxc = mainGame->is_siding ? 20 : 15;
+	int maxc = mainGame->is_siding ? 20 : SIDE_MAX_SIZE;
 	if((int)container.size() >= maxc)
 		return false;
 	if(seq >= 0 && seq < (int)container.size())

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -86,11 +86,11 @@ int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 	if(!list)
 		return 0;
 	int dc = 0;
-	if(deck.main.size() < 40 || deck.main.size() > 60)
+	if(deck.main.size() < DECK_MIN_SIZE || deck.main.size() > DECK_MAX_SIZE)
 		return (DECKERROR_MAINCOUNT << 28) + deck.main.size();
-	if(deck.extra.size() > 15)
+	if(deck.extra.size() > EXTRA_MAX_SIZE)
 		return (DECKERROR_EXTRACOUNT << 28) + deck.extra.size();
-	if(deck.side.size() > 15)
+	if(deck.side.size() > SIDE_MAX_SIZE)
 		return (DECKERROR_SIDECOUNT << 28) + deck.side.size();
 	const int rule_map[6] = { AVAIL_OCG, AVAIL_TCG, AVAIL_SC, AVAIL_CUSTOM, AVAIL_OCGTCG, 0 };
 	int avail = rule_map[rule];
@@ -158,10 +158,10 @@ int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_p
 			continue;
 		}
 		else if(cd.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK)) {
-			if(deck.extra.size() >= 15)
+			if(deck.extra.size() >= EXTRA_MAX_SIZE)
 				continue;
 			deck.extra.push_back(dataManager.GetCodePointer(code));
-		} else if(deck.main.size() < 60) {
+		} else if(deck.main.size() < DECK_MAX_SIZE) {
 			deck.main.push_back(dataManager.GetCodePointer(code));
 		}
 	}

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -246,7 +246,9 @@ bool DeckManager::LoadDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUICom
 }
 FILE* DeckManager::OpenDeckFile(const wchar_t* file, const char* mode) {
 #ifdef WIN32
-	FILE* fp = _wfopen(file, (wchar_t*)mode);
+	wchar_t wmode[20]{};
+	BufferIO::CopyWStr(mode, wmode, sizeof(wmode) / sizeof(wchar_t));
+	FILE* fp = _wfopen(file, wmode);
 #else
 	char file2[256];
 	BufferIO::EncodeUTF8(file, file2);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -8,6 +8,10 @@
 #include <sstream>
 
 namespace ygo {
+	constexpr int DECK_MAX_SIZE = 60;
+	constexpr int DECK_MIN_SIZE = 40;
+	constexpr int EXTRA_MAX_SIZE = 15;
+	constexpr int SIDE_MAX_SIZE = 15;
 
 struct LFList {
 	unsigned int hash{};

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -18,10 +18,10 @@ void Game::DrawSelectionLine(irr::video::S3DVertex* vec, bool strip, int width, 
 		glDisable(GL_TEXTURE_2D);
 		glMaterialfv(GL_FRONT, GL_AMBIENT, cv);
 		glBegin(GL_LINE_LOOP);
-		glVertex3fv((float*)&vec[0].Pos);
-		glVertex3fv((float*)&vec[1].Pos);
-		glVertex3fv((float*)&vec[3].Pos);
-		glVertex3fv((float*)&vec[2].Pos);
+		glVertex3fv(&vec[0].Pos.X);
+		glVertex3fv(&vec[1].Pos.X);
+		glVertex3fv(&vec[3].Pos.X);
+		glVertex3fv(&vec[2].Pos.X);
 		glEnd();
 		glMaterialfv(GL_FRONT, GL_AMBIENT, origin);
 		glDisable(GL_LINE_STIPPLE);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -244,7 +244,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_ERROR_MSG: {
-		STOC_ErrorMsg* pkt = (STOC_ErrorMsg*)pdata;
+		STOC_ErrorMsg packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		switch(pkt->msg) {
 		case ERRMSG_JOINERROR: {
 			mainGame->btnCreateHost->setEnabled(true);
@@ -358,7 +360,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_HAND_RESULT: {
-		STOC_HandResult* pkt = (STOC_HandResult*)pdata;
+		STOC_HandResult packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		mainGame->stHintMsg->setVisible(false);
 		mainGame->showcardcode = (pkt->res1 - 1) + ((pkt->res2 - 1) << 16);
 		mainGame->showcarddif = 50;
@@ -426,7 +430,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_JOIN_GAME: {
-		STOC_JoinGame* pkt = (STOC_JoinGame*)pdata;
+		STOC_JoinGame packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		std::wstring str;
 		wchar_t msgbuf[256];
 		myswprintf(msgbuf, L"%ls%ls\n", dataManager.GetSysString(1226), deckManager.GetLFListName(pkt->info.lflist));
@@ -505,7 +511,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_TYPE_CHANGE: {
-		STOC_TypeChange* pkt = (STOC_TypeChange*)pdata;
+		STOC_TypeChange packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		if(!mainGame->dInfo.isTag) {
 			selftype = pkt->type & 0xf;
 			is_host = ((pkt->type >> 4) & 0xf) != 0;
@@ -738,7 +746,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_TIME_LIMIT: {
-		STOC_TimeLimit* pkt = (STOC_TimeLimit*)pdata;
+		STOC_TimeLimit packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		int lplayer = mainGame->LocalPlayer(pkt->player);
 		if(lplayer == 0)
 			DuelClient::SendPacketToServer(CTOS_TIME_CONFIRM);
@@ -747,7 +757,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_CHAT: {
-		STOC_Chat* pkt = (STOC_Chat*)pdata;
+		STOC_Chat packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		int player = pkt->player;
 		auto play_sound = false;
 		if(player < 4) {
@@ -777,7 +789,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 	}
 	case STOC_HS_PLAYER_ENTER: {
 		soundManager.PlaySoundEffect(SOUND_PLAYER_ENTER);
-		STOC_HS_PlayerEnter* pkt = (STOC_HS_PlayerEnter*)pdata;
+		STOC_HS_PlayerEnter packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		if(pkt->pos > 3)
 			break;
 		wchar_t name[20];
@@ -808,7 +822,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_HS_PLAYER_CHANGE: {
-		STOC_HS_PlayerChange* pkt = (STOC_HS_PlayerChange*)pdata;
+		STOC_HS_PlayerChange packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		unsigned char pos = (pkt->status >> 4) & 0xf;
 		unsigned char state = pkt->status & 0xf;
 		if(pos > 3)
@@ -816,7 +832,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		mainGame->gMutex.lock();
 		if(state < 8) {
 			soundManager.PlaySoundEffect(SOUND_PLAYER_ENTER);
-			wchar_t* prename = (wchar_t*)mainGame->stHostPrepDuelist[pos]->getToolTipText().c_str();
+			const wchar_t* prename = mainGame->stHostPrepDuelist[pos]->getToolTipText().c_str();
 			if(mainGame->gameConf.hide_player_name)
 				mainGame->stHostPrepDuelist[state]->setText(L"[********]");
 			else
@@ -868,7 +884,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_HS_WATCH_CHANGE: {
-		STOC_HS_WatchChange* pkt = (STOC_HS_WatchChange*)pdata;
+		STOC_HS_WatchChange packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		watching = pkt->watch_count;
 		wchar_t watchbuf[32];
 		myswprintf(watchbuf, L"%ls%d", dataManager.GetSysString(1253), watching);
@@ -3946,7 +3964,7 @@ void DuelClient::SwapField() {
 	is_swapping = true;
 }
 void DuelClient::SetResponseI(int respI) {
-	*((int*)response_buf) = respI;
+	std::memcpy(response_buf, &respI, sizeof respI);
 	response_len = 4;
 }
 void DuelClient::SetResponseB(void* respB, unsigned int len) {
@@ -4032,7 +4050,8 @@ void DuelClient::BeginRefreshHost() {
 	for(int i = 0; i < 8; ++i) {
 		if(host->h_addr_list[i] == 0)
 			break;
-		unsigned int local_addr = *(unsigned int*)host->h_addr_list[i];
+		unsigned int local_addr = 0;
+		std::memcpy(&local_addr, host->h_addr_list[i], sizeof local_addr);
 		local.sin_addr.s_addr = local_addr;
 		SOCKET sSend = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 		if(sSend == INVALID_SOCKET)
@@ -4068,7 +4087,9 @@ void DuelClient::BroadcastReply(evutil_socket_t fd, short events, void * arg) {
 		socklen_t sz = sizeof(sockaddr_in);
 		char buf[256];
 		/*int ret = */recvfrom(fd, buf, 256, 0, (sockaddr*)&bc_addr, &sz);
-		HostPacket* pHP = (HostPacket*)buf;
+		HostPacket packet;
+		std::memcpy(&packet, buf, sizeof packet);
+		HostPacket* pHP = &packet;
 		if(is_closing || pHP->identifier != NETWORK_SERVER_ID)
 			return;
 		if(pHP->version != PRO_VERSION)

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -253,7 +253,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_ERROR_MSG: {
-		if (len != 1 + (int)sizeof(STOC_ErrorMsg))
+		if (len < 1 + (int)sizeof(STOC_ErrorMsg))
 			return;
 		STOC_ErrorMsg packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -371,7 +371,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HAND_RESULT: {
-		if (len != 1 + (int)sizeof(STOC_HandResult))
+		if (len < 1 + (int)sizeof(STOC_HandResult))
 			return;
 		STOC_HandResult packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -430,7 +430,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_DECK_COUNT: {
-		if (len != 1 + (int)sizeof(int16_t) * 6)
+		if (len < 1 + (int)sizeof(int16_t) * 6)
 			return;
 		mainGame->gMutex.lock();
 		int deckc = BufferIO::ReadInt16(pdata);
@@ -445,7 +445,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_JOIN_GAME: {
-		if (len != 1 + (int)sizeof(STOC_JoinGame))
+		if (len < 1 + (int)sizeof(STOC_JoinGame))
 			return;
 		STOC_JoinGame packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -528,7 +528,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_TYPE_CHANGE: {
-		if (len != 1 + (int)sizeof(STOC_TypeChange))
+		if (len < 1 + (int)sizeof(STOC_TypeChange))
 			return;
 		STOC_TypeChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -767,7 +767,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_TIME_LIMIT: {
-		if (len != 1 + (int)sizeof(STOC_TimeLimit))
+		if (len < 1 + (int)sizeof(STOC_TimeLimit))
 			return;
 		STOC_TimeLimit packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -818,7 +818,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HS_PLAYER_ENTER: {
-		if (len != 1 + (int)sizeof(STOC_HS_PlayerEnter))
+		if (len < 1 + (int)sizeof(STOC_HS_PlayerEnter))
 			return;
 		soundManager.PlaySoundEffect(SOUND_PLAYER_ENTER);
 		STOC_HS_PlayerEnter packet;
@@ -854,7 +854,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HS_PLAYER_CHANGE: {
-		if (len != 1 + (int)sizeof(STOC_HS_PlayerChange))
+		if (len < 1 + (int)sizeof(STOC_HS_PlayerChange))
 			return;
 		STOC_HS_PlayerChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -918,7 +918,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HS_WATCH_CHANGE: {
-		if (len != 1 + (int)sizeof(STOC_HS_WatchChange))
+		if (len < 1 + (int)sizeof(STOC_HS_WatchChange))
 			return;
 		STOC_HS_WatchChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -111,8 +111,10 @@ void DuelClient::ClientRead(bufferevent* bev, void* ctx) {
 		}
 		if(len < packet_len + 2)
 			return;
+		if (packet_len < 1)
+			return;
 		read_len = evbuffer_remove(input, duel_client_read, packet_len + 2);
-		if (read_len > 0)
+		if (read_len >= 3)
 			HandleSTOCPacketLan(&duel_client_read[2], read_len - 2);
 		len -= packet_len + 2;
 	}

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -242,15 +242,19 @@ int DuelClient::ClientThread() {
 	connect_state = 0;
 	return 0;
 }
-void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
+void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 	unsigned char* pdata = data;
 	unsigned char pktType = BufferIO::ReadUInt8(pdata);
 	switch(pktType) {
 	case STOC_GAME_MSG: {
+		if (len < 1 + (int)sizeof(unsigned char))
+			return;
 		ClientAnalyze(pdata, len - 1);
 		break;
 	}
 	case STOC_ERROR_MSG: {
+		if (len < 1 + (int)sizeof(STOC_ErrorMsg))
+			return;
 		STOC_ErrorMsg packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -367,6 +371,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_HAND_RESULT: {
+		if (len < 1 + (int)sizeof(STOC_HandResult))
+			return;
 		STOC_HandResult packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -424,6 +430,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_DECK_COUNT: {
+		if (len < 1 + (int)sizeof(int16_t) * 6)
+			return;
 		mainGame->gMutex.lock();
 		int deckc = BufferIO::ReadInt16(pdata);
 		int extrac = BufferIO::ReadInt16(pdata);
@@ -437,6 +445,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_JOIN_GAME: {
+		if (len < 1 + (int)sizeof(STOC_JoinGame))
+			return;
 		STOC_JoinGame packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -518,6 +528,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_TYPE_CHANGE: {
+		if (len < 1 + (int)sizeof(STOC_TypeChange))
+			return;
 		STOC_TypeChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -707,6 +719,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_REPLAY: {
+		if (len < 1 + (int)sizeof(ReplayHeader))
+			return;
 		mainGame->gMutex.lock();
 		mainGame->wPhase->setVisible(false);
 		if(mainGame->dInfo.player_type < 7)
@@ -714,7 +728,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		mainGame->CloseGameButtons();
 		auto prep = pdata;
 		Replay new_replay;
-		std::memcpy(&new_replay.pheader, prep, sizeof(ReplayHeader));
+		std::memcpy(&new_replay.pheader, prep, sizeof(new_replay.pheader));
 		time_t starttime;
 		if (new_replay.pheader.flag & REPLAY_UNIFORM)
 			starttime = new_replay.pheader.start_time;
@@ -753,6 +767,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_TIME_LIMIT: {
+		if (len < 1 + (int)sizeof(STOC_TimeLimit))
+			return;
 		STOC_TimeLimit packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -764,6 +780,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_CHAT: {
+		if (len < 1 + (int)sizeof(STOC_Chat))
+			return;
 		STOC_Chat packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -795,6 +813,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_HS_PLAYER_ENTER: {
+		if (len < 1 + (int)sizeof(STOC_HS_PlayerEnter))
+			return;
 		soundManager.PlaySoundEffect(SOUND_PLAYER_ENTER);
 		STOC_HS_PlayerEnter packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -829,6 +849,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_HS_PLAYER_CHANGE: {
+		if (len < 1 + (int)sizeof(STOC_HS_PlayerChange))
+			return;
 		STOC_HS_PlayerChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -891,6 +913,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		break;
 	}
 	case STOC_HS_WATCH_CHANGE: {
+		if (len < 1 + (int)sizeof(STOC_HS_WatchChange))
+			return;
 		STOC_HS_WatchChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -906,6 +930,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		if(!mainGame->dField.tag_surrender)
 			mainGame->dField.tag_teammate_surrender = true;
 		mainGame->btnLeaveGame->setText(dataManager.GetSysString(1355));
+		break;
 	}
 	}
 }

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -253,7 +253,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_ERROR_MSG: {
-		if (len < 1 + (int)sizeof(STOC_ErrorMsg))
+		if (len != 1 + (int)sizeof(STOC_ErrorMsg))
 			return;
 		STOC_ErrorMsg packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -371,7 +371,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HAND_RESULT: {
-		if (len < 1 + (int)sizeof(STOC_HandResult))
+		if (len != 1 + (int)sizeof(STOC_HandResult))
 			return;
 		STOC_HandResult packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -430,7 +430,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_DECK_COUNT: {
-		if (len < 1 + (int)sizeof(int16_t) * 6)
+		if (len != 1 + (int)sizeof(int16_t) * 6)
 			return;
 		mainGame->gMutex.lock();
 		int deckc = BufferIO::ReadInt16(pdata);
@@ -445,7 +445,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_JOIN_GAME: {
-		if (len < 1 + (int)sizeof(STOC_JoinGame))
+		if (len != 1 + (int)sizeof(STOC_JoinGame))
 			return;
 		STOC_JoinGame packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -528,7 +528,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_TYPE_CHANGE: {
-		if (len < 1 + (int)sizeof(STOC_TypeChange))
+		if (len != 1 + (int)sizeof(STOC_TypeChange))
 			return;
 		STOC_TypeChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -767,7 +767,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_TIME_LIMIT: {
-		if (len < 1 + (int)sizeof(STOC_TimeLimit))
+		if (len != 1 + (int)sizeof(STOC_TimeLimit))
 			return;
 		STOC_TimeLimit packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -780,7 +780,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_CHAT: {
-		if (len < 1 + (int)sizeof(STOC_Chat))
+		if (len != 1 + (int)sizeof(STOC_Chat))
 			return;
 		STOC_Chat packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -813,7 +813,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HS_PLAYER_ENTER: {
-		if (len < 1 + (int)sizeof(STOC_HS_PlayerEnter))
+		if (len != 1 + (int)sizeof(STOC_HS_PlayerEnter))
 			return;
 		soundManager.PlaySoundEffect(SOUND_PLAYER_ENTER);
 		STOC_HS_PlayerEnter packet;
@@ -849,7 +849,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HS_PLAYER_CHANGE: {
-		if (len < 1 + (int)sizeof(STOC_HS_PlayerChange))
+		if (len != 1 + (int)sizeof(STOC_HS_PlayerChange))
 			return;
 		STOC_HS_PlayerChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -913,7 +913,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HS_WATCH_CHANGE: {
-		if (len < 1 + (int)sizeof(STOC_HS_WatchChange))
+		if (len != 1 + (int)sizeof(STOC_HS_WatchChange))
 			return;
 		STOC_HS_WatchChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -99,21 +99,19 @@ void DuelClient::StopClient(bool is_exiting) {
 }
 void DuelClient::ClientRead(bufferevent* bev, void* ctx) {
 	evbuffer* input = bufferevent_get_input(bev);
-	size_t len = evbuffer_get_length(input);
+	int len = evbuffer_get_length(input);
 	unsigned short packet_len = 0;
 	while(true) {
 		if(len < 2)
 			return;
 		evbuffer_copyout(input, &packet_len, 2);
-		if(len < (size_t)packet_len + 2)
-			return;
 		if (packet_len + 2 > SIZE_NETWORK_BUFFER) {
-			evbuffer_drain(input, packet_len + 2);
-			read_len = 0;
+			ClientEvent(bev, BEV_EVENT_ERROR, 0);
+			return;
 		}
-		else {
-			read_len = evbuffer_remove(input, duel_client_read, packet_len + 2);
-		}
+		if(len < packet_len + 2)
+			return;
+		read_len = evbuffer_remove(input, duel_client_read, packet_len + 2);
 		if (read_len > 0)
 			HandleSTOCPacketLan(&duel_client_read[2], read_len - 2);
 		len -= packet_len + 2;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -714,7 +714,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		mainGame->CloseGameButtons();
 		auto prep = pdata;
 		Replay new_replay;
-		memcpy(&new_replay.pheader, prep, sizeof(ReplayHeader));
+		std::memcpy(&new_replay.pheader, prep, sizeof(ReplayHeader));
 		time_t starttime;
 		if (new_replay.pheader.flag & REPLAY_UNIFORM)
 			starttime = new_replay.pheader.start_time;
@@ -743,7 +743,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, unsigned int len) {
 		}
 		if(mainGame->actionParam || !is_host) {
 			prep += sizeof(ReplayHeader);
-			memcpy(new_replay.comp_data, prep, len - sizeof(ReplayHeader) - 1);
+			std::memcpy(new_replay.comp_data, prep, len - sizeof(ReplayHeader) - 1);
 			new_replay.comp_size = len - sizeof(ReplayHeader) - 1;
 			if(mainGame->actionParam)
 				new_replay.SaveReplay(mainGame->ebRSName->getText());
@@ -915,7 +915,7 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 	wchar_t textBuffer[256];
 	mainGame->dInfo.curMsg = BufferIO::ReadUInt8(pbuf);
 	if(mainGame->dInfo.curMsg != MSG_RETRY) {
-		memcpy(last_successful_msg, msg, len);
+		std::memcpy(last_successful_msg, msg, len);
 		last_successful_msg_length = len;
 	}
 	mainGame->dField.HideMenu();
@@ -3977,7 +3977,7 @@ void DuelClient::SetResponseI(int respI) {
 void DuelClient::SetResponseB(void* respB, unsigned int len) {
 	if (len > SIZE_RETURN_VALUE)
 		len = SIZE_RETURN_VALUE;
-	memcpy(response_buf, respB, len);
+	std::memcpy(response_buf, respB, len);
 	response_len = len;
 }
 void DuelClient::SendResponse() {

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -818,11 +818,11 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HS_PLAYER_ENTER: {
-		if (len < 1 + (int)sizeof(STOC_HS_PlayerEnter))
+		if (len < 1 + STOC_HS_PlayerEnter_size)
 			return;
 		soundManager.PlaySoundEffect(SOUND_PLAYER_ENTER);
 		STOC_HS_PlayerEnter packet;
-		std::memcpy(&packet, pdata, sizeof packet);
+		std::memcpy(&packet, pdata, STOC_HS_PlayerEnter_size);
 		const auto* pkt = &packet;
 		if(pkt->pos > 3)
 			break;

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -27,6 +27,7 @@ private:
 	static event_base* client_base;
 	static bufferevent* client_bev;
 	static unsigned char duel_client_read[SIZE_NETWORK_BUFFER];
+	static int read_len;
 	static unsigned char duel_client_write[SIZE_NETWORK_BUFFER];
 	static bool is_closing;
 	static bool is_swapping;
@@ -62,7 +63,7 @@ public:
 		auto p = duel_client_write;
 		int blen = sizeof(ST);
 		if (blen > MAX_DATA_SIZE)
-			blen = MAX_DATA_SIZE;
+			return;
 		BufferIO::WriteInt16(p, (short)(1 + blen));
 		BufferIO::WriteInt8(p, proto);
 		memcpy(p, &st, blen);

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -46,7 +46,7 @@ public:
 	static void ClientRead(bufferevent* bev, void* ctx);
 	static void ClientEvent(bufferevent *bev, short events, void *ctx);
 	static int ClientThread();
-	static void HandleSTOCPacketLan(unsigned char* data, unsigned int len);
+	static void HandleSTOCPacketLan(unsigned char* data, int len);
 	static int ClientAnalyze(unsigned char* msg, unsigned int len);
 	static void SwapField();
 	static void SetResponseI(int respI);

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -5,11 +5,6 @@
 #include <vector>
 #include <set>
 #include <utility>
-#include <event2/event.h>
-#include <event2/listener.h>
-#include <event2/bufferevent.h>
-#include <event2/buffer.h>
-#include <event2/thread.h>
 #include "network.h"
 #include "data_manager.h"
 #include "deck_manager.h"

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -66,7 +66,7 @@ public:
 			return;
 		BufferIO::WriteInt16(p, (short)(1 + blen));
 		BufferIO::WriteInt8(p, proto);
-		memcpy(p, &st, blen);
+		std::memcpy(p, &st, blen);
 		bufferevent_write(client_bev, duel_client_write, blen + 3);
 	}
 	static void SendBufferToServer(unsigned char proto, void* buffer, size_t len) {
@@ -78,7 +78,7 @@ public:
 			blen = MAX_DATA_SIZE;
 		BufferIO::WriteInt16(p, (short)(1 + blen));
 		BufferIO::WriteInt8(p, proto);
-		memcpy(p, buffer, blen);
+		std::memcpy(p, buffer, blen);
 		bufferevent_write(client_bev, duel_client_write, blen + 3);
 	}
 	

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -2028,9 +2028,9 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 					break;
 				const wchar_t* input = mainGame->ebChatInput->getText();
 				if(input[0]) {
-					unsigned short msgbuf[256];
-					int len = BufferIO::CopyWStr(input, msgbuf, 256);
-					DuelClient::SendBufferToServer(CTOS_CHAT, msgbuf, (len + 1) * sizeof(short));
+					uint16_t msgbuf[LEN_CHAT_MSG];
+					int len = BufferIO::CopyWStr(input, msgbuf, LEN_CHAT_MSG);
+					DuelClient::SendBufferToServer(CTOS_CHAT, msgbuf, (len + 1) * sizeof(uint16_t));
 					mainGame->ebChatInput->setText(L"");
 					return true;
 				}

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -84,7 +84,9 @@ void NetServer::BroadcastEvent(evutil_socket_t fd, short events, void* arg) {
 	int ret = recvfrom(fd, buf, 256, 0, (sockaddr*)&bc_addr, &sz);
 	if(ret == -1)
 		return;
-	HostRequest* pHR = (HostRequest*)buf;
+	HostRequest packet;
+	std::memcpy(&packet, buf, sizeof packet);
+	const HostRequest* pHR = &packet;
 	if(pHR->identifier == NETWORK_CLIENT_ID) {
 		SOCKADDR_IN sockTo;
 		sockTo.sin_addr.s_addr = bc_addr.sin_addr.s_addr;
@@ -204,26 +206,34 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, unsigned i
 	case CTOS_HAND_RESULT: {
 		if(!dp->game)
 			return;
-		CTOS_HandResult* pkt = (CTOS_HandResult*)pdata;
+		CTOS_HandResult packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		dp->game->HandResult(dp, pkt->res);
 		break;
 	}
 	case CTOS_TP_RESULT: {
 		if(!dp->game)
 			return;
-		CTOS_TPResult* pkt = (CTOS_TPResult*)pdata;
+		CTOS_TPResult packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		dp->game->TPResult(dp, pkt->res);
 		break;
 	}
 	case CTOS_PLAYER_INFO: {
-		CTOS_PlayerInfo* pkt = (CTOS_PlayerInfo*)pdata;
+		CTOS_PlayerInfo packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		BufferIO::CopyWStr(pkt->name, dp->name, 20);
 		break;
 	}
 	case CTOS_CREATE_GAME: {
 		if(dp->game || duel_mode)
 			return;
-		CTOS_CreateGame* pkt = (CTOS_CreateGame*)pdata;
+		CTOS_CreateGame packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		auto pkt = &packet;
 		if(pkt->info.mode == MODE_SINGLE) {
 			duel_mode = new SingleDuel(false);
 			duel_mode->etimer = event_new(net_evbase, 0, EV_TIMEOUT | EV_PERSIST, SingleDuel::SingleTimer, duel_mode);
@@ -247,6 +257,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, unsigned i
 		}
 		if(hash == 1)
 			pkt->info.lflist = deckManager._lfList[0].hash;
+		std::memcpy(pdata, &packet, sizeof packet);
 		duel_mode->host_info = pkt->info;
 		BufferIO::CopyWStr(pkt->name, duel_mode->name, 20);
 		BufferIO::CopyWStr(pkt->pass, duel_mode->pass, 20);
@@ -294,7 +305,9 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, unsigned i
 	case CTOS_HS_KICK: {
 		if(!duel_mode || duel_mode->pduel)
 			break;
-		CTOS_Kick* pkt = (CTOS_Kick*)pdata;
+		CTOS_Kick packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		duel_mode->PlayerKick(dp, pkt->pos);
 		break;
 	}

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -115,6 +115,11 @@ void NetServer::ServerAccept(evconnlistener* listener, evutil_socket_t fd, socka
 void NetServer::ServerAcceptError(evconnlistener* listener, void* ctx) {
 	event_base_loopexit(net_evbase, 0);
 }
+/*
+* packet_len: 2 bytes
+* proto: 1 byte
+* [data]: (packet_len - 1) bytes
+*/
 void NetServer::ServerEchoRead(bufferevent *bev, void *ctx) {
 	evbuffer* input = bufferevent_get_input(bev);
 	int len = evbuffer_get_length(input);
@@ -129,8 +134,10 @@ void NetServer::ServerEchoRead(bufferevent *bev, void *ctx) {
 		}
 		if (len < packet_len + 2)
 			return;
+		if (packet_len < 1)
+			return;
 		read_len = evbuffer_remove(input, net_server_read, packet_len + 2);
-		if (read_len > 0)
+		if (read_len >= 3)
 			HandleCTOSPacket(&users[bev], &net_server_read[2], read_len - 2);
 		len -= packet_len + 2;
 	}

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -350,5 +350,19 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	}
 	}
 }
+size_t NetServer::CreateChatPacket(unsigned char* src, int src_size, unsigned char* dst, uint16_t dst_player_type) {
+	if (!check_msg_size(src_size))
+		return 0;
+	uint16_t src_msg[LEN_CHAT_MSG];
+	std::memcpy(src_msg, src, src_size);
+	const int src_len = src_size / sizeof(uint16_t);
+	if (src_msg[src_len - 1] != 0)
+		return 0;
+	// STOC_Chat packet
+	auto pdst = dst;
+	buffer_write<uint16_t>(pdst, dst_player_type);
+	buffer_write_block(pdst, src_msg, src_size);
+	return sizeof(dst_player_type) + src_size;
+}
 
 }

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -225,7 +225,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_HAND_RESULT: {
 		if(!dp->game)
 			return;
-		if (len < 1 + (int)sizeof(CTOS_HandResult))
+		if (len != 1 + (int)sizeof(CTOS_HandResult))
 			return;
 		CTOS_HandResult packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -236,7 +236,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_TP_RESULT: {
 		if(!dp->game)
 			return;
-		if (len < 1 + (int)sizeof(CTOS_TPResult))
+		if (len != 1 + (int)sizeof(CTOS_TPResult))
 			return;
 		CTOS_TPResult packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -245,7 +245,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 		break;
 	}
 	case CTOS_PLAYER_INFO: {
-		if (len < 1 + (int)sizeof(CTOS_PlayerInfo))
+		if (len != 1 + (int)sizeof(CTOS_PlayerInfo))
 			return;
 		CTOS_PlayerInfo packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -256,7 +256,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_CREATE_GAME: {
 		if(dp->game || duel_mode)
 			return;
-		if (len < 1 + (int)sizeof(CTOS_CreateGame))
+		if (len != 1 + (int)sizeof(CTOS_CreateGame))
 			return;
 		CTOS_CreateGame packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -295,7 +295,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_JOIN_GAME: {
 		if (!duel_mode)
 			return;
-		if (len < 1 + (int)sizeof(CTOS_JoinGame))
+		if (len != 1 + (int)sizeof(CTOS_JoinGame))
 			return;
 		duel_mode->JoinGame(dp, pdata, false);
 		break;
@@ -334,7 +334,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_HS_KICK: {
 		if (!duel_mode || duel_mode->pduel)
 			return;
-		if (len < 1 + (int)sizeof(CTOS_Kick))
+		if (len != 1 + (int)sizeof(CTOS_Kick))
 			return;
 		CTOS_Kick packet;
 		std::memcpy(&packet, pdata, sizeof packet);

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -225,7 +225,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_HAND_RESULT: {
 		if(!dp->game)
 			return;
-		if (len != 1 + (int)sizeof(CTOS_HandResult))
+		if (len < 1 + (int)sizeof(CTOS_HandResult))
 			return;
 		CTOS_HandResult packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -236,7 +236,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_TP_RESULT: {
 		if(!dp->game)
 			return;
-		if (len != 1 + (int)sizeof(CTOS_TPResult))
+		if (len < 1 + (int)sizeof(CTOS_TPResult))
 			return;
 		CTOS_TPResult packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -245,7 +245,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 		break;
 	}
 	case CTOS_PLAYER_INFO: {
-		if (len != 1 + (int)sizeof(CTOS_PlayerInfo))
+		if (len < 1 + (int)sizeof(CTOS_PlayerInfo))
 			return;
 		CTOS_PlayerInfo packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -256,7 +256,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_CREATE_GAME: {
 		if(dp->game || duel_mode)
 			return;
-		if (len != 1 + (int)sizeof(CTOS_CreateGame))
+		if (len < 1 + (int)sizeof(CTOS_CreateGame))
 			return;
 		CTOS_CreateGame packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -295,7 +295,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_JOIN_GAME: {
 		if (!duel_mode)
 			return;
-		if (len != 1 + (int)sizeof(CTOS_JoinGame))
+		if (len < 1 + (int)sizeof(CTOS_JoinGame))
 			return;
 		duel_mode->JoinGame(dp, pdata, false);
 		break;
@@ -334,7 +334,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_HS_KICK: {
 		if (!duel_mode || duel_mode->pduel)
 			return;
-		if (len != 1 + (int)sizeof(CTOS_Kick))
+		if (len < 1 + (int)sizeof(CTOS_Kick))
 			return;
 		CTOS_Kick packet;
 		std::memcpy(&packet, pdata, sizeof packet);

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -54,7 +54,7 @@ public:
 			return;
 		BufferIO::WriteInt16(p, (short)(1 + blen));
 		BufferIO::WriteInt8(p, proto);
-		memcpy(p, &st, blen);
+		std::memcpy(p, &st, blen);
 		last_sent = blen + 3;
 		if (dp)
 			bufferevent_write(dp->bev, net_server_write, blen + 3);
@@ -68,7 +68,7 @@ public:
 			blen = MAX_DATA_SIZE;
 		BufferIO::WriteInt16(p, (short)(1 + blen));
 		BufferIO::WriteInt8(p, proto);
-		memcpy(p, buffer, blen);
+		std::memcpy(p, buffer, blen);
 		last_sent = blen + 3;
 		if (dp)
 			bufferevent_write(dp->bev, net_server_write, blen + 3);

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -19,6 +19,7 @@ private:
 	static evconnlistener* listener;
 	static DuelMode* duel_mode;
 	static unsigned char net_server_read[SIZE_NETWORK_BUFFER];
+	static int read_len;
 	static unsigned char net_server_write[SIZE_NETWORK_BUFFER];
 	static unsigned short last_sent;
 
@@ -50,7 +51,7 @@ public:
 		auto p = net_server_write;
 		int blen = sizeof(ST);
 		if (blen > MAX_DATA_SIZE)
-			blen = MAX_DATA_SIZE;
+			return;
 		BufferIO::WriteInt16(p, (short)(1 + blen));
 		BufferIO::WriteInt8(p, proto);
 		memcpy(p, &st, blen);

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -37,6 +37,7 @@ public:
 	static int ServerThread();
 	static void DisconnectPlayer(DuelPlayer* dp);
 	static void HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len);
+	static size_t CreateChatPacket(unsigned char* src, int src_size, unsigned char* dst, uint16_t dst_player_type);
 	static void SendPacketToPlayer(DuelPlayer* dp, unsigned char proto) {
 		auto p = net_server_write;
 		BufferIO::WriteInt16(p, 1);

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -36,7 +36,7 @@ public:
 	static void ServerEchoEvent(bufferevent* bev, short events, void* ctx);
 	static int ServerThread();
 	static void DisconnectPlayer(DuelPlayer* dp);
-	static void HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, unsigned int len);
+	static void HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len);
 	static void SendPacketToPlayer(DuelPlayer* dp, unsigned char proto) {
 		auto p = net_server_write;
 		BufferIO::WriteInt16(p, 1);

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -127,7 +127,6 @@ inline bool check_msg_size(int size) {
 
 class DuelMode {
 public:
-	DuelMode(): host_player(nullptr), pduel(0), duel_stage(0) {}
 	virtual ~DuelMode() {}
 	virtual void Chat(DuelPlayer* dp, unsigned char* pdata, int len) {}
 	virtual void JoinGame(DuelPlayer* dp, void* pdata, bool is_creater) {}
@@ -147,16 +146,16 @@ public:
 	virtual void Surrender(DuelPlayer* dp) {}
 	virtual void GetResponse(DuelPlayer* dp, void* pdata, unsigned int len) {}
 	virtual void TimeConfirm(DuelPlayer* dp) {}
-	virtual void EndDuel() {};
+	virtual void EndDuel() {}
 
 public:
-	event* etimer;
-	DuelPlayer* host_player;
+	event* etimer { nullptr };
+	DuelPlayer* host_player{ nullptr };
 	HostInfo host_info;
-	int duel_stage;
-	intptr_t pduel;
-	wchar_t name[20];
-	wchar_t pass[20];
+	int duel_stage{};
+	intptr_t pduel{};
+	wchar_t name[20]{};
+	wchar_t pass[20]{};
 };
 
 }

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -14,16 +14,16 @@ namespace ygo {
 	constexpr int MAX_DATA_SIZE = SIZE_NETWORK_BUFFER - 3;
 
 struct HostInfo {
-	unsigned int lflist{ 0 };
-	unsigned char rule{ 0 };
-	unsigned char mode{ 0 };
-	unsigned char duel_rule{ 0 };
-	bool no_check_deck{ false };
-	bool no_shuffle_deck{ false };
-	unsigned int start_lp{ 0 };
-	unsigned char start_hand{ 0 };
-	unsigned char draw_count{ 0 };
-	unsigned short time_limit{ 0 };
+	unsigned int lflist{};
+	unsigned char rule{};
+	unsigned char mode{};
+	unsigned char duel_rule{};
+	unsigned char no_check_deck{};
+	unsigned char no_shuffle_deck{};
+	unsigned int start_lp{};
+	unsigned char start_hand{};
+	unsigned char draw_count{};
+	unsigned short time_limit{};
 };
 struct HostPacket {
 	unsigned short identifier;

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -12,6 +12,8 @@
 namespace ygo {
 	constexpr int SIZE_NETWORK_BUFFER = 0x2000;
 	constexpr int MAX_DATA_SIZE = SIZE_NETWORK_BUFFER - 3;
+	constexpr int MAINC_MAX = 250;	// the limit of card_state
+	constexpr int SIDEC_MAX = MAINC_MAX;
 
 struct HostInfo {
 	unsigned int lflist{};

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -125,6 +125,12 @@ inline bool check_msg_size(int size) {
 	return true;
 }
 
+inline unsigned int GetPosition(unsigned char* qbuf, int offset) {
+	unsigned int info = 0;
+	std::memcpy(&info, qbuf + offset, sizeof info);
+	return info >> 24;
+}
+
 class DuelMode {
 public:
 	virtual ~DuelMode() {}

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -144,7 +144,7 @@ public:
 		return 0;
 	}
 	virtual void Surrender(DuelPlayer* dp) {}
-	virtual void GetResponse(DuelPlayer* dp, void* pdata, unsigned int len) {}
+	virtual void GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {}
 	virtual void TimeConfirm(DuelPlayer* dp) {}
 	virtual void EndDuel() {}
 

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -8,6 +8,9 @@
 #include <event2/bufferevent.h>
 #include <event2/buffer.h>
 #include <event2/thread.h>
+#include <type_traits>
+
+#define check_trivially_copyable(T) static_assert(std::is_trivially_copyable<T>::value == true, "not trivially copyable")
 
 namespace ygo {
 	constexpr int SIZE_NETWORK_BUFFER = 0x2000;
@@ -29,6 +32,7 @@ struct HostInfo {
 	unsigned char draw_count{};
 	unsigned short time_limit{};
 };
+check_trivially_copyable(HostInfo);
 static_assert(sizeof(HostInfo) == 20, "size mismatch: HostInfo");
 
 struct HostPacket {
@@ -41,26 +45,31 @@ struct HostPacket {
 	unsigned short name[20];
 	HostInfo host;
 };
+check_trivially_copyable(HostPacket);
 static_assert(sizeof(HostPacket) == 72, "size mismatch: HostPacket");
 
 struct HostRequest {
 	unsigned short identifier;
 };
+check_trivially_copyable(HostRequest);
 static_assert(sizeof(HostRequest) == 2, "size mismatch: HostRequest");
 
 struct CTOS_HandResult {
 	unsigned char res;
 };
+check_trivially_copyable(CTOS_HandResult);
 static_assert(sizeof(CTOS_HandResult) == 1, "size mismatch: CTOS_HandResult");
 
 struct CTOS_TPResult {
 	unsigned char res;
 };
+check_trivially_copyable(CTOS_TPResult);
 static_assert(sizeof(CTOS_TPResult) == 1, "size mismatch: CTOS_TPResult");
 
 struct CTOS_PlayerInfo {
 	unsigned short name[20];
 };
+check_trivially_copyable(CTOS_PlayerInfo);
 static_assert(sizeof(CTOS_PlayerInfo) == 40, "size mismatch: CTOS_PlayerInfo");
 
 struct CTOS_CreateGame {
@@ -68,6 +77,7 @@ struct CTOS_CreateGame {
 	unsigned short name[20];
 	unsigned short pass[20];
 };
+check_trivially_copyable(CTOS_CreateGame);
 static_assert(sizeof(CTOS_CreateGame) == 100, "size mismatch: CTOS_CreateGame");
 
 struct CTOS_JoinGame {
@@ -77,11 +87,13 @@ struct CTOS_JoinGame {
 	unsigned int gameid;
 	unsigned short pass[20];
 };
+check_trivially_copyable(CTOS_JoinGame);
 static_assert(sizeof(CTOS_JoinGame) == 48, "size mismatch: CTOS_JoinGame");
 
 struct CTOS_Kick {
 	unsigned char pos;
 };
+check_trivially_copyable(CTOS_Kick);
 static_assert(sizeof(CTOS_Kick) == 1, "size mismatch: CTOS_Kick");
 
 // STOC
@@ -91,32 +103,38 @@ struct STOC_ErrorMsg {
 
 	unsigned int code;
 };
+check_trivially_copyable(STOC_ErrorMsg);
 static_assert(sizeof(STOC_ErrorMsg) == 8, "size mismatch: STOC_ErrorMsg");
 
 struct STOC_HandResult {
 	unsigned char res1;
 	unsigned char res2;
 };
+check_trivially_copyable(STOC_HandResult);
 static_assert(sizeof(STOC_HandResult) == 2, "size mismatch: STOC_HandResult");
 
 struct STOC_CreateGame {
 	unsigned int gameid;
 };
+check_trivially_copyable(STOC_CreateGame);
 static_assert(sizeof(STOC_CreateGame) == 4, "size mismatch: STOC_CreateGame");
 
 struct STOC_JoinGame {
 	HostInfo info;
 };
+check_trivially_copyable(STOC_JoinGame);
 static_assert(sizeof(STOC_JoinGame) == 20, "size mismatch: STOC_JoinGame");
 
 struct STOC_TypeChange {
 	unsigned char type;
 };
+check_trivially_copyable(STOC_TypeChange);
 static_assert(sizeof(STOC_TypeChange) == 1, "size mismatch: STOC_TypeChange");
 
 struct STOC_ExitGame {
 	unsigned char pos;
 };
+check_trivially_copyable(STOC_ExitGame);
 static_assert(sizeof(STOC_ExitGame) == 1, "size mismatch: STOC_ExitGame");
 
 struct STOC_TimeLimit {
@@ -125,6 +143,7 @@ struct STOC_TimeLimit {
 
 	unsigned short left_time;
 };
+check_trivially_copyable(STOC_TimeLimit);
 static_assert(sizeof(STOC_TimeLimit) == 4, "size mismatch: STOC_TimeLimit");
 
 /*
@@ -141,17 +160,20 @@ struct STOC_HS_PlayerEnter {
 	unsigned char pos;
 	// byte padding[1]
 };
+check_trivially_copyable(STOC_HS_PlayerEnter);
 static_assert(sizeof(STOC_HS_PlayerEnter) == 42, "size mismatch: STOC_HS_PlayerEnter");
 
 struct STOC_HS_PlayerChange {
 	//pos<<4 | state
 	unsigned char status;
 };
+check_trivially_copyable(STOC_HS_PlayerChange);
 static_assert(sizeof(STOC_HS_PlayerChange) == 1, "size mismatch: STOC_HS_PlayerChange");
 
 struct STOC_HS_WatchChange {
 	unsigned short watch_count;
 };
+check_trivially_copyable(STOC_HS_WatchChange);
 static_assert(sizeof(STOC_HS_WatchChange) == 2, "size mismatch: STOC_HS_WatchChange");
 
 class DuelMode;

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -19,7 +19,7 @@ namespace ygo {
 	constexpr int SIDEC_MAX = MAINC_MAX;
 
 struct HostInfo {
-	unsigned int lflist{};
+	uint32_t lflist{};
 	unsigned char rule{};
 	unsigned char mode{};
 	unsigned char duel_rule{};
@@ -27,7 +27,7 @@ struct HostInfo {
 	unsigned char no_shuffle_deck{};
 	// byte padding[3]
 
-	unsigned int start_lp{};
+	uint32_t start_lp{};
 	unsigned char start_hand{};
 	unsigned char draw_count{};
 	uint16_t time_limit{};
@@ -41,7 +41,7 @@ struct HostPacket {
 	uint16_t port;
 	// byte padding[2]
 
-	unsigned int ipaddr;
+	uint32_t ipaddr;
 	uint16_t name[20];
 	HostInfo host;
 };
@@ -84,7 +84,7 @@ struct CTOS_JoinGame {
 	uint16_t version;
 	// byte padding[2]
 
-	unsigned int gameid;
+	uint32_t gameid;
 	uint16_t pass[20];
 };
 check_trivially_copyable(CTOS_JoinGame);
@@ -101,7 +101,7 @@ struct STOC_ErrorMsg {
 	unsigned char msg;
 	// byte padding[3]
 
-	unsigned int code;
+	uint32_t code;
 };
 check_trivially_copyable(STOC_ErrorMsg);
 static_assert(sizeof(STOC_ErrorMsg) == 8, "size mismatch: STOC_ErrorMsg");
@@ -114,7 +114,7 @@ check_trivially_copyable(STOC_HandResult);
 static_assert(sizeof(STOC_HandResult) == 2, "size mismatch: STOC_HandResult");
 
 struct STOC_CreateGame {
-	unsigned int gameid;
+	uint32_t gameid;
 };
 check_trivially_copyable(STOC_CreateGame);
 static_assert(sizeof(STOC_CreateGame) == 4, "size mismatch: STOC_CreateGame");

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -20,70 +20,111 @@ struct HostInfo {
 	unsigned char duel_rule{};
 	unsigned char no_check_deck{};
 	unsigned char no_shuffle_deck{};
+	// byte padding[3]
+
 	unsigned int start_lp{};
 	unsigned char start_hand{};
 	unsigned char draw_count{};
 	unsigned short time_limit{};
 };
+static_assert(sizeof(HostInfo) == 20, "size mismatch: HostInfo");
+
 struct HostPacket {
 	unsigned short identifier;
 	unsigned short version;
 	unsigned short port;
+	// byte padding[2]
+
 	unsigned int ipaddr;
 	unsigned short name[20];
 	HostInfo host;
 };
+static_assert(sizeof(HostPacket) == 72, "size mismatch: HostPacket");
+
 struct HostRequest {
 	unsigned short identifier;
 };
+static_assert(sizeof(HostRequest) == 2, "size mismatch: HostRequest");
+
 struct CTOS_HandResult {
 	unsigned char res;
 };
+static_assert(sizeof(CTOS_HandResult) == 1, "size mismatch: CTOS_HandResult");
+
 struct CTOS_TPResult {
 	unsigned char res;
 };
+static_assert(sizeof(CTOS_TPResult) == 1, "size mismatch: CTOS_TPResult");
+
 struct CTOS_PlayerInfo {
 	unsigned short name[20];
 };
+static_assert(sizeof(CTOS_PlayerInfo) == 40, "size mismatch: CTOS_PlayerInfo");
+
 struct CTOS_CreateGame {
 	HostInfo info;
 	unsigned short name[20];
 	unsigned short pass[20];
 };
+static_assert(sizeof(CTOS_CreateGame) == 100, "size mismatch: CTOS_CreateGame");
+
 struct CTOS_JoinGame {
 	unsigned short version;
+	// byte padding[2]
+
 	unsigned int gameid;
 	unsigned short pass[20];
 };
+static_assert(sizeof(CTOS_JoinGame) == 48, "size mismatch: CTOS_JoinGame");
+
 struct CTOS_Kick {
 	unsigned char pos;
 };
+static_assert(sizeof(CTOS_Kick) == 1, "size mismatch: CTOS_Kick");
 
 // STOC
 struct STOC_ErrorMsg {
 	unsigned char msg;
+	// byte padding[3]
+
 	unsigned int code;
 };
+static_assert(sizeof(STOC_ErrorMsg) == 8, "size mismatch: STOC_ErrorMsg");
+
 struct STOC_HandResult {
 	unsigned char res1;
 	unsigned char res2;
 };
+static_assert(sizeof(STOC_HandResult) == 2, "size mismatch: STOC_HandResult");
+
 struct STOC_CreateGame {
 	unsigned int gameid;
 };
+static_assert(sizeof(STOC_CreateGame) == 4, "size mismatch: STOC_CreateGame");
+
 struct STOC_JoinGame {
 	HostInfo info;
 };
+static_assert(sizeof(STOC_JoinGame) == 20, "size mismatch: STOC_JoinGame");
+
 struct STOC_TypeChange {
 	unsigned char type;
 };
+static_assert(sizeof(STOC_TypeChange) == 1, "size mismatch: STOC_TypeChange");
+
 struct STOC_ExitGame {
 	unsigned char pos;
 };
+static_assert(sizeof(STOC_ExitGame) == 1, "size mismatch: STOC_ExitGame");
+
 struct STOC_TimeLimit {
 	unsigned char player;
+	// byte padding[1]
+
 	unsigned short left_time;
 };
+static_assert(sizeof(STOC_TimeLimit) == 4, "size mismatch: STOC_TimeLimit");
+
 /*
 * STOC_Chat
 * uint16_t player_type;
@@ -92,17 +133,24 @@ struct STOC_TimeLimit {
 constexpr int LEN_CHAT_PLAYER = 1;
 constexpr int LEN_CHAT_MSG = 256;
 constexpr int SIZE_STOC_CHAT = (LEN_CHAT_PLAYER + LEN_CHAT_MSG) * sizeof(uint16_t);
+
 struct STOC_HS_PlayerEnter {
 	unsigned short name[20];
 	unsigned char pos;
+	// byte padding[1]
 };
+static_assert(sizeof(STOC_HS_PlayerEnter) == 42, "size mismatch: STOC_HS_PlayerEnter");
+
 struct STOC_HS_PlayerChange {
 	//pos<<4 | state
 	unsigned char status;
 };
+static_assert(sizeof(STOC_HS_PlayerChange) == 1, "size mismatch: STOC_HS_PlayerChange");
+
 struct STOC_HS_WatchChange {
 	unsigned short watch_count;
 };
+static_assert(sizeof(STOC_HS_WatchChange) == 2, "size mismatch: STOC_HS_WatchChange");
 
 class DuelMode;
 

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -58,6 +58,8 @@ struct CTOS_JoinGame {
 struct CTOS_Kick {
 	unsigned char pos;
 };
+
+// STOC
 struct STOC_ErrorMsg {
 	unsigned char msg;
 	unsigned int code;
@@ -82,10 +84,14 @@ struct STOC_TimeLimit {
 	unsigned char player;
 	unsigned short left_time;
 };
-struct STOC_Chat {
-	unsigned short player;
-	unsigned short msg[256];
-};
+/*
+* STOC_Chat
+* uint16_t player_type;
+* uint16_t msg[256]; (UTF-16 string)
+*/
+constexpr int LEN_CHAT_PLAYER = 1;
+constexpr int LEN_CHAT_MSG = 256;
+constexpr int SIZE_STOC_CHAT = (LEN_CHAT_PLAYER + LEN_CHAT_MSG) * sizeof(uint16_t);
 struct STOC_HS_PlayerEnter {
 	unsigned short name[20];
 	unsigned char pos;
@@ -108,11 +114,22 @@ struct DuelPlayer {
 	bufferevent* bev{ 0 };
 };
 
+inline bool check_msg_size(int size) {
+	// empty string is not allowed
+	if (size < 2* sizeof(uint16_t))
+		return false;
+	if (size > LEN_CHAT_MSG * sizeof(uint16_t))
+		return false;
+	if (size % sizeof(uint16_t) != 0)
+		return false;
+	return true;
+}
+
 class DuelMode {
 public:
 	DuelMode(): host_player(nullptr), pduel(0), duel_stage(0) {}
 	virtual ~DuelMode() {}
-	virtual void Chat(DuelPlayer* dp, void* pdata, int len) {}
+	virtual void Chat(DuelPlayer* dp, unsigned char* pdata, int len) {}
 	virtual void JoinGame(DuelPlayer* dp, void* pdata, bool is_creater) {}
 	virtual void LeaveGame(DuelPlayer* dp) {}
 	virtual void ToDuelist(DuelPlayer* dp) {}

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -30,26 +30,26 @@ struct HostInfo {
 	unsigned int start_lp{};
 	unsigned char start_hand{};
 	unsigned char draw_count{};
-	unsigned short time_limit{};
+	uint16_t time_limit{};
 };
 check_trivially_copyable(HostInfo);
 static_assert(sizeof(HostInfo) == 20, "size mismatch: HostInfo");
 
 struct HostPacket {
-	unsigned short identifier;
-	unsigned short version;
-	unsigned short port;
+	uint16_t identifier;
+	uint16_t version;
+	uint16_t port;
 	// byte padding[2]
 
 	unsigned int ipaddr;
-	unsigned short name[20];
+	uint16_t name[20];
 	HostInfo host;
 };
 check_trivially_copyable(HostPacket);
 static_assert(sizeof(HostPacket) == 72, "size mismatch: HostPacket");
 
 struct HostRequest {
-	unsigned short identifier;
+	uint16_t identifier;
 };
 check_trivially_copyable(HostRequest);
 static_assert(sizeof(HostRequest) == 2, "size mismatch: HostRequest");
@@ -67,25 +67,25 @@ check_trivially_copyable(CTOS_TPResult);
 static_assert(sizeof(CTOS_TPResult) == 1, "size mismatch: CTOS_TPResult");
 
 struct CTOS_PlayerInfo {
-	unsigned short name[20];
+	uint16_t name[20];
 };
 check_trivially_copyable(CTOS_PlayerInfo);
 static_assert(sizeof(CTOS_PlayerInfo) == 40, "size mismatch: CTOS_PlayerInfo");
 
 struct CTOS_CreateGame {
 	HostInfo info;
-	unsigned short name[20];
-	unsigned short pass[20];
+	uint16_t name[20];
+	uint16_t pass[20];
 };
 check_trivially_copyable(CTOS_CreateGame);
 static_assert(sizeof(CTOS_CreateGame) == 100, "size mismatch: CTOS_CreateGame");
 
 struct CTOS_JoinGame {
-	unsigned short version;
+	uint16_t version;
 	// byte padding[2]
 
 	unsigned int gameid;
-	unsigned short pass[20];
+	uint16_t pass[20];
 };
 check_trivially_copyable(CTOS_JoinGame);
 static_assert(sizeof(CTOS_JoinGame) == 48, "size mismatch: CTOS_JoinGame");
@@ -141,7 +141,7 @@ struct STOC_TimeLimit {
 	unsigned char player;
 	// byte padding[1]
 
-	unsigned short left_time;
+	uint16_t left_time;
 };
 check_trivially_copyable(STOC_TimeLimit);
 static_assert(sizeof(STOC_TimeLimit) == 4, "size mismatch: STOC_TimeLimit");
@@ -156,7 +156,7 @@ constexpr int LEN_CHAT_MSG = 256;
 constexpr int SIZE_STOC_CHAT = (LEN_CHAT_PLAYER + LEN_CHAT_MSG) * sizeof(uint16_t);
 
 struct STOC_HS_PlayerEnter {
-	unsigned short name[20];
+	uint16_t name[20];
 	unsigned char pos;
 	// byte padding[1]
 };
@@ -171,7 +171,7 @@ check_trivially_copyable(STOC_HS_PlayerChange);
 static_assert(sizeof(STOC_HS_PlayerChange) == 1, "size mismatch: STOC_HS_PlayerChange");
 
 struct STOC_HS_WatchChange {
-	unsigned short watch_count;
+	uint16_t watch_count;
 };
 check_trivially_copyable(STOC_HS_WatchChange);
 static_assert(sizeof(STOC_HS_WatchChange) == 2, "size mismatch: STOC_HS_WatchChange");

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -136,7 +136,7 @@ public:
 	virtual void ToObserver(DuelPlayer* dp) {}
 	virtual void PlayerReady(DuelPlayer* dp, bool is_ready) {}
 	virtual void PlayerKick(DuelPlayer* dp, unsigned char pos) {}
-	virtual void UpdateDeck(DuelPlayer* dp, void* pdata, unsigned int len) {}
+	virtual void UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {}
 	virtual void StartDuel(DuelPlayer* dp) {}
 	virtual void HandResult(DuelPlayer* dp, unsigned char res) {}
 	virtual void TPResult(DuelPlayer* dp, unsigned char tp) {}

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -158,7 +158,7 @@ constexpr int SIZE_STOC_CHAT = (LEN_CHAT_PLAYER + LEN_CHAT_MSG) * sizeof(uint16_
 struct STOC_HS_PlayerEnter {
 	uint16_t name[20];
 	unsigned char pos;
-	// byte padding[1]
+	unsigned char padding;	// only for padding
 };
 check_trivially_copyable(STOC_HS_PlayerEnter);
 static_assert(sizeof(STOC_HS_PlayerEnter) == 42, "size mismatch: STOC_HS_PlayerEnter");

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -158,10 +158,11 @@ constexpr int SIZE_STOC_CHAT = (LEN_CHAT_PLAYER + LEN_CHAT_MSG) * sizeof(uint16_
 struct STOC_HS_PlayerEnter {
 	uint16_t name[20];
 	unsigned char pos;
-	unsigned char padding;	// only for padding
+	// byte padding[1]
 };
 check_trivially_copyable(STOC_HS_PlayerEnter);
-static_assert(sizeof(STOC_HS_PlayerEnter) == 42, "size mismatch: STOC_HS_PlayerEnter");
+//static_assert(sizeof(STOC_HS_PlayerEnter) == 42, "size mismatch: STOC_HS_PlayerEnter");
+constexpr int STOC_HS_PlayerEnter_size = 41;	//workwround
 
 struct STOC_HS_PlayerChange {
 	//pos<<4 | state

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -129,7 +129,7 @@ class DuelMode {
 public:
 	virtual ~DuelMode() {}
 	virtual void Chat(DuelPlayer* dp, unsigned char* pdata, int len) {}
-	virtual void JoinGame(DuelPlayer* dp, void* pdata, bool is_creater) {}
+	virtual void JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {}
 	virtual void LeaveGame(DuelPlayer* dp) {}
 	virtual void ToDuelist(DuelPlayer* dp) {}
 	virtual void ToObserver(DuelPlayer* dp) {}

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1480,10 +1480,6 @@ inline int SingleDuel::WriteUpdateData(int& player, int location, int& flag, uns
 	int len = query_field_card(pduel, player, location, flag, qbuf, use_cache);
 	return len;
 }
-inline unsigned int GetPosition(unsigned char*& qbuf, int offset) {
-	unsigned int info = *(unsigned int*)(qbuf + offset);
-	return info >> 24;
-}
 void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -12,12 +12,12 @@ SingleDuel::SingleDuel(bool is_match) {
 }
 SingleDuel::~SingleDuel() {
 }
-void SingleDuel::Chat(DuelPlayer* dp, void* pdata, int len) {
-	STOC_Chat scc;
-	scc.player = dp->type;
-	unsigned short* msg = (unsigned short*)pdata;
-	int msglen = BufferIO::CopyWStr(msg, scc.msg, 256);
-	NetServer::SendBufferToPlayer(players[0], STOC_CHAT, &scc, 4 + msglen * 2);
+void SingleDuel::Chat(DuelPlayer* dp, unsigned char* pdata, int len) {
+	unsigned char scc[SIZE_STOC_CHAT];
+	const auto scc_size = NetServer::CreateChatPacket(pdata, len, scc, dp->type);
+	if (!scc_size)
+		return;
+	NetServer::SendBufferToPlayer(players[0], STOC_CHAT, scc, scc_size);
 	NetServer::ReSendToPlayer(players[1]);
 	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
 		NetServer::ReSendToPlayer(*pit);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1416,7 +1416,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 	}
 	return 0;
 }
-void SingleDuel::GetResponse(DuelPlayer* dp, void* pdata, unsigned int len) {
+void SingleDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
 	byte resb[SIZE_RETURN_VALUE];
 	if (len > SIZE_RETURN_VALUE)
 		len = SIZE_RETURN_VALUE;

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -330,9 +330,9 @@ void SingleDuel::StartDuel(DuelPlayer* dp) {
 	BufferIO::WriteInt16(pbuf, (short)pdeck[1].side.size());
 	NetServer::SendBufferToPlayer(players[0], STOC_DECK_COUNT, deckbuff, 12);
 	char tempbuff[6];
-	memcpy(tempbuff, deckbuff, 6);
-	memcpy(deckbuff, deckbuff + 6, 6);
-	memcpy(deckbuff + 6, tempbuff, 6);
+	std::memcpy(tempbuff, deckbuff, 6);
+	std::memcpy(deckbuff, deckbuff + 6, 6);
+	std::memcpy(deckbuff + 6, tempbuff, 6);
 	NetServer::SendBufferToPlayer(players[1], STOC_DECK_COUNT, deckbuff, 12);
 	NetServer::SendPacketToPlayer(players[0], STOC_SELECT_HAND);
 	NetServer::ReSendToPlayer(players[1]);
@@ -1408,7 +1408,7 @@ void SingleDuel::GetResponse(DuelPlayer* dp, void* pdata, unsigned int len) {
 	byte resb[SIZE_RETURN_VALUE];
 	if (len > SIZE_RETURN_VALUE)
 		len = SIZE_RETURN_VALUE;
-	memcpy(resb, pdata, len);
+	std::memcpy(resb, pdata, len);
 	last_replay.WriteInt8(len);
 	last_replay.WriteData(resb, len);
 	set_responseb(pduel, resb);
@@ -1426,9 +1426,9 @@ void SingleDuel::EndDuel() {
 		return;
 	last_replay.EndRecord();
 	char replaybuf[0x2000], *pbuf = replaybuf;
-	memcpy(pbuf, &last_replay.pheader, sizeof(ReplayHeader));
+	std::memcpy(pbuf, &last_replay.pheader, sizeof(ReplayHeader));
 	pbuf += sizeof(ReplayHeader);
-	memcpy(pbuf, last_replay.comp_data, last_replay.comp_size);
+	std::memcpy(pbuf, last_replay.comp_data, last_replay.comp_size);
 	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replaybuf, sizeof(ReplayHeader) + last_replay.comp_size);
 	NetServer::ReSendToPlayer(players[1]);
 	for(auto oit = observers.begin(); oit != observers.end(); ++oit)

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -22,7 +22,7 @@ void SingleDuel::Chat(DuelPlayer* dp, unsigned char* pdata, int len) {
 	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
 		NetServer::ReSendToPlayer(*pit);
 }
-void SingleDuel::JoinGame(DuelPlayer* dp, void* pdata, bool is_creater) {
+void SingleDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 	if(!is_creater) {
 		if(dp->game && dp->type != 0xff) {
 			STOC_ErrorMsg scem;

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -32,7 +32,9 @@ void SingleDuel::JoinGame(DuelPlayer* dp, void* pdata, bool is_creater) {
 			NetServer::DisconnectPlayer(dp);
 			return;
 		}
-		CTOS_JoinGame* pkt = (CTOS_JoinGame*)pdata;
+		CTOS_JoinGame packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		if(pkt->version != PRO_VERSION) {
 			STOC_ErrorMsg scem;
 			scem.msg = ERRMSG_VERERROR;

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -277,16 +277,16 @@ void SingleDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
 void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 	if(dp->type > 1 || ready[dp->type])
 		return;
-	if (len <= 8 || len % sizeof(int32_t) != 0)
+	if (len < 8)
 		return;
 	bool valid = true;
 	auto deckbuf = pdata;
 	int mainc = BufferIO::ReadInt32(deckbuf);
 	int sidec = BufferIO::ReadInt32(deckbuf);
 	const int deck_size = len - 2 * sizeof(int32_t);
-	if (mainc < DECK_MIN_SIZE || mainc > DECK_MAX_SIZE + EXTRA_MAX_SIZE)
+	if (mainc < 0 || mainc > MAINC_MAX)
 		valid = false;
-	else if (sidec < 0 || sidec > SIDE_MAX_SIZE)
+	else if (sidec < 0 || sidec > SIDEC_MAX)
 		valid = false;
 	else if (deck_size != (mainc + sidec) * (int)sizeof(int32_t))
 		valid = false;
@@ -297,7 +297,7 @@ void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 		NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
 		return;
 	}
-	int deck_list[DECK_MAX_SIZE + EXTRA_MAX_SIZE + SIDE_MAX_SIZE];
+	int deck_list[SIZE_NETWORK_BUFFER / sizeof(int32_t)];
 	std::memcpy(deck_list, deckbuf, deck_size);
 	if(duel_count == 0) {
 		deck_error[dp->type] = deckManager.LoadDeck(pdeck[dp->type], deck_list, mainc, sidec);

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -18,7 +18,7 @@ public:
 	virtual void ToObserver(DuelPlayer* dp);
 	virtual void PlayerReady(DuelPlayer* dp, bool ready);
 	virtual void PlayerKick(DuelPlayer* dp, unsigned char pos);
-	virtual void UpdateDeck(DuelPlayer* dp, void* pdata, unsigned int len);
+	virtual void UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len);
 	virtual void StartDuel(DuelPlayer* dp);
 	virtual void HandResult(DuelPlayer* dp, unsigned char res);
 	virtual void TPResult(DuelPlayer* dp, unsigned char tp);

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -25,7 +25,7 @@ public:
 	virtual void Process();
 	virtual void Surrender(DuelPlayer* dp);
 	virtual int Analyze(unsigned char* msgbuffer, unsigned int len);
-	virtual void GetResponse(DuelPlayer* dp, void* pdata, unsigned int len);
+	virtual void GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len);
 	virtual void TimeConfirm(DuelPlayer* dp);
 	virtual void EndDuel();
 	

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -12,7 +12,7 @@ public:
 	SingleDuel(bool is_match);
 	virtual ~SingleDuel();
 	virtual void Chat(DuelPlayer* dp, unsigned char* pdata, int len);
-	virtual void JoinGame(DuelPlayer* dp, void* pdata, bool is_creater);
+	virtual void JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater);
 	virtual void LeaveGame(DuelPlayer* dp);
 	virtual void ToDuelist(DuelPlayer* dp);
 	virtual void ToObserver(DuelPlayer* dp);

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -11,7 +11,7 @@ class SingleDuel: public DuelMode {
 public:
 	SingleDuel(bool is_match);
 	virtual ~SingleDuel();
-	virtual void Chat(DuelPlayer* dp, void* pdata, int len);
+	virtual void Chat(DuelPlayer* dp, unsigned char* pdata, int len);
 	virtual void JoinGame(DuelPlayer* dp, void* pdata, bool is_creater);
 	virtual void LeaveGame(DuelPlayer* dp);
 	virtual void ToDuelist(DuelPlayer* dp);

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -751,7 +751,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			int len = BufferIO::ReadInt16(pbuf);
 			auto begin = pbuf;
 			pbuf += len + 1;
-			memcpy(namebuf, begin, len + 1);
+			std::memcpy(namebuf, begin, len + 1);
 			BufferIO::DecodeUTF8(namebuf, wname);
 			BufferIO::CopyWStr(wname, mainGame->dInfo.clientname, 20);
 			break;
@@ -762,7 +762,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			int len = BufferIO::ReadInt16(pbuf);
 			auto begin = pbuf;
 			pbuf += len + 1;
-			memcpy(msgbuf, begin, len + 1);
+			std::memcpy(msgbuf, begin, len + 1);
 			BufferIO::DecodeUTF8(msgbuf, msg);
 			mainGame->gMutex.lock();
 			mainGame->SetStaticText(mainGame->stMessage, 310, mainGame->guiFont, msg);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -16,13 +16,13 @@ TagDuel::TagDuel() {
 }
 TagDuel::~TagDuel() {
 }
-void TagDuel::Chat(DuelPlayer* dp, void* pdata, int len) {
-	STOC_Chat scc;
-	scc.player = dp->type;
-	unsigned short* msg = (unsigned short*)pdata;
-	int msglen = BufferIO::CopyWStr(msg, scc.msg, 256);
+void TagDuel::Chat(DuelPlayer* dp, unsigned char* pdata, int len) {
+	unsigned char scc[SIZE_STOC_CHAT];
+	const auto scc_size = NetServer::CreateChatPacket(pdata, len, scc, dp->type);
+	if (!scc_size)
+		return;
 	for(int i = 0; i < 4; ++i)
-		NetServer::SendBufferToPlayer(players[i], STOC_CHAT, &scc, 4 + msglen * 2);
+		NetServer::SendBufferToPlayer(players[i], STOC_CHAT, scc, scc_size);
 	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
 		NetServer::ReSendToPlayer(*pit);
 }

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -296,9 +296,9 @@ void TagDuel::StartDuel(DuelPlayer* dp) {
 	NetServer::SendBufferToPlayer(players[0], STOC_DECK_COUNT, deckbuff, 12);
 	NetServer::ReSendToPlayer(players[1]);
 	char tempbuff[6];
-	memcpy(tempbuff, deckbuff, 6);
-	memcpy(deckbuff, deckbuff + 6, 6);
-	memcpy(deckbuff + 6, tempbuff, 6);
+	std::memcpy(tempbuff, deckbuff, 6);
+	std::memcpy(deckbuff, deckbuff + 6, 6);
+	std::memcpy(deckbuff + 6, tempbuff, 6);
 	NetServer::SendBufferToPlayer(players[2], STOC_DECK_COUNT, deckbuff, 12);
 	NetServer::ReSendToPlayer(players[3]);
 	NetServer::SendPacketToPlayer(players[0], STOC_SELECT_HAND);
@@ -1523,7 +1523,7 @@ void TagDuel::GetResponse(DuelPlayer* dp, void* pdata, unsigned int len) {
 	byte resb[SIZE_RETURN_VALUE];
 	if (len > SIZE_RETURN_VALUE)
 		len = SIZE_RETURN_VALUE;
-	memcpy(resb, pdata, len);
+	std::memcpy(resb, pdata, len);
 	last_replay.WriteInt8(len);
 	last_replay.WriteData(resb, len);
 	set_responseb(pduel, resb);
@@ -1542,9 +1542,9 @@ void TagDuel::EndDuel() {
 		return;
 	last_replay.EndRecord();
 	char replaybuf[0x2000], *pbuf = replaybuf;
-	memcpy(pbuf, &last_replay.pheader, sizeof(ReplayHeader));
+	std::memcpy(pbuf, &last_replay.pheader, sizeof(ReplayHeader));
 	pbuf += sizeof(ReplayHeader);
-	memcpy(pbuf, last_replay.comp_data, last_replay.comp_size);
+	std::memcpy(pbuf, last_replay.comp_data, last_replay.comp_size);
 	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replaybuf, sizeof(ReplayHeader) + last_replay.comp_size);
 	NetServer::ReSendToPlayer(players[1]);
 	NetServer::ReSendToPlayer(players[2]);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -260,16 +260,16 @@ void TagDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
 void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 	if(dp->type > 3 || ready[dp->type])
 		return;
-	if (len <= 8 || len % sizeof(int32_t) != 0)
+	if (len < 8)
 		return;
 	bool valid = true;
 	auto deckbuf = pdata;
 	int mainc = BufferIO::ReadInt32(deckbuf);
 	int sidec = BufferIO::ReadInt32(deckbuf);
 	const int deck_size = len - 2 * sizeof(int32_t);
-	if (mainc < DECK_MIN_SIZE || mainc > DECK_MAX_SIZE + EXTRA_MAX_SIZE)
+	if (mainc < 0 || mainc > MAINC_MAX)
 		valid = false;
-	else if (sidec < 0 || sidec > SIDE_MAX_SIZE)
+	else if (sidec < 0 || sidec > SIDEC_MAX)
 		valid = false;
 	else if (deck_size != (mainc + sidec) * (int)sizeof(int32_t))
 		valid = false;
@@ -280,7 +280,7 @@ void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 		NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
 		return;
 	}
-	int deck_list[DECK_MAX_SIZE + EXTRA_MAX_SIZE + SIDE_MAX_SIZE];
+	int deck_list[SIZE_NETWORK_BUFFER / sizeof(int32_t)];
 	std::memcpy(deck_list, deckbuf, deck_size);
 	deck_error[dp->type] = deckManager.LoadDeck(pdeck[dp->type], deck_list, mainc, sidec);
 }

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1531,7 +1531,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 	}
 	return 0;
 }
-void TagDuel::GetResponse(DuelPlayer* dp, void* pdata, unsigned int len) {
+void TagDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
 	byte resb[SIZE_RETURN_VALUE];
 	if (len > SIZE_RETURN_VALUE)
 		len = SIZE_RETURN_VALUE;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -26,7 +26,7 @@ void TagDuel::Chat(DuelPlayer* dp, unsigned char* pdata, int len) {
 	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
 		NetServer::ReSendToPlayer(*pit);
 }
-void TagDuel::JoinGame(DuelPlayer* dp, void* pdata, bool is_creater) {
+void TagDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 	if(!is_creater) {
 		if(dp->game && dp->type != 0xff) {
 			STOC_ErrorMsg scem;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -36,7 +36,9 @@ void TagDuel::JoinGame(DuelPlayer* dp, void* pdata, bool is_creater) {
 			NetServer::DisconnectPlayer(dp);
 			return;
 		}
-		CTOS_JoinGame* pkt = (CTOS_JoinGame*)pdata;
+		CTOS_JoinGame packet;
+		std::memcpy(&packet, pdata, sizeof packet);
+		const auto* pkt = &packet;
 		if(pkt->version != PRO_VERSION) {
 			STOC_ErrorMsg scem;
 			scem.msg = ERRMSG_VERERROR;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1602,10 +1602,6 @@ inline int TagDuel::WriteUpdateData(int& player, int location, int& flag, unsign
 	int len = query_field_card(pduel, player, location, flag, qbuf, use_cache);
 	return len;
 }
-inline unsigned int GetPosition(unsigned char*& qbuf, int offset) {
-	unsigned int info = *(unsigned int*)(qbuf + offset);
-	return info >> 24;
-}
 void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -11,7 +11,7 @@ class TagDuel: public DuelMode {
 public:
 	TagDuel();
 	virtual ~TagDuel();
-	virtual void Chat(DuelPlayer* dp, void* pdata, int len);
+	virtual void Chat(DuelPlayer* dp, unsigned char* pdata, int len);
 	virtual void JoinGame(DuelPlayer* dp, void* pdata, bool is_creater);
 	virtual void LeaveGame(DuelPlayer* dp);
 	virtual void ToDuelist(DuelPlayer* dp);

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -18,7 +18,7 @@ public:
 	virtual void ToObserver(DuelPlayer* dp);
 	virtual void PlayerReady(DuelPlayer* dp, bool ready);
 	virtual void PlayerKick(DuelPlayer* dp, unsigned char pos);
-	virtual void UpdateDeck(DuelPlayer* dp, void* pdata, unsigned int len);
+	virtual void UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len);
 	virtual void StartDuel(DuelPlayer* dp);
 	virtual void HandResult(DuelPlayer* dp, unsigned char res);
 	virtual void TPResult(DuelPlayer* dp, unsigned char tp);

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -25,7 +25,7 @@ public:
 	virtual void Process();
 	virtual void Surrender(DuelPlayer* dp);
 	virtual int Analyze(unsigned char* msgbuffer, unsigned int len);
-	virtual void GetResponse(DuelPlayer* dp, void* pdata, unsigned int len);
+	virtual void GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len);
 	virtual void TimeConfirm(DuelPlayer* dp);
 	virtual void EndDuel();
 	

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -12,7 +12,7 @@ public:
 	TagDuel();
 	virtual ~TagDuel();
 	virtual void Chat(DuelPlayer* dp, unsigned char* pdata, int len);
-	virtual void JoinGame(DuelPlayer* dp, void* pdata, bool is_creater);
+	virtual void JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater);
 	virtual void LeaveGame(DuelPlayer* dp);
 	virtual void ToDuelist(DuelPlayer* dp);
 	virtual void ToObserver(DuelPlayer* dp);


### PR DESCRIPTION
-  use memcpy in DuelClient, NetServer 
-  replace memcpy with std::memcpy 

# Buffer overflow in current version
9570e838a0afc9630e478bb456656f5207708f59
Before:
The server will copy `packet_len + 2` bytes to buffer, where `packet_len` is sent by the client.
It will suffer from buffer overflow if the client sends a very large packet.
(crash and/or security issues)

Now:
The server will disconnect when the packet is too large .

e8209d5d38a6a3f8d8274d0b41be071bf006c32e
8d542df6cbe0856a439cf3528afd8171f78cdbae
Before:
The server did not check the length of current data before handling the current packet.
The server might read data from previous packet.

Now:
The server will check the packet before handling.

# Remove `struct STOC_Chat`
Before:
```cpp
struct STOC_Chat {
	unsigned short player;
	unsigned short msg[256];
};
```
The size of STOC_Chat: 2+512=514
But the length of almost every `msg` sent by server is less than 256.

If the length is 100, the buffer would be:
player: 2 bytes
msg: 100*2=200 bytes
(total: 202)

If the client treat this buffer as a `struct STOC_Chat`, it will go out of bounds.
It indicates that the buffer should be treated as a `uint_16` array, and `struct STOC_Chat` is unnecessary.

Now:
The buffer is treated as a `uint_16` array.
The buffer size is checked by 
```cpp
bool check_msg_size(int size);
```

# `bool` in `struct HostInfo` is replaced by `unsigned char`
https://en.cppreference.com/w/cpp/language/types
> bool — integer type, capable of holding one of the two values: true or false. The value of sizeof(bool) is implementation defined and might differ from 1. 

If we use struct to exchange data, the size of every member should be fixed.

# fix DuelMode::UpdateDeck() 
Before: 
```cpp
const unsigned int possibleMaxLength = (len - 8) / 4;
```
If len = 4U
possibleMaxLength =1073741823U
The check will fail.

Now:
Use signed integer compare
Check the value, alignment of `len`
Check the value of `mianc`, `sidec`
Check the value of `deck_size` 
fix #2314 

# Reference
edo9300/edopro@533b300


@mercury233 
@purerosefallen 

