### PR TITLE
allow 9-digit code for lflist

### DIFF
--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -35,7 +35,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 			int count = -1;
 			if (sscanf(linebuf, "%d %d", &code, &count) != 2)
 				continue;
-			if (code <= 0 || code > 99999999)
+			if (code <= 0 || code > 0xfffffff)
 				continue;
 			if (count < 0 || count > 2)
 				continue;


### PR DESCRIPTION
This is very popular in custom card or rush duel communities. So we have to change it back.