### PR TITLE
use safe filename in Replay::SaveReplay

### DIFF
--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -138,8 +138,11 @@ void Replay::EndRecord() {
 void Replay::SaveReplay(const wchar_t* name) {
 	if(!FileSystem::IsDirExists(L"./replay") && !FileSystem::MakeDir(L"./replay"))
 		return;
+	wchar_t safe_name[256];
 	wchar_t fname[256];
-	myswprintf(fname, L"./replay/%ls.yrp", name);
+	BufferIO::CopyWStr(name, safe_name, 256);
+	FileSystem::SafeFileName(safe_name);
+	myswprintf(fname, L"./replay/%ls.yrp", safe_name);
 #ifdef WIN32
 	fp = _wfopen(fname, L"wb");
 #else


### PR DESCRIPTION
Save the replay with filename `1*2*3`

Before:
The replay file is not created.

After:
The replay file is created with filename `1_2_3.yrp`.

@mercury233 
@purerosefallen 
