### PR TITLE
Replay: add bounds checking

### DIFF
--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -28,7 +28,7 @@ void Replay::BeginRecord() {
 	if(!fp)
 		return;
 #endif
-	pdata = replay_data;
+	pwrite = replay_data;
 	replay_size = 0;
 	comp_size = 0;
 	is_replaying = false;
@@ -47,10 +47,10 @@ void Replay::WriteHeader(ReplayHeader& header) {
 void Replay::WriteData(const void* data, int length, bool flush) {
 	if(!is_recording)
 		return;
-	if (length < 0 || (pdata - replay_data) + length > MAX_REPLAY_SIZE)
+	if (length < 0 || (int)(pwrite - replay_data) + length > MAX_REPLAY_SIZE)
 		return;
-	std::memcpy(pdata, data, length);
-	pdata += length;
+	std::memcpy(pwrite, data, length);
+	pwrite += length;
 #ifdef _WIN32
 	DWORD size;
 	WriteFile(recording_fp, data, length, &size, NULL);
@@ -85,10 +85,7 @@ void Replay::EndRecord() {
 #else
 	fclose(fp);
 #endif
-	if(pdata - replay_data > 0 && pdata - replay_data <= MAX_REPLAY_SIZE)
-		replay_size = pdata - replay_data;
-	else
-		replay_size = 0;
+	replay_size = pwrite - replay_data;
 	pheader.datasize = replay_size;
 	pheader.flag |= REPLAY_COMPRESSED;
 	size_t propsize = 5;

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -246,23 +246,21 @@ bool Replay::ReadData(void* data, int length) {
 	pdata += length;
 	return true;
 }
-int Replay::ReadInt32() {
-	if(!is_replaying)
+template<typename T>
+T Replay::ReadValue() {
+	T ret{};
+	if (!ReadData(&ret, sizeof ret))
 		return -1;
-	int ret = BufferIO::ReadInt32(pdata);
 	return ret;
+}
+int Replay::ReadInt32() {
+	return ReadValue<int32_t>();
 }
 short Replay::ReadInt16() {
-	if(!is_replaying)
-		return -1;
-	short ret = BufferIO::ReadInt16(pdata);
-	return ret;
+	return ReadValue<int16_t>();
 }
 char Replay::ReadInt8() {
-	if(!is_replaying)
-		return -1;
-	char ret= BufferIO::ReadInt8(pdata);
-	return ret;
+	return ReadValue<char>();
 }
 void Replay::Rewind() {
 	pdata = replay_data;

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -61,49 +61,13 @@ void Replay::WriteData(const void* data, int length, bool flush) {
 #endif
 }
 void Replay::WriteInt32(int data, bool flush) {
-	if(!is_recording)
-		return;
-	if ((pdata - replay_data) + 4 > MAX_REPLAY_SIZE)
-		return;
-	BufferIO::WriteInt32(pdata, data);
-#ifdef _WIN32
-	DWORD size;
-	WriteFile(recording_fp, &data, sizeof(int), &size, NULL);
-#else
-	fwrite(&data, sizeof(int), 1, fp);
-	if(flush)
-		fflush(fp);
-#endif
+	WriteData(&data, sizeof data, flush);
 }
 void Replay::WriteInt16(short data, bool flush) {
-	if(!is_recording)
-		return;
-	if ((pdata - replay_data) + 2 > MAX_REPLAY_SIZE)
-		return;
-	BufferIO::WriteInt16(pdata, data);
-#ifdef _WIN32
-	DWORD size;
-	WriteFile(recording_fp, &data, sizeof(short), &size, NULL);
-#else
-	fwrite(&data, sizeof(short), 1, fp);
-	if(flush)
-		fflush(fp);
-#endif
+	WriteData(&data, sizeof data, flush);
 }
 void Replay::WriteInt8(char data, bool flush) {
-	if(!is_recording)
-		return;
-	if ((pdata - replay_data) + 1 > MAX_REPLAY_SIZE)
-		return;
-	BufferIO::WriteInt8(pdata, data);
-#ifdef _WIN32
-	DWORD size;
-	WriteFile(recording_fp, &data, sizeof(char), &size, NULL);
-#else
-	fwrite(&data, sizeof(char), 1, fp);
-	if(flush)
-		fflush(fp);
-#endif
+	WriteData(&data, sizeof data, flush);
 }
 void Replay::Flush() {
 	if(!is_recording)

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -51,6 +51,8 @@ public:
 	void ReadName(wchar_t* data);
 	//void ReadHeader(ReplayHeader& header);
 	bool ReadData(void* data, int length);
+	template<typename T>
+	T ReadValue();
 	int ReadInt32();
 	short ReadInt16();
 	char ReadInt8();

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -62,12 +62,13 @@ public:
 #endif
 
 	ReplayHeader pheader;
-	unsigned char* replay_data;
 	unsigned char* comp_data;
-	size_t replay_size{};
 	size_t comp_size{};
 
 private:
+	unsigned char* replay_data;
+	size_t replay_size{};
+	unsigned char* pwrite{};
 	unsigned char* pdata{ nullptr };
 	bool is_recording{};
 	bool is_replaying{};

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -50,7 +50,7 @@ public:
 	bool ReadNextResponse(unsigned char resp[]);
 	void ReadName(wchar_t* data);
 	//void ReadHeader(ReplayHeader& header);
-	void ReadData(void* data, int length);
+	bool ReadData(void* data, int length);
 	int ReadInt32();
 	short ReadInt16();
 	char ReadInt8();
@@ -69,7 +69,7 @@ private:
 	unsigned char* replay_data;
 	size_t replay_size{};
 	unsigned char* pwrite{};
-	unsigned char* pdata{ nullptr };
+	unsigned char* pdata{};
 	bool is_recording{};
 	bool is_replaying{};
 };


### PR DESCRIPTION
Problem:
Replay reading does not check boundaries.


read/write with different pointer:
Now writing will use `pwrite`.
`Rewind()` does not affect `pwrite`.


Write:
Now it will use `WriteData`.
`WriteInt*` are all wrapper functions of `WriteData`.

Read:
Now it will use `ReadData`.

bool Replay::ReadData(void* data, int length)
Return: the reading is successful or not
Add bounds checking.

template<typename T>
T Replay::ReadValue()
Return: the value or -1 (failed)
Read a single value from replay.

ReadInt*
wrapper functions of `ReadValue`


@mercury233 
@purerosefallen 

  