### PR TITLE
clean config.h

### DIFF
--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -32,12 +32,12 @@ ClientCard::~ClientCard() {
 	}
 	overlayed.clear();
 }
-void ClientCard::SetCode(int code) {
-	if((location == LOCATION_HAND) && (this->code != (unsigned int)code)) {
-		this->code = code;
+void ClientCard::SetCode(int x) {
+	if((location == LOCATION_HAND) && (code != (unsigned int)x)) {
+		code = x;
 		mainGame->dField.MoveCard(this, 5);
 	} else
-		this->code = code;
+		code = x;
 }
 void ClientCard::UpdateInfo(unsigned char* buf) {
 	int flag = BufferIO::ReadInt32(buf);

--- a/gframe/client_card.h
+++ b/gframe/client_card.h
@@ -98,7 +98,7 @@ public:
 
 	ClientCard() = default;
 	~ClientCard();
-	void SetCode(int code);
+	void SetCode(int x);
 	void UpdateInfo(unsigned char* buf);
 	void ClearTarget();
 	void ClearData();

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -1,5 +1,5 @@
-#ifndef __CONFIG_H
-#define __CONFIG_H
+#ifndef YGOPRO_CONFIG_H
+#define YGOPRO_CONFIG_H
 
 #define _IRR_STATIC_LIB_
 #define IRR_COMPILE_WITH_DX9_DEV_PACK

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -56,13 +56,6 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 }
 
 #include <irrlicht.h>
-#ifdef __APPLE__
-#include <OpenGL/gl.h>
-#include <OpenGL/glu.h>
-#else //__APPLE__
-#include <GL/gl.h>
-#include <GL/glu.h>
-#endif //__APPLE__
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -39,13 +39,8 @@
 #define SOCKADDR sockaddr
 #define SOCKET_ERRNO() (errno)
 
-#include <wchar.h>
 #define mywcsncasecmp wcsncasecmp
 #define mystrncasecmp strncasecmp
-inline int _wtoi(const wchar_t * s) {
-	wchar_t * endptr;
-	return (int)wcstol(s, &endptr, 10);
-}
 #endif
 
 template<size_t N, typename... TR>
@@ -56,6 +51,7 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 #include <irrlicht.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <wchar.h>
 #include <iostream>
 #include <algorithm>
 #include <string>

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -1,8 +1,6 @@
 #ifndef __CONFIG_H
 #define __CONFIG_H
 
-#pragma once
-
 #define _IRR_STATIC_LIB_
 #define IRR_COMPILE_WITH_DX9_DEV_PACK
 #ifdef _WIN32

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -69,7 +69,6 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 #include <thread>
 #include <algorithm>
 #include "bufferio.h"
-#include "myfilesystem.h"
 #include "../ocgcore/ocgapi.h"
 #include "../ocgcore/common.h"
 

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -67,11 +67,9 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 #include <stdio.h>
 #include <stdlib.h>
 #include <thread>
-#include <mutex>
 #include <algorithm>
 #include "bufferio.h"
 #include "myfilesystem.h"
-#include "mysignal.h"
 #include "../ocgcore/ocgapi.h"
 #include "../ocgcore/common.h"
 

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -66,7 +66,6 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
-#include <thread>
 #include <algorithm>
 #include "bufferio.h"
 #include "../ocgcore/ocgapi.h"

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -63,12 +63,9 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 #include <GL/gl.h>
 #include <GL/glu.h>
 #endif //__APPLE__
-#include "CGUITTFont.h"
-#include "CGUIImageButton.h"
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 #include <thread>
 #include <mutex>
 #include <algorithm>

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -63,10 +63,11 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 #include <GL/gl.h>
 #include <GL/glu.h>
 #endif //__APPLE__
-#include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <iostream>
 #include <algorithm>
+#include <string>
 #include "bufferio.h"
 #include "../ocgcore/ocgapi.h"
 #include "../ocgcore/common.h"

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -127,7 +127,7 @@ bool DataManager::LoadStrings(IReadFile* reader) {
 	while(reader->read(&ch[0], 1)) {
 		if(ch[0] == '\0')
 			break;
-		strcat(linebuf, ch);
+		std::strcat(linebuf, ch);
 		if(ch[0] == '\n') {
 			ReadStringConfLine(linebuf);
 			linebuf[0] = '\0';
@@ -144,22 +144,22 @@ void DataManager::ReadStringConfLine(const char* linebuf) {
 	wchar_t strBuffer[4096]{};
 	if (sscanf(linebuf, "!%63s", strbuf) != 1)
 		return;
-	if(!strcmp(strbuf, "system")) {
+	if(!std::strcmp(strbuf, "system")) {
 		if (sscanf(&linebuf[7], "%d %240[^\n]", &value, strbuf) != 2)
 			return;
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_sysStrings[value] = strBuffer;
-	} else if(!strcmp(strbuf, "victory")) {
+	} else if(!std::strcmp(strbuf, "victory")) {
 		if (sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2)
 			return;
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_victoryStrings[value] = strBuffer;
-	} else if(!strcmp(strbuf, "counter")) {
+	} else if(!std::strcmp(strbuf, "counter")) {
 		if (sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2)
 			return;
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_counterStrings[value] = strBuffer;
-	} else if(!strcmp(strbuf, "setname")) {
+	} else if(!std::strcmp(strbuf, "setname")) {
 		//using tab for comment
 		if (sscanf(&linebuf[8], "%x %240[^\t\n]", &value, strbuf) != 2)
 			return;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "deck_con.h"
+#include "myfilesystem.h"
 #include "data_manager.h"
 #include "deck_manager.h"
 #include "image_manager.h"

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1301,12 +1301,12 @@ void DeckBuilder::GetHoveredCard() {
 	} else if(x >= 810 && x <= 995 && y >= 165 && y <= 626) {
 		hovered_pos = 4;
 		hovered_seq = (y - 165) / 66;
-		int pos = mainGame->scrFilter->getPos() + hovered_seq;
-		if(pos >= (int)results.size()) {
+		int current_pos = mainGame->scrFilter->getPos() + hovered_seq;
+		if(current_pos >= (int)results.size()) {
 			hovered_seq = -1;
 			hovered_code = 0;
 		} else {
-			hovered_code = results[pos]->first;
+			hovered_code = results[current_pos]->first;
 		}
 	}
 	if(is_draging) {

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -1,4 +1,5 @@
 #include "deck_manager.h"
+#include "myfilesystem.h"
 #include "data_manager.h"
 #include "network.h"
 #include "game.h"

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -225,7 +225,7 @@ void Game::DrawBackGround() {
 	}
 }
 void Game::DrawLinkedZones(ClientCard* pcard) {
-	int mark = pcard->link_marker;
+	auto mark = pcard->link_marker;
 	ClientCard* pcard2;
 	if (dField.hovered_sequence < 5) {
 		if (mark & LINK_MARKER_LEFT && dField.hovered_sequence > 0) {
@@ -242,25 +242,25 @@ void Game::DrawLinkedZones(ClientCard* pcard) {
 			if ((mark & LINK_MARKER_TOP_LEFT && dField.hovered_sequence == 2)
 				|| (mark & LINK_MARKER_TOP && dField.hovered_sequence == 1)
 				|| (mark & LINK_MARKER_TOP_RIGHT && dField.hovered_sequence == 0)) {
-				int mark = (dField.hovered_sequence == 2) ? LINK_MARKER_BOTTOM_RIGHT : (dField.hovered_sequence == 1) ? LINK_MARKER_BOTTOM : LINK_MARKER_BOTTOM_LEFT;
+				int arrow = (dField.hovered_sequence == 2) ? LINK_MARKER_BOTTOM_RIGHT : (dField.hovered_sequence == 1) ? LINK_MARKER_BOTTOM : LINK_MARKER_BOTTOM_LEFT;
 				pcard2 = dField.mzone[dField.hovered_controler][5];
 				if (!pcard2) {
 					pcard2 = dField.mzone[1 - dField.hovered_controler][6];
-					mark = (dField.hovered_sequence == 2) ? LINK_MARKER_TOP_LEFT : (dField.hovered_sequence == 1) ? LINK_MARKER_TOP : LINK_MARKER_TOP_RIGHT;
+					arrow = (dField.hovered_sequence == 2) ? LINK_MARKER_TOP_LEFT : (dField.hovered_sequence == 1) ? LINK_MARKER_TOP : LINK_MARKER_TOP_RIGHT;
 				}
-				CheckMutual(pcard2, mark);
+				CheckMutual(pcard2, arrow);
 				driver->drawVertexPrimitiveList(&matManager.vFieldMzone[dField.hovered_controler][5], 4, matManager.iRectangle, 2);
 			}
 			if ((mark & LINK_MARKER_TOP_LEFT && dField.hovered_sequence == 4)
 				|| (mark & LINK_MARKER_TOP && dField.hovered_sequence == 3)
 				|| (mark & LINK_MARKER_TOP_RIGHT && dField.hovered_sequence == 2)) {
-				int mark = (dField.hovered_sequence == 4) ? LINK_MARKER_BOTTOM_RIGHT : (dField.hovered_sequence == 3) ? LINK_MARKER_BOTTOM : LINK_MARKER_BOTTOM_LEFT;
+				int arrow = (dField.hovered_sequence == 4) ? LINK_MARKER_BOTTOM_RIGHT : (dField.hovered_sequence == 3) ? LINK_MARKER_BOTTOM : LINK_MARKER_BOTTOM_LEFT;
 				pcard2 = dField.mzone[dField.hovered_controler][6];
 				if (!pcard2) {
 					pcard2 = dField.mzone[1 - dField.hovered_controler][5];
-					mark = (dField.hovered_sequence == 4) ? LINK_MARKER_TOP_LEFT : (dField.hovered_sequence == 3) ? LINK_MARKER_TOP : LINK_MARKER_TOP_RIGHT;
+					arrow = (dField.hovered_sequence == 4) ? LINK_MARKER_TOP_LEFT : (dField.hovered_sequence == 3) ? LINK_MARKER_TOP : LINK_MARKER_TOP_RIGHT;
 				}
-				CheckMutual(pcard2, mark);
+				CheckMutual(pcard2, arrow);
 				driver->drawVertexPrimitiveList(&matManager.vFieldMzone[dField.hovered_controler][6], 4, matManager.iRectangle, 2);
 			}
 		}

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1,4 +1,11 @@
 #include "game.h"
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+#else //__APPLE__
+#include <GL/gl.h>
+#include <GL/glu.h>
+#endif //__APPLE__
 #include "materials.h"
 #include "image_manager.h"
 #include "deck_manager.h"

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1,11 +1,4 @@
 #include "game.h"
-#ifdef __APPLE__
-#include <OpenGL/gl.h>
-#include <OpenGL/glu.h>
-#else //__APPLE__
-#include <GL/gl.h>
-#include <GL/glu.h>
-#endif //__APPLE__
 #include "materials.h"
 #include "image_manager.h"
 #include "deck_manager.h"

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -62,8 +62,8 @@ bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_g
 	rnd.reset((uint_fast32_t)std::random_device()());
 	if(!create_game) {
 		timeval timeout = {5, 0};
-		event* resp_event = event_new(client_base, 0, EV_TIMEOUT, ConnectTimeout, 0);
-		event_add(resp_event, &timeout);
+		event* timeout_event = event_new(client_base, 0, EV_TIMEOUT, ConnectTimeout, 0);
+		event_add(timeout_event, &timeout);
 	}
 	std::thread(ClientThread).detach();
 	return true;
@@ -1403,8 +1403,8 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 			else if (pcard->location == LOCATION_EXTRA)
 				mainGame->dField.extra_act = true;
 			else {
-				int seq = mainGame->dInfo.duel_rule >= 4 ? 0 : 6;
-				if (pcard->location == LOCATION_SZONE && pcard->sequence == seq && (pcard->type & TYPE_PENDULUM) && !pcard->equipTarget)
+				int left_seq = mainGame->dInfo.duel_rule >= 4 ? 0 : 6;
+				if (pcard->location == LOCATION_SZONE && pcard->sequence == left_seq && (pcard->type & TYPE_PENDULUM) && !pcard->equipTarget)
 					mainGame->dField.pzone_act[pcard->controler] = true;
 			}
 		}
@@ -3149,8 +3149,8 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 				pcard = mainGame->dField.GetCard(player, LOCATION_DECK, mainGame->dField.deck[player].size() - 1);
 				mainGame->dField.deck[player].erase(mainGame->dField.deck[player].end() - 1);
 				mainGame->dField.AddCard(pcard, player, LOCATION_HAND, 0);
-				for(size_t i = 0; i < mainGame->dField.hand[player].size(); ++i)
-					mainGame->dField.MoveCard(mainGame->dField.hand[player][i], 10);
+				for(int j = 0; j < (int)mainGame->dField.hand[player].size(); ++j)
+					mainGame->dField.MoveCard(mainGame->dField.hand[player][j], 10);
 				mainGame->gMutex.unlock();
 				mainGame->WaitFrameSignal(5);
 			}

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -145,10 +145,10 @@ void DuelClient::ClientEvent(bufferevent *bev, short events, void *ctx) {
 				BufferIO::CopyWStr(mainGame->ebServerPass->getText(), cscg.pass, 20);
 				cscg.info.rule = mainGame->cbRule->getSelected();
 				cscg.info.mode = mainGame->cbMatchMode->getSelected();
-				cscg.info.start_hand = _wtoi(mainGame->ebStartHand->getText());
-				cscg.info.start_lp = _wtoi(mainGame->ebStartLP->getText());
-				cscg.info.draw_count = _wtoi(mainGame->ebDrawCount->getText());
-				cscg.info.time_limit = _wtoi(mainGame->ebTimeLimit->getText());
+				cscg.info.start_hand = wcstol(mainGame->ebStartHand->getText(),nullptr,10);
+				cscg.info.start_lp = wcstol(mainGame->ebStartLP->getText(),nullptr,10);
+				cscg.info.draw_count = wcstol(mainGame->ebDrawCount->getText(),nullptr,10);
+				cscg.info.time_limit = wcstol(mainGame->ebTimeLimit->getText(),nullptr,10);
 				cscg.info.lflist = mainGame->cbHostLFlist->getItemData(mainGame->cbHostLFlist->getSelected());
 				cscg.info.duel_rule = mainGame->cbDuelRule->getSelected() + 1;
 				cscg.info.no_check_deck = mainGame->chkNoCheckDeck->isChecked();

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -8,6 +8,7 @@
 #include "game.h"
 #include "replay.h"
 #include "replay_mode.h"
+#include <thread>
 
 namespace ygo {
 

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -1456,7 +1456,6 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					DuelClient::SetResponseB(respbuf, selectable_cards.size() * 2);
 					DuelClient::SendResponse();
 				} else {
-					wchar_t formatBuffer[2048];
 					myswprintf(formatBuffer, dataManager.GetSysString(204), select_counter_count, dataManager.GetCounterName(select_counter_type));
 					mainGame->stHintMsg->setText(formatBuffer);
 				}
@@ -1665,8 +1664,8 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 							player_name = mainGame->dInfo.clientname_tag;
 					}
 					std::wstring str(player_name);
-					const auto& player_desc_hints = mainGame->dField.player_desc_hints[mplayer];
-					for(auto iter = player_desc_hints.begin(); iter != player_desc_hints.end(); ++iter) {
+					const auto& mplayer_hints = mainGame->dField.player_desc_hints[mplayer];
+					for(auto iter = mplayer_hints.begin(); iter != mplayer_hints.end(); ++iter) {
 						myswprintf(formatBuffer, L"\n*%ls", dataManager.GetDesc(iter->first));
 						str.append(formatBuffer);
 					}

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "game.h"
+#include "myfilesystem.h"
 #include "image_manager.h"
 #include "data_manager.h"
 #include "deck_manager.h"

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1284,10 +1284,10 @@ void Game::RefreshBot() {
 				BufferIO::DecodeUTF8(strbuf, newinfo.desc);
 				if (!fgets(linebuf, 256, fp))
 					break;
-				newinfo.support_master_rule_3 = !!strstr(linebuf, "SUPPORT_MASTER_RULE_3");
-				newinfo.support_new_master_rule = !!strstr(linebuf, "SUPPORT_NEW_MASTER_RULE");
-				newinfo.support_master_rule_2020 = !!strstr(linebuf, "SUPPORT_MASTER_RULE_2020");
-				newinfo.select_deckfile = !!strstr(linebuf, "SELECT_DECKFILE");
+				newinfo.support_master_rule_3 = !!std::strstr(linebuf, "SUPPORT_MASTER_RULE_3");
+				newinfo.support_new_master_rule = !!std::strstr(linebuf, "SUPPORT_NEW_MASTER_RULE");
+				newinfo.support_master_rule_2020 = !!std::strstr(linebuf, "SUPPORT_MASTER_RULE_2020");
+				newinfo.select_deckfile = !!std::strstr(linebuf, "SELECT_DECKFILE");
 				int rule = cbBotRule->getSelected() + 3;
 				if((rule == 3 && newinfo.support_master_rule_3)
 					|| (rule == 4 && newinfo.support_new_master_rule)
@@ -1323,137 +1323,137 @@ void Game::LoadConfig() {
 	while(fgets(linebuf, 256, fp)) {
 		if (sscanf(linebuf, "%63s = %255s", strbuf, valbuf) != 2)
 			continue;
-		if(!strcmp(strbuf, "antialias")) {
+		if(!std::strcmp(strbuf, "antialias")) {
 			gameConf.antialias = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "use_d3d")) {
+		} else if(!std::strcmp(strbuf, "use_d3d")) {
 			gameConf.use_d3d = strtol(valbuf, nullptr, 10) > 0;
-		} else if(!strcmp(strbuf, "use_image_scale")) {
+		} else if(!std::strcmp(strbuf, "use_image_scale")) {
 			gameConf.use_image_scale = strtol(valbuf, nullptr, 10) > 0;
-		} else if(!strcmp(strbuf, "errorlog")) {
+		} else if(!std::strcmp(strbuf, "errorlog")) {
 			unsigned int val = strtol(valbuf, nullptr, 10);
 			enable_log = val & 0xff;
-		} else if(!strcmp(strbuf, "textfont")) {
+		} else if(!std::strcmp(strbuf, "textfont")) {
 			int textfontsize = 0;
 			if (sscanf(linebuf, "%63s = %255s %d", strbuf, valbuf, &textfontsize) != 3)
 				continue;
 			gameConf.textfontsize = textfontsize;
 			BufferIO::DecodeUTF8(valbuf, wstr);
 			BufferIO::CopyWStr(wstr, gameConf.textfont, 256);
-		} else if(!strcmp(strbuf, "numfont")) {
+		} else if(!std::strcmp(strbuf, "numfont")) {
 			BufferIO::DecodeUTF8(valbuf, wstr);
 			BufferIO::CopyWStr(wstr, gameConf.numfont, 256);
-		} else if(!strcmp(strbuf, "serverport")) {
+		} else if(!std::strcmp(strbuf, "serverport")) {
 			gameConf.serverport = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "lasthost")) {
+		} else if(!std::strcmp(strbuf, "lasthost")) {
 			BufferIO::DecodeUTF8(valbuf, wstr);
 			BufferIO::CopyWStr(wstr, gameConf.lasthost, 100);
-		} else if(!strcmp(strbuf, "lastport")) {
+		} else if(!std::strcmp(strbuf, "lastport")) {
 			BufferIO::DecodeUTF8(valbuf, wstr);
 			BufferIO::CopyWStr(wstr, gameConf.lastport, 20);
-		} else if(!strcmp(strbuf, "roompass")) {
+		} else if(!std::strcmp(strbuf, "roompass")) {
 			BufferIO::DecodeUTF8(valbuf, wstr);
 			BufferIO::CopyWStr(wstr, gameConf.roompass, 20);
-		} else if(!strcmp(strbuf, "automonsterpos")) {
+		} else if(!std::strcmp(strbuf, "automonsterpos")) {
 			gameConf.chkMAutoPos = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "autospellpos")) {
+		} else if(!std::strcmp(strbuf, "autospellpos")) {
 			gameConf.chkSTAutoPos = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "randompos")) {
+		} else if(!std::strcmp(strbuf, "randompos")) {
 			gameConf.chkRandomPos = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "autochain")) {
+		} else if(!std::strcmp(strbuf, "autochain")) {
 			gameConf.chkAutoChain = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "waitchain")) {
+		} else if(!std::strcmp(strbuf, "waitchain")) {
 			gameConf.chkWaitChain = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "showchain")) {
+		} else if(!std::strcmp(strbuf, "showchain")) {
 			gameConf.chkDefaultShowChain = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "mute_opponent")) {
+		} else if(!std::strcmp(strbuf, "mute_opponent")) {
 			gameConf.chkIgnore1 = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "mute_spectators")) {
+		} else if(!std::strcmp(strbuf, "mute_spectators")) {
 			gameConf.chkIgnore2 = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "use_lflist")) {
+		} else if(!std::strcmp(strbuf, "use_lflist")) {
 			gameConf.use_lflist = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "default_lflist")) {
+		} else if(!std::strcmp(strbuf, "default_lflist")) {
 			gameConf.default_lflist = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "default_rule")) {
+		} else if(!std::strcmp(strbuf, "default_rule")) {
 			gameConf.default_rule = strtol(valbuf, nullptr, 10);
 			if(gameConf.default_rule <= 0)
 				gameConf.default_rule = DEFAULT_DUEL_RULE;
-		} else if(!strcmp(strbuf, "hide_setname")) {
+		} else if(!std::strcmp(strbuf, "hide_setname")) {
 			gameConf.hide_setname = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "hide_hint_button")) {
+		} else if(!std::strcmp(strbuf, "hide_hint_button")) {
 			gameConf.hide_hint_button = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "control_mode")) {
+		} else if(!std::strcmp(strbuf, "control_mode")) {
 			gameConf.control_mode = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "draw_field_spell")) {
+		} else if(!std::strcmp(strbuf, "draw_field_spell")) {
 			gameConf.draw_field_spell = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "separate_clear_button")) {
+		} else if(!std::strcmp(strbuf, "separate_clear_button")) {
 			gameConf.separate_clear_button = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "auto_search_limit")) {
+		} else if(!std::strcmp(strbuf, "auto_search_limit")) {
 			gameConf.auto_search_limit = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "search_multiple_keywords")) {
+		} else if(!std::strcmp(strbuf, "search_multiple_keywords")) {
 			gameConf.search_multiple_keywords = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "ignore_deck_changes")) {
+		} else if(!std::strcmp(strbuf, "ignore_deck_changes")) {
 			gameConf.chkIgnoreDeckChanges = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "default_ot")) {
+		} else if(!std::strcmp(strbuf, "default_ot")) {
 			gameConf.defaultOT = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "enable_bot_mode")) {
+		} else if(!std::strcmp(strbuf, "enable_bot_mode")) {
 			gameConf.enable_bot_mode = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "quick_animation")) {
+		} else if(!std::strcmp(strbuf, "quick_animation")) {
 			gameConf.quick_animation = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "auto_save_replay")) {
+		} else if(!std::strcmp(strbuf, "auto_save_replay")) {
 			gameConf.auto_save_replay = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "draw_single_chain")) {
+		} else if(!std::strcmp(strbuf, "draw_single_chain")) {
 			gameConf.draw_single_chain = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "hide_player_name")) {
+		} else if(!std::strcmp(strbuf, "hide_player_name")) {
 			gameConf.hide_player_name = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "prefer_expansion_script")) {
+		} else if(!std::strcmp(strbuf, "prefer_expansion_script")) {
 			gameConf.prefer_expansion_script = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "window_maximized")) {
+		} else if(!std::strcmp(strbuf, "window_maximized")) {
 			gameConf.window_maximized = strtol(valbuf, nullptr, 10) > 0;
-		} else if(!strcmp(strbuf, "window_width")) {
+		} else if(!std::strcmp(strbuf, "window_width")) {
 			gameConf.window_width = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "window_height")) {
+		} else if(!std::strcmp(strbuf, "window_height")) {
 			gameConf.window_height = strtol(valbuf, nullptr, 10);
-		} else if(!strcmp(strbuf, "resize_popup_menu")) {
+		} else if(!std::strcmp(strbuf, "resize_popup_menu")) {
 			gameConf.resize_popup_menu = strtol(valbuf, nullptr, 10) > 0;
 #ifdef YGOPRO_USE_IRRKLANG
-		} else if(!strcmp(strbuf, "enable_sound")) {
+		} else if(!std::strcmp(strbuf, "enable_sound")) {
 			gameConf.enable_sound = strtol(valbuf, nullptr, 10) > 0;
-		} else if(!strcmp(strbuf, "sound_volume")) {
+		} else if(!std::strcmp(strbuf, "sound_volume")) {
 			int vol = strtol(valbuf, nullptr, 10);
 			if (vol < 0)
 				vol = 0;
 			else if (vol > 100)
 				vol = 100;
 			gameConf.sound_volume = (double)vol / 100;
-		} else if(!strcmp(strbuf, "enable_music")) {
+		} else if(!std::strcmp(strbuf, "enable_music")) {
 			gameConf.enable_music = strtol(valbuf, nullptr, 10) > 0;
-		} else if(!strcmp(strbuf, "music_volume")) {
+		} else if(!std::strcmp(strbuf, "music_volume")) {
 			int vol = strtol(valbuf, nullptr, 10);
 			if (vol < 0)
 				vol = 0;
 			else if (vol > 100)
 				vol = 100;
 			gameConf.music_volume = (double)vol / 100;
-		} else if(!strcmp(strbuf, "music_mode")) {
+		} else if(!std::strcmp(strbuf, "music_mode")) {
 			gameConf.music_mode = strtol(valbuf, nullptr, 10);
 #endif
 		} else {
 			// options allowing multiple words
 			if (sscanf(linebuf, "%63s = %240[^\n]", strbuf, valbuf) != 2)
 				continue;
-			if (!strcmp(strbuf, "nickname")) {
+			if (!std::strcmp(strbuf, "nickname")) {
 				BufferIO::DecodeUTF8(valbuf, wstr);
 				BufferIO::CopyWStr(wstr, gameConf.nickname, 20);
-			} else if (!strcmp(strbuf, "gamename")) {
+			} else if (!std::strcmp(strbuf, "gamename")) {
 				BufferIO::DecodeUTF8(valbuf, wstr);
 				BufferIO::CopyWStr(wstr, gameConf.gamename, 20);
-			} else if (!strcmp(strbuf, "lastcategory")) {
+			} else if (!std::strcmp(strbuf, "lastcategory")) {
 				BufferIO::DecodeUTF8(valbuf, wstr);
 				BufferIO::CopyWStr(wstr, gameConf.lastcategory, 64);
-			} else if (!strcmp(strbuf, "lastdeck")) {
+			} else if (!std::strcmp(strbuf, "lastdeck")) {
 				BufferIO::DecodeUTF8(valbuf, wstr);
 				BufferIO::CopyWStr(wstr, gameConf.lastdeck, 64);
-			} else if(!strcmp(strbuf, "bot_deck_path")) {
+			} else if(!std::strcmp(strbuf, "bot_deck_path")) {
 				BufferIO::DecodeUTF8(valbuf, wstr);
 				BufferIO::CopyWStr(wstr, gameConf.bot_deck_path, 64);
 			}

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -2,6 +2,13 @@
 #define GAME_H
 
 #include "config.h"
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+#else //__APPLE__
+#include <GL/gl.h>
+#include <GL/glu.h>
+#endif //__APPLE__
 #include "CGUIImageButton.h"
 #include "CGUITTFont.h"
 #include "mysignal.h"

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -4,6 +4,7 @@
 #include "config.h"
 #include "CGUIImageButton.h"
 #include "CGUITTFont.h"
+#include "mysignal.h"
 #include "client_field.h"
 #include "deck_con.h"
 #include "menu_handler.h"
@@ -11,6 +12,7 @@
 #include <unordered_map>
 #include <vector>
 #include <list>
+#include <mutex>
 
 #define DEFAULT_DUEL_RULE 5
 

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <list>
 #include <mutex>
+#include <functional>
 
 #define DEFAULT_DUEL_RULE 5
 

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -2,9 +2,12 @@
 #define GAME_H
 
 #include "config.h"
+#include "CGUIImageButton.h"
+#include "CGUITTFont.h"
 #include "client_field.h"
 #include "deck_con.h"
 #include "menu_handler.h"
+#include <time.h>
 #include <unordered_map>
 #include <vector>
 #include <list>

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
 #ifdef _WIN32
 #ifndef _DEBUG
 	char* pstrext;
-	if(argc == 2 && (pstrext = strrchr(argv[1], '.'))
+	if(argc == 2 && (pstrext = std::strrchr(argv[1], '.'))
 		&& (!mystrncasecmp(pstrext, ".ydk", 4) || !mystrncasecmp(pstrext, ".yrp", 4))) {
 		wchar_t exepath[MAX_PATH];
 		GetModuleFileNameW(NULL, exepath, MAX_PATH);

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -1,5 +1,6 @@
 #include "image_manager.h"
 #include "game.h"
+#include <thread>
 
 namespace ygo {
 

--- a/gframe/image_manager.h
+++ b/gframe/image_manager.h
@@ -5,6 +5,7 @@
 #include "data_manager.h"
 #include <unordered_map>
 #include <queue>
+#include <mutex>
 
 namespace ygo {
 

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -162,14 +162,14 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_HP_KICK: {
-				int id = 0;
-				while(id < 4) {
-					if(mainGame->btnHostPrepKick[id] == caller)
+				int index = 0;
+				while(index < 4) {
+					if(mainGame->btnHostPrepKick[index] == caller)
 						break;
-					id++;
+					++index;
 				}
 				CTOS_Kick csk;
-				csk.pos = id;
+				csk.pos = index;
 				DuelClient::SendPacketToServer(CTOS_HS_KICK, csk);
 				break;
 			}

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "menu_handler.h"
+#include "myfilesystem.h"
 #include "netserver.h"
 #include "duelclient.h"
 #include "deck_manager.h"

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -97,7 +97,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 						evutil_freeaddrinfo(answer);
 					}
 				}
-				unsigned int remote_port = _wtoi(mainGame->ebJoinPort->getText());
+				unsigned int remote_port = wcstol(mainGame->ebJoinPort->getText(), nullptr, 10);
 				BufferIO::CopyWStr(pstr, mainGame->gameConf.lasthost, 100);
 				BufferIO::CopyWStr(mainGame->ebJoinPort->getText(), mainGame->gameConf.lastport, 20);
 				if(DuelClient::StartClient(remote_addr, remote_port, false)) {
@@ -253,7 +253,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				mainGame->dField.Clear();
 				mainGame->HideElement(mainGame->wReplay);
 				mainGame->device->setEventReceiver(&mainGame->dField);
-				unsigned int start_turn = _wtoi(mainGame->ebRepStartTurn->getText());
+				unsigned int start_turn = wcstol(mainGame->ebRepStartTurn->getText(), nullptr, 10);
 				if(start_turn == 1)
 					start_turn = 0;
 				ReplayMode::StartReplay(start_turn);

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -587,9 +587,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				std::wstring message = L"";
 				bool in_message = false;
 				while(fgets(linebuf, 1024, fp)) {
-					if(!strncmp(linebuf, "--[[message", 11)) {
-						size_t len = strlen(linebuf);
-						char* msgend = strrchr(linebuf, ']');
+					if(!std::strncmp(linebuf, "--[[message", 11)) {
+						size_t len = std::strlen(linebuf);
+						char* msgend = std::strrchr(linebuf, ']');
 						if(len <= 13) {
 							in_message = true;
 							continue;
@@ -600,7 +600,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 							break;
 						}
 					}
-					if(!strncmp(linebuf, "]]", 2)) {
+					if(!std::strncmp(linebuf, "]]", 2)) {
 						in_message = false;
 						break;
 					}

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -1,6 +1,7 @@
 #include "netserver.h"
 #include "single_duel.h"
 #include "tag_duel.h"
+#include <thread>
 
 namespace ygo {
 std::unordered_map<bufferevent*, DuelPlayer> NetServer::users;

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -1,4 +1,5 @@
 #include "replay.h"
+#include "myfilesystem.h"
 #include "lzma/LzmaLib.h"
 
 namespace ygo {

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -3,6 +3,7 @@
 #include "game.h"
 #include "../ocgcore/common.h"
 #include "../ocgcore/mtrandom.h"
+#include <thread>
 
 namespace ygo {
 

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -3,6 +3,7 @@
 #include "game.h"
 #include "../ocgcore/common.h"
 #include "../ocgcore/mtrandom.h"
+#include <thread>
 
 namespace ygo {
 

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -1,4 +1,5 @@
 #include "sound_manager.h"
+#include "myfilesystem.h"
 #ifdef IRRKLANG_STATIC
 #include "../ikpmp3/ikpMP3.h"
 #endif


### PR DESCRIPTION
CGUITTFont.h
CGUIImageButton.h
mysignal.h
They are only used in `class game`.

myfilesystem.h
It is used in less than 10 files.
`#include "myfilesystem.h"` are moved to those files.


<time.h>
moved to `game.h`

<thread>
<mutex>
include when necessary

GL library
It is only used in `drawing.cpp`.
moved to `game.h`.

Add:
#include <string>
Some files might include <string> indirectly before.
The including path:
CGUITTFont.h
->irrUString.h
-> string


Rename guard macro:
https://gcc.gnu.org/onlinedocs/cpp/Once-Only-Headers.html
> In a user header file, the macro name should not begin with ‘_’. 
> In a system header file, it should begin with ‘__’ to avoid conflicts with user programs. 
> In any kind of header file, the macro name should contain the name of the file and some additional text, to avoid conflicts with other header files. 

Now the guard macro is YGOPRO_CONFIG_H following the GCC convention.
`#pragma once` is removed.

Test:
It can be built in VS 2022.
Maybe you can test it in GCC?



@mercury233 
@purerosefallen 

