### PR TITLE
use UTF-8 locale

### DIFF
--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -247,15 +247,9 @@ bool DeckManager::LoadDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUICom
 	return res;
 }
 FILE* DeckManager::OpenDeckFile(const wchar_t* file, const char* mode) {
-#ifdef WIN32
-	wchar_t wmode[20]{};
-	BufferIO::CopyWStr(mode, wmode, sizeof(wmode) / sizeof(wchar_t));
-	FILE* fp = _wfopen(file, wmode);
-#else
-	char file2[256];
+	char file2[256]{};
 	BufferIO::EncodeUTF8(file, file2);
 	FILE* fp = fopen(file2, mode);
-#endif
 	return fp;
 }
 IReadFile* DeckManager::OpenDeckReader(const wchar_t* file) {

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -23,9 +23,7 @@ void ClickButton(irr::gui::IGUIElement* btn) {
 }
 
 int main(int argc, char* argv[]) {
-#ifndef _WIN32
-	setlocale(LC_CTYPE, "UTF-8");
-#endif
+	setlocale(LC_ALL, ".UTF-8");
 #ifdef __APPLE__
 	CFURLRef bundle_url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
 	CFURLRef bundle_base_url = CFURLCreateCopyDeletingLastPathComponent(NULL, bundle_url);

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -570,13 +570,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				wchar_t fname[256];
 				myswprintf(fname, L"./single/%ls", name);
 				FILE *fp;
-#ifdef _WIN32
-				fp = _wfopen(fname, L"rb");
-#else
 				char filename[256];
 				BufferIO::EncodeUTF8(fname, filename);
 				fp = fopen(filename, "rb");
-#endif
 				if(!fp) {
 					mainGame->stSinglePlayInfo->setText(L"");
 					break;

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -142,7 +142,7 @@ void Replay::SaveReplay(const wchar_t* name) {
 	myswprintf(fname, L"./replay/%ls.yrp", name);
 	char fname2[256];
 	BufferIO::EncodeUTF8(fname, fname2);
-	fp = fopen(fname2, "wb");
+	FILE* fp = fopen(fname2, "wb");
 	if(!fp)
 		return;
 	fwrite(&pheader, sizeof(pheader), 1, fp);
@@ -150,13 +150,13 @@ void Replay::SaveReplay(const wchar_t* name) {
 	fclose(fp);
 }
 bool Replay::OpenReplay(const wchar_t* name) {
-	char name2[256];
+	char name2[256]{};
 	BufferIO::EncodeUTF8(name, name2);
-	fp = fopen(name2, "rb");
+	FILE* fp = fopen(name2, "rb");
 	if(!fp) {
-		wchar_t fname[256];
+		wchar_t fname[256]{};
 		myswprintf(fname, L"./replay/%ls", name);
-		char fname2[256];
+		char fname2[256]{};
 		BufferIO::EncodeUTF8(fname, fname2);
 		fp = fopen(fname2, "rb");
 	}

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -140,13 +140,9 @@ void Replay::SaveReplay(const wchar_t* name) {
 		return;
 	wchar_t fname[256];
 	myswprintf(fname, L"./replay/%ls.yrp", name);
-#ifdef WIN32
-	fp = _wfopen(fname, L"wb");
-#else
 	char fname2[256];
 	BufferIO::EncodeUTF8(fname, fname2);
 	fp = fopen(fname2, "wb");
-#endif
 	if(!fp)
 		return;
 	fwrite(&pheader, sizeof(pheader), 1, fp);
@@ -154,23 +150,15 @@ void Replay::SaveReplay(const wchar_t* name) {
 	fclose(fp);
 }
 bool Replay::OpenReplay(const wchar_t* name) {
-#ifdef WIN32
-	fp = _wfopen(name, L"rb");
-#else
 	char name2[256];
 	BufferIO::EncodeUTF8(name, name2);
 	fp = fopen(name2, "rb");
-#endif
 	if(!fp) {
 		wchar_t fname[256];
 		myswprintf(fname, L"./replay/%ls", name);
-#ifdef WIN32
-		fp = _wfopen(fname, L"rb");
-#else
 		char fname2[256];
 		BufferIO::EncodeUTF8(fname, fname2);
 		fp = fopen(fname2, "rb");
-#endif
 	}
 	if(!fp)
 		return false;
@@ -207,13 +195,9 @@ bool Replay::OpenReplay(const wchar_t* name) {
 bool Replay::CheckReplay(const wchar_t* name) {
 	wchar_t fname[256];
 	myswprintf(fname, L"./replay/%ls", name);
-#ifdef WIN32
-	FILE* rfp = _wfopen(fname, L"rb");
-#else
 	char fname2[256];
 	BufferIO::EncodeUTF8(fname, fname2);
 	FILE* rfp = fopen(fname2, "rb");
-#endif
 	if(!rfp)
 		return false;
 	ReplayHeader rheader;

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -56,10 +56,7 @@ public:
 	char ReadInt8();
 	void Rewind();
 
-	FILE* fp{ nullptr };
-#ifdef _WIN32
-	HANDLE recording_fp{ nullptr };
-#endif
+	FILE* recording_fp{ nullptr };
 
 	ReplayHeader pheader;
 	unsigned char* replay_data;


### PR DESCRIPTION
https://learn.microsoft.com/en-us/cpp/porting/upgrade-your-code-to-the-universal-crt?view=msvc-170
The Microsoft C Runtime Library (CRT) was refactored in Visual Studio 2015. The Standard C Library, POSIX extensions and Microsoft-specific functions, macros, and global variables were moved into a new library, the Universal C Runtime Library (Universal CRT or UCRT). The compiler-specific components of the CRT were moved into a new vcruntime library.

The UCRT is now a Windows component, and ships as part of Windows 10 and later. The UCRT supports a stable ABI based on C calling conventions, and it conforms closely to the ISO C99 standard, with only a few exceptions.

Because the UCRT is now a Microsoft Windows operating system component, it's included as part of the operating system in Windows 10 and later. It's available through Windows Update for older operating systems, Windows Vista through Windows 8.1. A Redistributable version is available for Windows XP. As an operating system component, UCRT updates and servicing are managed by Windows Update independently of Visual Studio and Microsoft C++ compiler versions.

https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setlocale-wsetlocale?view=msvc-170#utf-8-support
Starting in Windows 10 version 1803 (10.0.17134.0), the Universal C Runtime supports using a UTF-8 code page. The change means that char strings passed to C runtime functions can expect strings in the UTF-8 encoding. To enable UTF-8 mode, use ".UTF8" as the code page when using setlocale. For example, setlocale(LC_ALL, ".UTF8") uses the current default Windows ANSI code page (ACP) for the locale and UTF-8 for the code page.

----
Now we can use UTF8 locale on Windows, and the UCRT is available for older opearting systems too.
Now we can open all files with `fopen`.


@mercury233 
@purerosefallen 
