### PR TITLE
deckManager: add LoadCurrentDeck, SaveDeckBuffer

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -461,7 +461,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					}
 					for(int i = 0; i < (int)mainGame->lstDecks->getItemCount(); i++) {
 						if(!mywcsncasecmp(mainGame->lstDecks->getListItem(i), deckname, 256)) {
-							deckManager.LoadDeck(filepath);
+							deckManager.LoadCurrentDeck(filepath);
 							prev_deck = i;
 							mainGame->cbDBDecks->setSelected(prev_deck);
 							mainGame->lstDecks->setSelected(prev_deck);
@@ -495,7 +495,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					ChangeCategory(catesel);
 					for(int i = 0; i < (int)mainGame->lstDecks->getItemCount(); i++) {
 						if(!mywcsncasecmp(mainGame->lstDecks->getListItem(i), newdeckname, 256)) {
-							deckManager.LoadDeck(newfilepath);
+							deckManager.LoadCurrentDeck(newfilepath);
 							prev_deck = i;
 							mainGame->cbDBDecks->setSelected(prev_deck);
 							mainGame->lstDecks->setSelected(prev_deck);
@@ -522,7 +522,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 						if(decksel != -1) {
 							mainGame->lstDecks->setSelected(decksel);
 							mainGame->cbDBDecks->setSelected(decksel);
-							deckManager.LoadDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
+							deckManager.LoadCurrentDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
 						}
 						RefreshReadonly(prev_category);
 						prev_deck = decksel;
@@ -559,7 +559,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					ChangeCategory(catesel);
 					for(int i = 0; i < (int)mainGame->lstDecks->getItemCount(); i++) {
 						if(!mywcsncasecmp(mainGame->lstDecks->getListItem(i), deckname, 256)) {
-							deckManager.LoadDeck(newfilepath);
+							deckManager.LoadCurrentDeck(newfilepath);
 							prev_deck = i;
 							mainGame->cbDBDecks->setSelected(prev_deck);
 							mainGame->lstDecks->setSelected(prev_deck);
@@ -597,7 +597,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					ChangeCategory(catesel);
 					for(int i = 0; i < (int)mainGame->lstDecks->getItemCount(); i++) {
 						if(!mywcsncasecmp(mainGame->lstDecks->getListItem(i), deckname, 256)) {
-							deckManager.LoadDeck(newfilepath);
+							deckManager.LoadCurrentDeck(newfilepath);
 							prev_deck = i;
 							mainGame->cbDBDecks->setSelected(prev_deck);
 							mainGame->lstDecks->setSelected(prev_deck);
@@ -650,7 +650,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_SIDE_RELOAD: {
-				deckManager.LoadDeck(mainGame->cbCategorySelect, mainGame->cbDeckSelect);
+				deckManager.LoadCurrentDeck(mainGame->cbCategorySelect, mainGame->cbDeckSelect);
 				break;
 			}
 			case BUTTON_BIG_CARD_ORIG_SIZE: {
@@ -696,7 +696,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 							sel = count - 1;
 						mainGame->cbDBDecks->setSelected(sel);
 						if(sel != -1)
-							deckManager.LoadDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
+							deckManager.LoadCurrentDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
 						mainGame->stACMessage->setText(dataManager.GetSysString(1338));
 						mainGame->PopupElement(mainGame->wACMessage, 20);
 						prev_deck = sel;
@@ -710,7 +710,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					ChangeCategory(catesel);
 				} else if(prev_operation == COMBOBOX_DBDECKS) {
 					int decksel = mainGame->cbDBDecks->getSelected();
-					deckManager.LoadDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
+					deckManager.LoadCurrentDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
 					prev_deck = decksel;
 					is_modified = false;
 				} else if(prev_operation == BUTTON_MANAGE_DECK) {
@@ -827,7 +827,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				}
 				int decksel = mainGame->cbDBDecks->getSelected();
 				if(decksel >= 0) {
-					deckManager.LoadDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
+					deckManager.LoadCurrentDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
 				}
 				prev_deck = decksel;
 				is_modified = false;
@@ -986,7 +986,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				wchar_t catepath[256];
 				deckManager.GetCategoryPath(catepath, mainGame->lstCategories->getSelected(), mainGame->lstCategories->getListItem(mainGame->lstCategories->getSelected()));
 				myswprintf(filepath, L"%ls/%ls.ydk", catepath, mainGame->lstDecks->getListItem(decksel));
-				deckManager.LoadDeck(filepath, showing_pack);
+				deckManager.LoadCurrentDeck(filepath, showing_pack);
 				RefreshPackListScroll();
 				prev_deck = decksel;
 				break;
@@ -1633,7 +1633,7 @@ void DeckBuilder::ChangeCategory(int catesel) {
 	mainGame->RefreshDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
 	mainGame->cbDBDecks->setSelected(0);
 	RefreshReadonly(catesel);
-	deckManager.LoadDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
+	deckManager.LoadCurrentDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
 	is_modified = false;
 	prev_category = catesel;
 	prev_deck = 0;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -9,7 +9,7 @@ char DeckManager::deckBuffer[0x10000]{};
 DeckManager deckManager;
 
 void DeckManager::LoadLFListSingle(const char* path) {
-	LFList* cur = nullptr;
+	auto cur = _lfList.rend();
 	FILE* fp = fopen(path, "r");
 	char linebuf[256]{};
 	wchar_t strBuffer[256]{};
@@ -24,7 +24,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 				strBuffer[sa] = 0;
 				LFList newlist;
 				_lfList.push_back(newlist);
-				cur = &_lfList[_lfList.size() - 1];
+				cur = _lfList.rbegin();
 				cur->listName = strBuffer;
 				cur->hash = 0x7dfcee6a;
 				continue;
@@ -39,10 +39,11 @@ void DeckManager::LoadLFListSingle(const char* path) {
 				continue;
 			if (count < 0 || count > 2)
 				continue;
-			if (!cur)
+			if (cur == _lfList.rend())
 				continue;
+			unsigned int hcode = code;
 			cur->content[code] = count;
-			cur->hash = cur->hash ^ ((code << 18) | (code >> 14)) ^ ((code << (27 + count)) | (code >> (5 - count)));
+			cur->hash = cur->hash ^ ((hcode << 18) | (hcode >> 14)) ^ ((hcode << (27 + count)) | (hcode >> (5 - count)));
 		}
 		fclose(fp);
 	}

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -153,16 +153,17 @@ int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_p
 		}
 		if(cd.type & TYPE_TOKEN)
 			continue;
-		else if(is_packlist) {
+		if(is_packlist) {
 			deck.main.push_back(dataManager.GetCodePointer(code));
 			continue;
 		}
-		else if(cd.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK)) {
-			if(deck.extra.size() >= EXTRA_MAX_SIZE)
-				continue;
-			deck.extra.push_back(dataManager.GetCodePointer(code));
-		} else if(deck.main.size() < DECK_MAX_SIZE) {
-			deck.main.push_back(dataManager.GetCodePointer(code));
+		if (cd.type & TYPES_EXTRA_DECK) {
+			if ((int)deck.extra.size() < EXTRA_MAX_SIZE)
+				deck.extra.push_back(dataManager.GetCodePointer(code));
+		}
+		else {
+			if ((int)deck.main.size() < DECK_MAX_SIZE)
+				deck.main.push_back(dataManager.GetCodePointer(code));
 		}
 	}
 	for(int i = 0; i < sidec; ++i) {

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -212,21 +212,21 @@ bool DeckManager::LoadSide(Deck& deck, int* dbuf, int mainc, int sidec) {
 	std::unordered_map<int, int> pcount;
 	std::unordered_map<int, int> ncount;
 	for(size_t i = 0; i < deck.main.size(); ++i)
-		pcount[deck.main[i]->first]++;
+		++pcount[deck.main[i]->first];
 	for(size_t i = 0; i < deck.extra.size(); ++i)
-		pcount[deck.extra[i]->first]++;
+		++pcount[deck.extra[i]->first];
 	for(size_t i = 0; i < deck.side.size(); ++i)
-		pcount[deck.side[i]->first]++;
+		++pcount[deck.side[i]->first];
 	Deck ndeck;
 	LoadDeck(ndeck, dbuf, mainc, sidec);
-	if(ndeck.main.size() != deck.main.size() || ndeck.extra.size() != deck.extra.size())
+	if (ndeck.main.size() != deck.main.size() || ndeck.extra.size() != deck.extra.size() || ndeck.side.size() != deck.side.size())
 		return false;
 	for(size_t i = 0; i < ndeck.main.size(); ++i)
-		ncount[ndeck.main[i]->first]++;
+		++ncount[ndeck.main[i]->first];
 	for(size_t i = 0; i < ndeck.extra.size(); ++i)
-		ncount[ndeck.extra[i]->first]++;
+		++ncount[ndeck.extra[i]->first];
 	for(size_t i = 0; i < ndeck.side.size(); ++i)
-		ncount[ndeck.side[i]->first]++;
+		++ncount[ndeck.side[i]->first];
 	for (auto& cdit : ncount)
 		if (cdit.second != pcount[cdit.first])
 			return false;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -71,7 +71,7 @@ const std::unordered_map<int, int>* DeckManager::GetLFListContent(int lfhash) {
 		return &lit->content;
 	return nullptr;
 }
-static int checkAvail(int ot, int avail) {
+static int checkAvail(unsigned int ot, unsigned int avail) {
 	if((ot & avail) == avail)
 		return 0;
 	if((ot & AVAIL_OCG) && !(avail == AVAIL_OCG))
@@ -86,20 +86,21 @@ int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 	if(!list)
 		return 0;
 	int dc = 0;
-	if(deck.main.size() < DECK_MIN_SIZE || deck.main.size() > DECK_MAX_SIZE)
-		return (DECKERROR_MAINCOUNT << 28) + deck.main.size();
-	if(deck.extra.size() > EXTRA_MAX_SIZE)
-		return (DECKERROR_EXTRACOUNT << 28) + deck.extra.size();
-	if(deck.side.size() > SIDE_MAX_SIZE)
-		return (DECKERROR_SIDECOUNT << 28) + deck.side.size();
-	const int rule_map[6] = { AVAIL_OCG, AVAIL_TCG, AVAIL_SC, AVAIL_CUSTOM, AVAIL_OCGTCG, 0 };
-	int avail = rule_map[rule];
-	for(size_t i = 0; i < deck.main.size(); ++i) {
-		code_pointer cit = deck.main[i];
+	if((int)deck.main.size() < DECK_MIN_SIZE || (int)deck.main.size() > DECK_MAX_SIZE)
+		return ((unsigned)DECKERROR_MAINCOUNT << 28) + deck.main.size();
+	if((int)deck.extra.size() > EXTRA_MAX_SIZE)
+		return ((unsigned)DECKERROR_EXTRACOUNT << 28) + deck.extra.size();
+	if((int)deck.side.size() > SIDE_MAX_SIZE)
+		return ((unsigned)DECKERROR_SIDECOUNT << 28) + deck.side.size();
+	if (rule < 0 || rule >= 6)
+		return 0;
+	const unsigned int rule_map[6] = { AVAIL_OCG, AVAIL_TCG, AVAIL_SC, AVAIL_CUSTOM, AVAIL_OCGTCG, 0 };
+	auto avail = rule_map[rule];
+	for (auto& cit : deck.main) {
 		int gameruleDeckError = checkAvail(cit->second.ot, avail);
 		if(gameruleDeckError)
 			return (gameruleDeckError << 28) + cit->first;
-		if(cit->second.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_TOKEN | TYPE_LINK))
+		if (cit->second.type & (TYPES_EXTRA_DECK | TYPE_TOKEN))
 			return (DECKERROR_EXTRACOUNT << 28);
 		int code = cit->second.alias ? cit->second.alias : cit->first;
 		ccount[code]++;
@@ -110,8 +111,7 @@ int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 		if(it != list->end() && dc > it->second)
 			return (DECKERROR_LFLIST << 28) + cit->first;
 	}
-	for(size_t i = 0; i < deck.extra.size(); ++i) {
-		code_pointer cit = deck.extra[i];
+	for (auto& cit : deck.extra) {
 		int gameruleDeckError = checkAvail(cit->second.ot, avail);
 		if(gameruleDeckError)
 			return (gameruleDeckError << 28) + cit->first;
@@ -124,8 +124,7 @@ int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 		if(it != list->end() && dc > it->second)
 			return (DECKERROR_LFLIST << 28) + cit->first;
 	}
-	for(size_t i = 0; i < deck.side.size(); ++i) {
-		code_pointer cit = deck.side[i];
+	for (auto& cit : deck.side) {
 		int gameruleDeckError = checkAvail(cit->second.ot, avail);
 		if(gameruleDeckError)
 			return (gameruleDeckError << 28) + cit->first;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -262,15 +262,6 @@ void DeckManager::GetDeckFile(wchar_t* ret, irr::gui::IGUIComboBox* cbCategory, 
 		BufferIO::CopyWStr(L"", ret, 256);
 	}
 }
-bool DeckManager::LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck) {
-	wchar_t filepath[256];
-	GetDeckFile(filepath, cbCategory, cbDeck);
-	bool is_packlist = cbCategory->getSelected() == 0;
-	bool res = LoadCurrentDeck(filepath, is_packlist);
-	if(res && mainGame->is_building)
-		mainGame->deckBuilder.RefreshPackListScroll();
-	return res;
-}
 FILE* DeckManager::OpenDeckFile(const wchar_t* file, const char* mode) {
 #ifdef WIN32
 	wchar_t wmode[20]{};
@@ -318,6 +309,15 @@ bool DeckManager::LoadCurrentDeck(const wchar_t* file, bool is_packlist) {
 	reader->drop();
 	std::istringstream deckStream(deckBuffer);
 	return LoadDeck(current_deck, deckStream, is_packlist);
+}
+bool DeckManager::LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck) {
+	wchar_t filepath[256];
+	GetDeckFile(filepath, cbCategory, cbDeck);
+	bool is_packlist = cbCategory->getSelected() == 0;
+	bool res = LoadCurrentDeck(filepath, is_packlist);
+	if (res && mainGame->is_building)
+		mainGame->deckBuilder.RefreshPackListScroll();
+	return res;
 }
 bool DeckManager::SaveDeck(Deck& deck, const wchar_t* file) {
 	if(!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck"))

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -151,8 +151,10 @@ int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_p
 			errorcode = code;
 			continue;
 		}
-		if(cd.type & TYPE_TOKEN)
+		if (cd.type & TYPE_TOKEN) {
+			errorcode = code;
 			continue;
+		}
 		if(is_packlist) {
 			deck.main.push_back(dataManager.GetCodePointer(code));
 			continue;
@@ -172,8 +174,10 @@ int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_p
 			errorcode = code;
 			continue;
 		}
-		if(cd.type & TYPE_TOKEN)
+		if (cd.type & TYPE_TOKEN) {
+			errorcode = code;
 			continue;
+		}
 		if(deck.side.size() < SIDE_MAX_SIZE)
 			deck.side.push_back(dataManager.GetCodePointer(code));
 	}

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -268,7 +268,7 @@ void DeckManager::GetDeckFile(wchar_t* ret, irr::gui::IGUIComboBox* cbCategory, 
 FILE* DeckManager::OpenDeckFile(const wchar_t* file, const char* mode) {
 #ifdef WIN32
 	wchar_t wmode[20]{};
-	BufferIO::CopyWStr(mode, wmode, sizeof(wmode) / sizeof(wchar_t));
+	BufferIO::CopyWStr(mode, wmode, sizeof wmode / sizeof wmode[0]);
 	FILE* fp = _wfopen(file, wmode);
 #else
 	char file2[256];

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -179,7 +179,7 @@ int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_p
 	}
 	return errorcode;
 }
-bool DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist) {
+int DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist) {
 	int sp = 0, ct = 0, mainc = 0, sidec = 0, code;
 	int cardlist[300]{};
 	bool is_side = false;
@@ -202,8 +202,7 @@ bool DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_p
 		else
 			mainc++;
 	}
-	LoadDeck(current_deck, cardlist, mainc, sidec, is_packlist);
-	return true; // the above LoadDeck has return value but we ignore it here for now
+	return LoadDeck(current_deck, cardlist, mainc, sidec, is_packlist);
 }
 bool DeckManager::LoadSide(Deck& deck, int* dbuf, int mainc, int sidec) {
 	std::unordered_map<int, int> pcount;
@@ -308,7 +307,8 @@ bool DeckManager::LoadCurrentDeck(const wchar_t* file, bool is_packlist) {
 	reader->read(deckBuffer, size);
 	reader->drop();
 	std::istringstream deckStream(deckBuffer);
-	return LoadDeck(current_deck, deckStream, is_packlist);
+	LoadDeck(current_deck, deckStream, is_packlist);
+	return true;  // the above LoadDeck has return value but we ignore it here for now
 }
 bool DeckManager::LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck) {
 	wchar_t filepath[256];

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -292,14 +292,14 @@ bool DeckManager::LoadDeck(const wchar_t* file, bool is_packlist) {
 	reader->read(deckBuffer, size);
 	reader->drop();
 	std::istringstream deckStream(deckBuffer);
-	return LoadDeck(&deckStream, is_packlist);
+	return LoadDeck(current_deck, deckStream, is_packlist);
 }
-bool DeckManager::LoadDeck(std::istringstream* deckStream, bool is_packlist) {
+bool DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist) {
 	int sp = 0, ct = 0, mainc = 0, sidec = 0, code;
-	int cardlist[300];
+	int cardlist[300]{};
 	bool is_side = false;
 	std::string linebuf;
-	while(std::getline(*deckStream, linebuf, '\n') && ct < 300) {
+	while(std::getline(deckStream, linebuf, '\n') && ct < 300) {
 		if(linebuf[0] == '!') {
 			is_side = true;
 			continue;
@@ -307,12 +307,15 @@ bool DeckManager::LoadDeck(std::istringstream* deckStream, bool is_packlist) {
 		if(linebuf[0] < '0' || linebuf[0] > '9')
 			continue;
 		sp = 0;
-		while(linebuf[sp] >= '0' && linebuf[sp] <= '9') sp++;
+		while(linebuf[sp] >= '0' && linebuf[sp] <= '9')
+			sp++;
 		linebuf[sp] = 0;
 		code = std::stoi(linebuf);
 		cardlist[ct++] = code;
-		if(is_side) sidec++;
-		else mainc++;
+		if(is_side)
+			sidec++;
+		else
+			mainc++;
 	}
 	LoadDeck(current_deck, cardlist, mainc, sidec, is_packlist);
 	return true; // the above LoadDeck has return value but we ignore it here for now

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -179,6 +179,32 @@ int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_p
 	}
 	return errorcode;
 }
+bool DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist) {
+	int sp = 0, ct = 0, mainc = 0, sidec = 0, code;
+	int cardlist[300]{};
+	bool is_side = false;
+	std::string linebuf;
+	while (std::getline(deckStream, linebuf, '\n') && ct < 300) {
+		if (linebuf[0] == '!') {
+			is_side = true;
+			continue;
+		}
+		if (linebuf[0] < '0' || linebuf[0] > '9')
+			continue;
+		sp = 0;
+		while (linebuf[sp] >= '0' && linebuf[sp] <= '9')
+			sp++;
+		linebuf[sp] = 0;
+		code = std::stoi(linebuf);
+		cardlist[ct++] = code;
+		if (is_side)
+			sidec++;
+		else
+			mainc++;
+	}
+	LoadDeck(current_deck, cardlist, mainc, sidec, is_packlist);
+	return true; // the above LoadDeck has return value but we ignore it here for now
+}
 bool DeckManager::LoadSide(Deck& deck, int* dbuf, int mainc, int sidec) {
 	std::unordered_map<int, int> pcount;
 	std::unordered_map<int, int> ncount;
@@ -293,32 +319,6 @@ bool DeckManager::LoadDeck(const wchar_t* file, bool is_packlist) {
 	reader->drop();
 	std::istringstream deckStream(deckBuffer);
 	return LoadDeck(current_deck, deckStream, is_packlist);
-}
-bool DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist) {
-	int sp = 0, ct = 0, mainc = 0, sidec = 0, code;
-	int cardlist[300]{};
-	bool is_side = false;
-	std::string linebuf;
-	while(std::getline(deckStream, linebuf, '\n') && ct < 300) {
-		if(linebuf[0] == '!') {
-			is_side = true;
-			continue;
-		}
-		if(linebuf[0] < '0' || linebuf[0] > '9')
-			continue;
-		sp = 0;
-		while(linebuf[sp] >= '0' && linebuf[sp] <= '9')
-			sp++;
-		linebuf[sp] = 0;
-		code = std::stoi(linebuf);
-		cardlist[ct++] = code;
-		if(is_side)
-			sidec++;
-		else
-			mainc++;
-	}
-	LoadDeck(current_deck, cardlist, mainc, sidec, is_packlist);
-	return true; // the above LoadDeck has return value but we ignore it here for now
 }
 bool DeckManager::SaveDeck(Deck& deck, const wchar_t* file) {
 	if(!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck"))

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -262,11 +262,11 @@ void DeckManager::GetDeckFile(wchar_t* ret, irr::gui::IGUIComboBox* cbCategory, 
 		BufferIO::CopyWStr(L"", ret, 256);
 	}
 }
-bool DeckManager::LoadDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck) {
+bool DeckManager::LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck) {
 	wchar_t filepath[256];
 	GetDeckFile(filepath, cbCategory, cbDeck);
 	bool is_packlist = cbCategory->getSelected() == 0;
-	bool res = LoadDeck(filepath, is_packlist);
+	bool res = LoadCurrentDeck(filepath, is_packlist);
 	if(res && mainGame->is_building)
 		mainGame->deckBuilder.RefreshPackListScroll();
 	if (!res)
@@ -295,7 +295,7 @@ IReadFile* DeckManager::OpenDeckReader(const wchar_t* file) {
 #endif
 	return reader;
 }
-bool DeckManager::LoadDeck(const wchar_t* file, bool is_packlist) {
+bool DeckManager::LoadCurrentDeck(const wchar_t* file, bool is_packlist) {
 	IReadFile* reader = OpenDeckReader(file);
 	if(!reader) {
 		wchar_t localfile[64];

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -269,8 +269,6 @@ bool DeckManager::LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::
 	bool res = LoadCurrentDeck(filepath, is_packlist);
 	if(res && mainGame->is_building)
 		mainGame->deckBuilder.RefreshPackListScroll();
-	if (!res)
-		current_deck.clear();
 	return res;
 }
 FILE* DeckManager::OpenDeckFile(const wchar_t* file, const char* mode) {
@@ -296,6 +294,7 @@ IReadFile* DeckManager::OpenDeckReader(const wchar_t* file) {
 	return reader;
 }
 bool DeckManager::LoadCurrentDeck(const wchar_t* file, bool is_packlist) {
+	current_deck.clear();
 	IReadFile* reader = OpenDeckReader(file);
 	if(!reader) {
 		wchar_t localfile[64];

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -184,27 +184,23 @@ int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_p
 	return errorcode;
 }
 int DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist) {
-	int sp = 0, ct = 0, mainc = 0, sidec = 0, code;
+	int ct = 0, mainc = 0, sidec = 0, code = 0;
 	int cardlist[300]{};
 	bool is_side = false;
 	std::string linebuf;
-	while (std::getline(deckStream, linebuf, '\n') && ct < 300) {
+	while (std::getline(deckStream, linebuf, '\n') && ct < (int)(sizeof cardlist / sizeof cardlist[0])) {
 		if (linebuf[0] == '!') {
 			is_side = true;
 			continue;
 		}
 		if (linebuf[0] < '0' || linebuf[0] > '9')
 			continue;
-		sp = 0;
-		while (linebuf[sp] >= '0' && linebuf[sp] <= '9')
-			sp++;
-		linebuf[sp] = 0;
 		code = std::stoi(linebuf);
 		cardlist[ct++] = code;
 		if (is_side)
-			sidec++;
+			++sidec;
 		else
-			mainc++;
+			++mainc;
 	}
 	return LoadDeck(current_deck, cardlist, mainc, sidec, is_packlist);
 }

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -227,8 +227,8 @@ bool DeckManager::LoadSide(Deck& deck, int* dbuf, int mainc, int sidec) {
 		ncount[ndeck.extra[i]->first]++;
 	for(size_t i = 0; i < ndeck.side.size(); ++i)
 		ncount[ndeck.side[i]->first]++;
-	for(auto cdit = ncount.begin(); cdit != ncount.end(); ++cdit)
-		if(cdit->second != pcount[cdit->first])
+	for (auto& cdit : ncount)
+		if (cdit.second != pcount[cdit.first])
 			return false;
 	deck = ndeck;
 	return true;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -379,4 +379,35 @@ bool DeckManager::DeleteCategory(const wchar_t* name) {
 		return false;
 	return FileSystem::DeleteDir(localname);
 }
+bool DeckManager::SaveDeckBuffer(const int deckbuf[], const wchar_t* name) {
+	if (!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck"))
+		return false;
+	FILE* fp = OpenDeckFile(name, "w");
+	if (!fp)
+		return false;
+	int it = 0;
+	const int mainc = deckbuf[it];
+	++it;
+	fprintf(fp, "#created by ...\n#main\n");
+	for (int i = 0; i < mainc; ++i) {
+		fprintf(fp, "%d\n", deckbuf[it]);
+		++it;
+	}
+	const int extrac = deckbuf[it];
+	++it;
+	fprintf(fp, "#extra\n");
+	for (int i = 0; i < extrac; ++i) {
+		fprintf(fp, "%d\n", deckbuf[it]);
+		++it;
+	}
+	const int sidec = deckbuf[it];
+	++it;
+	fprintf(fp, "!side\n");
+	for (int i = 0; i < sidec; ++i) {
+		fprintf(fp, "%d\n", deckbuf[it]);
+		++it;
+	}
+	fclose(fp);
+	return true;
+}
 }

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -48,6 +48,7 @@ public:
 	const std::unordered_map<int, int>* GetLFListContent(int lfhash);
 	int CheckDeck(Deck& deck, int lfhash, int rule);
 	int LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_packlist = false);
+	bool LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
 	bool LoadSide(Deck& deck, int* dbuf, int mainc, int sidec);
 	void GetCategoryPath(wchar_t* ret, int index, const wchar_t* text);
 	void GetDeckFile(wchar_t* ret, irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
@@ -55,7 +56,6 @@ public:
 	FILE* OpenDeckFile(const wchar_t* file, const char* mode);
 	IReadFile* OpenDeckReader(const wchar_t* file);
 	bool LoadDeck(const wchar_t* file, bool is_packlist = false);
-	bool LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
 	bool SaveDeck(Deck& deck, const wchar_t* file);
 	bool DeleteDeck(const wchar_t* file);
 	bool CreateCategory(const wchar_t* name);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -61,6 +61,7 @@ public:
 	bool CreateCategory(const wchar_t* name);
 	bool RenameCategory(const wchar_t* oldname, const wchar_t* newname);
 	bool DeleteCategory(const wchar_t* name);
+	bool SaveDeckBuffer(const int deckbuf[], const wchar_t* name);
 };
 
 extern DeckManager deckManager;

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -55,7 +55,7 @@ public:
 	FILE* OpenDeckFile(const wchar_t* file, const char* mode);
 	IReadFile* OpenDeckReader(const wchar_t* file);
 	bool LoadDeck(const wchar_t* file, bool is_packlist = false);
-	bool LoadDeck(std::istringstream* deckStream, bool is_packlist = false);
+	bool LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
 	bool SaveDeck(Deck& deck, const wchar_t* file);
 	bool DeleteDeck(const wchar_t* file);
 	bool CreateCategory(const wchar_t* name);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -52,10 +52,10 @@ public:
 	bool LoadSide(Deck& deck, int* dbuf, int mainc, int sidec);
 	void GetCategoryPath(wchar_t* ret, int index, const wchar_t* text);
 	void GetDeckFile(wchar_t* ret, irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
-	bool LoadDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
+	bool LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
 	FILE* OpenDeckFile(const wchar_t* file, const char* mode);
 	IReadFile* OpenDeckReader(const wchar_t* file);
-	bool LoadDeck(const wchar_t* file, bool is_packlist = false);
+	bool LoadCurrentDeck(const wchar_t* file, bool is_packlist = false);
 	bool SaveDeck(Deck& deck, const wchar_t* file);
 	bool DeleteDeck(const wchar_t* file);
 	bool CreateCategory(const wchar_t* name);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -48,7 +48,7 @@ public:
 	const std::unordered_map<int, int>* GetLFListContent(int lfhash);
 	int CheckDeck(Deck& deck, int lfhash, int rule);
 	int LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_packlist = false);
-	bool LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
+	int LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
 	bool LoadSide(Deck& deck, int* dbuf, int mainc, int sidec);
 	void GetCategoryPath(wchar_t* ret, int index, const wchar_t* text);
 	void GetDeckFile(wchar_t* ret, irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -52,10 +52,10 @@ public:
 	bool LoadSide(Deck& deck, int* dbuf, int mainc, int sidec);
 	void GetCategoryPath(wchar_t* ret, int index, const wchar_t* text);
 	void GetDeckFile(wchar_t* ret, irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
-	bool LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
 	FILE* OpenDeckFile(const wchar_t* file, const char* mode);
 	IReadFile* OpenDeckReader(const wchar_t* file);
 	bool LoadCurrentDeck(const wchar_t* file, bool is_packlist = false);
+	bool LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
 	bool SaveDeck(Deck& deck, const wchar_t* file);
 	bool DeleteDeck(const wchar_t* file);
 	bool CreateCategory(const wchar_t* name);

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -303,31 +303,31 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				const ReplayHeader& rh = replay.pheader;
 				if(rh.flag & REPLAY_SINGLE_MODE)
 					break;
-				int max = (rh.flag & REPLAY_TAG) ? 4 : 2;
+				int player_count = (rh.flag & REPLAY_TAG) ? 4 : 2;
 				//player name
-				for(int i = 0; i < max; ++i)
+				for(int i = 0; i < player_count; ++i)
 					replay.ReadName(namebuf[i]);
 				//skip pre infos
 				for(int i = 0; i < 4; ++i)
 					replay.ReadInt32();
 				//deck
 				std::vector<int> deckbuf;
-				Deck tmp_deck;
-				for(int i = 0; i < max; ++i) {
-					int main = replay.ReadInt32();
-					tmp_deck.clear();
+				for(int i = 0; i < player_count; ++i) {
 					deckbuf.clear();
+					int main = replay.ReadInt32();
+					deckbuf.push_back(main);
 					for (int j = 0; j < main; ++j) {
 						deckbuf.push_back(replay.ReadInt32());
 					}
 					int extra = replay.ReadInt32();
+					deckbuf.push_back(extra);
 					for (int j = 0; j < extra; ++j) {
 						deckbuf.push_back(replay.ReadInt32());
 					}
-					deckManager.LoadDeck(tmp_deck, deckbuf.data(), deckbuf.size(), 0);
+					deckbuf.push_back(0);
 					FileSystem::SafeFileName(namebuf[i]);
 					myswprintf(filename, L"deck/%ls-%d %ls.ydk", ex_filename, i + 1, namebuf[i]);
-					deckManager.SaveDeck(tmp_deck, filename);
+					deckManager.SaveDeckBuffer(deckbuf.data(), filename);
 				}
 				mainGame->stACMessage->setText(dataManager.GetSysString(1335));
 				mainGame->PopupElement(mainGame->wACMessage, 20);

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -174,7 +174,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_HP_READY: {
 				if(mainGame->cbCategorySelect->getSelected() == -1 || mainGame->cbDeckSelect->getSelected() == -1 ||
-					!deckManager.LoadDeck(mainGame->cbCategorySelect, mainGame->cbDeckSelect)) {
+					!deckManager.LoadCurrentDeck(mainGame->cbCategorySelect, mainGame->cbDeckSelect)) {
 					mainGame->gMutex.lock();
 					soundManager.PlaySoundEffect(SOUND_INFO);
 					mainGame->env->addMessageBox(L"", dataManager.GetSysString(1406));
@@ -425,7 +425,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_DECK_EDIT: {
 				mainGame->RefreshCategoryDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
-				if(open_file && deckManager.LoadDeck(open_file_name)) {
+				if(open_file && deckManager.LoadCurrentDeck(open_file_name)) {
 #ifdef WIN32
 					wchar_t *dash = wcsrchr(open_file_name, L'\\');
 #else
@@ -463,7 +463,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					}
 					open_file = false;
 				} else if(mainGame->cbDBCategory->getSelected() != -1 && mainGame->cbDBDecks->getSelected() != -1) {
-					deckManager.LoadDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
+					deckManager.LoadCurrentDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
 					mainGame->ebDeckname->setText(L"");
 				}
 				mainGame->HideElement(mainGame->wMainMenu);
@@ -632,7 +632,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				mainGame->env->setFocus(mainGame->wHostPrepare);
 				if(static_cast<irr::gui::IGUICheckBox*>(caller)->isChecked()) {
 					if(mainGame->cbCategorySelect->getSelected() == -1 || mainGame->cbDeckSelect->getSelected() == -1 ||
-						!deckManager.LoadDeck(mainGame->cbCategorySelect, mainGame->cbDeckSelect)) {
+						!deckManager.LoadCurrentDeck(mainGame->cbCategorySelect, mainGame->cbDeckSelect)) {
 						mainGame->gMutex.lock();
 						static_cast<irr::gui::IGUICheckBox*>(caller)->setChecked(false);
 						soundManager.PlaySoundEffect(SOUND_INFO);

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -294,9 +294,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				if(mainGame->lstReplayList->getSelected() == -1)
 					break;
 				Replay replay;
-				wchar_t ex_filename[256];
-				wchar_t namebuf[4][20];
-				wchar_t filename[256];
+				wchar_t ex_filename[256]{};
+				wchar_t namebuf[4][20]{};
+				wchar_t filename[256]{};
 				myswprintf(ex_filename, L"%ls", mainGame->lstReplayList->getListItem(mainGame->lstReplayList->getSelected()));
 				if(!replay.OpenReplay(ex_filename))
 					break;
@@ -311,20 +311,20 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				for(int i = 0; i < 4; ++i)
 					replay.ReadInt32();
 				//deck
+				std::vector<int> deckbuf;
+				Deck tmp_deck;
 				for(int i = 0; i < max; ++i) {
 					int main = replay.ReadInt32();
-					Deck tmp_deck;
+					tmp_deck.clear();
+					deckbuf.clear();
 					for (int j = 0; j < main; ++j) {
-						auto card = dataManager.GetCodePointer(replay.ReadInt32());
-						if (card != dataManager.datas_end)
-							tmp_deck.main.push_back(card);
+						deckbuf.push_back(replay.ReadInt32());
 					}
 					int extra = replay.ReadInt32();
 					for (int j = 0; j < extra; ++j) {
-						auto card = dataManager.GetCodePointer(replay.ReadInt32());
-						if (card != dataManager.datas_end)
-							tmp_deck.extra.push_back(card);
+						deckbuf.push_back(replay.ReadInt32());
 					}
+					deckManager.LoadDeck(tmp_deck, deckbuf.data(), deckbuf.size(), 0);
 					FileSystem::SafeFileName(namebuf[i]);
 					myswprintf(filename, L"deck/%ls-%d %ls.ydk", ex_filename, i + 1, namebuf[i]);
 					deckManager.SaveDeck(tmp_deck, filename);

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -546,7 +546,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				tm* st = localtime(&curtime);
 				wcsftime(infobuf, 256, L"%Y/%m/%d %H:%M:%S\n", st);
 				repinfo.append(infobuf);
-				wchar_t namebuf[4][20];
+				wchar_t namebuf[4][20]{};
 				ReplayMode::cur_replay.ReadName(namebuf[0]);
 				ReplayMode::cur_replay.ReadName(namebuf[1]);
 				if(ReplayMode::cur_replay.pheader.flag & REPLAY_TAG) {

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -253,7 +253,7 @@ public:
 #define NETPLAYER_TYPE_OBSERVER		7
 
 #define CTOS_RESPONSE		0x1		// byte array
-#define CTOS_UPDATE_DECK	0x2		// int32_t array
+#define CTOS_UPDATE_DECK	0x2		// mainc, sidec, int32_t[mainc + sidec]
 #define CTOS_HAND_RESULT	0x3		// CTOS_HandResult
 #define CTOS_TP_RESULT		0x4		// CTOS_TPResult
 #define CTOS_PLAYER_INFO	0x10	// CTOS_PlayerInfo

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -440,7 +440,7 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	pduel = create_duel(duel_seed);
 	set_player_info(pduel, 0, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	set_player_info(pduel, 1, host_info.start_lp, host_info.start_hand, host_info.draw_count);
-	int opt = (int)host_info.duel_rule << 16;
+	unsigned int opt = (unsigned int)host_info.duel_rule << 16;
 	if(host_info.no_shuffle_deck)
 		opt |= DUEL_PSEUDO_SHUFFLE;
 	last_replay.WriteInt32(host_info.start_lp, false);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -417,7 +417,7 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	pduel = create_duel(duel_seed);
 	set_player_info(pduel, 0, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	set_player_info(pduel, 1, host_info.start_lp, host_info.start_hand, host_info.draw_count);
-	int opt = (int)host_info.duel_rule << 16;
+	unsigned int opt = (unsigned int)host_info.duel_rule << 16;
 	if(host_info.no_shuffle_deck)
 		opt |= DUEL_PSEUDO_SHUFFLE;
 	opt |= DUEL_TAG_MODE;


### PR DESCRIPTION
class deckManager
```cpp
int LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_packlist = false);
```
Read card id from the int array `dbuf` and write them into `deck`.
Return: error code

```cpp
int LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
```
Read card id from the strem `deckStream` and write them into `deck`.
It is a wrapper of the above function.

```cpp
bool LoadCurrentDeck(const wchar_t* file, bool is_packlist = false);
```
Read card id from ydk file `file` and write them into `current_deck`.
Return: The ydk file is read sucessfully


```cpp
bool LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
```
A wrapper of the above function.


```cpp
bool SaveDeckBuffer(const int deckbuf[], const wchar_t* name);
```
Save the id list in `deckbuf` to a ydk file.
It is called by Extract Deck from replay file.
The id will not be converted to `Deck`, so it will keep the id of pre-release card.

@mercury233 
@purerosefallen 