### PR TITLE
include <thread> in game.cpp

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -10,6 +10,7 @@
 #include "duelclient.h"
 #include "netserver.h"
 #include "single_mode.h"
+#include <thread>
 
 const unsigned short PRO_VERSION = 0x1361;
 


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/header/thread
Some functions are defined in namespace std::this_thread.

Search: std::this_thread
only in game.cpp
fix #2578 

----
已搜尋std::this_thread
只有在game.cpp使用


@mercury233 
@purerosefallen 
@Wind2009-Louse