### PR TITLE
check sizeof deckBuffer in LoadDeck

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -31,7 +31,6 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <unistd.h>
-#include <locale.h>
 
 #define SD_BOTH 2
 #define SOCKET int

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -280,8 +280,8 @@ bool DeckManager::LoadDeck(const wchar_t* file, bool is_packlist) {
 	}
 	if(!reader)
 		return false;
-	size_t size = reader->getSize();
-	if(size >= 0x20000) {
+	auto size = reader->getSize();
+	if(size >= (int)sizeof deckBuffer) {
 		reader->drop();
 		return false;
 	}
@@ -296,7 +296,7 @@ bool DeckManager::LoadDeck(std::istringstream* deckStream, bool is_packlist) {
 	int cardlist[300];
 	bool is_side = false;
 	std::string linebuf;
-	while(std::getline(*deckStream, linebuf) && ct < 300) {
+	while(std::getline(*deckStream, linebuf, '\n') && ct < 300) {
 		if(linebuf[0] == '!') {
 			is_side = true;
 			continue;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -242,6 +242,8 @@ bool DeckManager::LoadDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUICom
 	bool res = LoadDeck(filepath, is_packlist);
 	if(res && mainGame->is_building)
 		mainGame->deckBuilder.RefreshPackListScroll();
+	if (!res)
+		current_deck.clear();
 	return res;
 }
 FILE* DeckManager::OpenDeckFile(const wchar_t* file, const char* mode) {

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -2,6 +2,7 @@
 #include "game.h"
 #include "data_manager.h"
 #include <event2/thread.h>
+#include <locale.h>
 #include <memory>
 #ifdef __APPLE__
 #import <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION
Problem:
The process will crash if a ydk file is bigger than 65535 and smaller than 131072.

Example:
[normal.zip](https://github.com/user-attachments/files/15751089/normal.zip)
normal.ydk
91656 Bytes


Fix:
- check sizeof deckBuffer in LoadDeck

- clear current_deck when selecting a wrong file

Before:
If a option of a corrupted file X is selected, `LoadDeck` will fail and do nothing.
The `current_deck` will show the content of the previous file.
The user cannot tell which one happened:
(a) The file X is corrupted.
(b) The content of file X is the same as the previous ydk file.  

After:
If a option of a corrupted file X is selected, `LoadDeck` will fail and clear `current_deck` .
The result is the same as selecting an empty file.


- `#include <locale.h>` is only included when necessary
https://en.cppreference.com/w/cpp/locale/setlocale
`setlocale` will modify the global state, so it should be used very, very carefully.
If we really want to use `setlocale`, it should be limited to the beginning of main().
revert 51aa89407bc107ede4bc9b56c97002fa9a7edca6


@mercury233 
@purerosefallen 
