### PR TITLE
Use local variable in ServerEchoRead, ClientRead

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -19,8 +19,6 @@ unsigned char DuelClient::selftype = 0;
 bool DuelClient::is_host = false;
 event_base* DuelClient::client_base = 0;
 bufferevent* DuelClient::client_bev = 0;
-unsigned char DuelClient::duel_client_read[SIZE_NETWORK_BUFFER];
-int DuelClient::read_len = 0;
 unsigned char DuelClient::duel_client_write[SIZE_NETWORK_BUFFER];
 bool DuelClient::is_closing = false;
 bool DuelClient::is_swapping = false;
@@ -50,6 +48,7 @@ bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_g
 	sin.sin_addr.s_addr = htonl(ip);
 	sin.sin_port = htons(port);
 	client_bev = bufferevent_socket_new(client_base, -1, BEV_OPT_CLOSE_ON_FREE);
+	bufferevent_setwatermark(client_bev, EV_READ, 3, 0);
 	bufferevent_setcb(client_bev, ClientRead, NULL, ClientEvent, (void*)create_game);
 	if (bufferevent_socket_connect(client_bev, (sockaddr*)&sin, sizeof(sin)) < 0) {
 		bufferevent_free(client_bev);
@@ -100,24 +99,23 @@ void DuelClient::StopClient(bool is_exiting) {
 void DuelClient::ClientRead(bufferevent* bev, void* ctx) {
 	evbuffer* input = bufferevent_get_input(bev);
 	int len = evbuffer_get_length(input);
-	unsigned short packet_len = 0;
-	while(true) {
-		if(len < 2)
-			return;
-		evbuffer_copyout(input, &packet_len, 2);
+	unsigned char* duel_client_read = new unsigned char[std::min(len, SIZE_NETWORK_BUFFER)];
+	unsigned short packet_len;
+	while (len >= 2) {
+		evbuffer_copyout(input, &packet_len, sizeof packet_len);
 		if (packet_len + 2 > SIZE_NETWORK_BUFFER) {
+			delete[] duel_client_read;
 			ClientEvent(bev, BEV_EVENT_ERROR, 0);
 			return;
 		}
-		if(len < packet_len + 2)
-			return;
-		if (packet_len < 1)
-			return;
-		read_len = evbuffer_remove(input, duel_client_read, packet_len + 2);
+		if (len < packet_len + 2)
+			break;
+		int read_len = evbuffer_remove(input, duel_client_read, packet_len + 2);
 		if (read_len >= 3)
 			HandleSTOCPacketLan(&duel_client_read[2], read_len - 2);
 		len -= packet_len + 2;
 	}
+	delete[] duel_client_read;
 }
 void DuelClient::ClientEvent(bufferevent *bev, short events, void *ctx) {
 	if (events & BEV_EVENT_CONNECTED) {

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -21,8 +21,6 @@ private:
 	static bool is_host;
 	static event_base* client_base;
 	static bufferevent* client_bev;
-	static unsigned char duel_client_read[SIZE_NETWORK_BUFFER];
-	static int read_len;
 	static unsigned char duel_client_write[SIZE_NETWORK_BUFFER];
 	static bool is_closing;
 	static bool is_swapping;
@@ -56,13 +54,12 @@ public:
 	template<typename ST>
 	static void SendPacketToServer(unsigned char proto, ST& st) {
 		auto p = duel_client_write;
-		int blen = sizeof(ST);
-		if (blen > MAX_DATA_SIZE)
+		if ((int)sizeof(ST) > MAX_DATA_SIZE)
 			return;
-		BufferIO::WriteInt16(p, (short)(1 + blen));
+		BufferIO::WriteInt16(p, (short)(1 + sizeof(ST)));
 		BufferIO::WriteInt8(p, proto);
-		std::memcpy(p, &st, blen);
-		bufferevent_write(client_bev, duel_client_write, blen + 3);
+		std::memcpy(p, &st, sizeof(ST));
+		bufferevent_write(client_bev, duel_client_write, sizeof(ST) + 3);
 	}
 	static void SendBufferToServer(unsigned char proto, void* buffer, size_t len) {
 		auto p = duel_client_write;

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -9,8 +9,6 @@ event_base* NetServer::net_evbase = 0;
 event* NetServer::broadcast_ev = 0;
 evconnlistener* NetServer::listener = 0;
 DuelMode* NetServer::duel_mode = 0;
-unsigned char NetServer::net_server_read[SIZE_NETWORK_BUFFER];
-int NetServer::read_len = 0;
 unsigned char NetServer::net_server_write[SIZE_NETWORK_BUFFER];
 unsigned short NetServer::last_sent = 0;
 
@@ -109,6 +107,7 @@ void NetServer::ServerAccept(evconnlistener* listener, evutil_socket_t fd, socka
 	dp.type = 0xff;
 	dp.bev = bev;
 	users[bev] = dp;
+	bufferevent_setwatermark(bev, EV_READ, 3, 0);
 	bufferevent_setcb(bev, ServerEchoRead, NULL, ServerEchoEvent, NULL);
 	bufferevent_enable(bev, EV_READ);
 }
@@ -123,24 +122,23 @@ void NetServer::ServerAcceptError(evconnlistener* listener, void* ctx) {
 void NetServer::ServerEchoRead(bufferevent *bev, void *ctx) {
 	evbuffer* input = bufferevent_get_input(bev);
 	int len = evbuffer_get_length(input);
-	unsigned short packet_len = 0;
-	while(true) {
-		if(len < 2)
-			return;
-		evbuffer_copyout(input, &packet_len, 2);
+	unsigned char* net_server_read = new unsigned char[std::min(len, SIZE_NETWORK_BUFFER)];
+	unsigned short packet_len;
+	while (len >= 2) {
+		evbuffer_copyout(input, &packet_len, sizeof packet_len);
 		if (packet_len + 2 > SIZE_NETWORK_BUFFER) {
+			delete[] net_server_read;
 			ServerEchoEvent(bev, BEV_EVENT_ERROR, 0);
 			return;
 		}
 		if (len < packet_len + 2)
-			return;
-		if (packet_len < 1)
-			return;
-		read_len = evbuffer_remove(input, net_server_read, packet_len + 2);
+			break;
+		int read_len = evbuffer_remove(input, net_server_read, packet_len + 2);
 		if (read_len >= 3)
 			HandleCTOSPacket(&users[bev], &net_server_read[2], read_len - 2);
 		len -= packet_len + 2;
 	}
+	delete[] net_server_read;
 }
 void NetServer::ServerEchoEvent(bufferevent* bev, short events, void* ctx) {
 	if (events & (BEV_EVENT_EOF | BEV_EVENT_ERROR)) {

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -18,8 +18,6 @@ private:
 	static event* broadcast_ev;
 	static evconnlistener* listener;
 	static DuelMode* duel_mode;
-	static unsigned char net_server_read[SIZE_NETWORK_BUFFER];
-	static int read_len;
 	static unsigned char net_server_write[SIZE_NETWORK_BUFFER];
 	static unsigned short last_sent;
 
@@ -50,15 +48,14 @@ public:
 	template<typename ST>
 	static void SendPacketToPlayer(DuelPlayer* dp, unsigned char proto, ST& st) {
 		auto p = net_server_write;
-		int blen = sizeof(ST);
-		if (blen > MAX_DATA_SIZE)
+		if ((int)sizeof(ST) > MAX_DATA_SIZE)
 			return;
-		BufferIO::WriteInt16(p, (short)(1 + blen));
+		BufferIO::WriteInt16(p, (short)(1 + sizeof(ST)));
 		BufferIO::WriteInt8(p, proto);
-		std::memcpy(p, &st, blen);
-		last_sent = blen + 3;
+		std::memcpy(p, &st, sizeof(ST));
+		last_sent = sizeof(ST) + 3;
 		if (dp)
-			bufferevent_write(dp->bev, net_server_write, blen + 3);
+			bufferevent_write(dp->bev, net_server_write, sizeof(ST) + 3);
 	}
 	static void SendBufferToPlayer(DuelPlayer* dp, unsigned char proto, void* buffer, size_t len) {
 		auto p = net_server_write;

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1417,7 +1417,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 	return 0;
 }
 void SingleDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
-	byte resb[SIZE_RETURN_VALUE];
+	byte resb[SIZE_RETURN_VALUE]{};
 	if (len > SIZE_RETURN_VALUE)
 		len = SIZE_RETURN_VALUE;
 	std::memcpy(resb, pdata, len);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1532,7 +1532,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 	return 0;
 }
 void TagDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
-	byte resb[SIZE_RETURN_VALUE];
+	byte resb[SIZE_RETURN_VALUE]{};
 	if (len > SIZE_RETURN_VALUE)
 		len = SIZE_RETURN_VALUE;
 	std::memcpy(resb, pdata, len);


### PR DESCRIPTION
One of the problems found in #2551:
The server copies the packet of user A and user B into the same global array.
So the packet of A can be revealed or reused if the server did not check the packet of B very carefully.

Solution:
- The read callback functions use local variable now.
- Set the low watermark to 3, the min length of a normal packet.

@mercury233 
@purerosefallen 

