### PR TITLE
 fix EncodeUTF8String, DecodeUTF8String

### DIFF
--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -6,30 +6,30 @@
 
 class BufferIO {
 public:
-	inline static int ReadInt32(unsigned char*& p) {
+	static int ReadInt32(unsigned char*& p) {
 		return buffer_read<int32_t>(p);
 	}
-	inline static short ReadInt16(unsigned char*& p) {
+	static short ReadInt16(unsigned char*& p) {
 		return buffer_read<int16_t>(p);
 	}
-	inline static char ReadInt8(unsigned char*& p) {
+	static char ReadInt8(unsigned char*& p) {
 		return buffer_read<char>(p);
 	}
-	inline static unsigned char ReadUInt8(unsigned char*& p) {
+	static unsigned char ReadUInt8(unsigned char*& p) {
 		return buffer_read<unsigned char>(p);
 	}
-	inline static void WriteInt32(unsigned char*& p, int val) {
+	static void WriteInt32(unsigned char*& p, int val) {
 		buffer_write<int32_t>(p, val);
 	}
-	inline static void WriteInt16(unsigned char*& p, short val) {
+	static void WriteInt16(unsigned char*& p, short val) {
 		buffer_write<int16_t>(p, val);
 	}
-	inline static void WriteInt8(unsigned char*& p, char val) {
+	static void WriteInt8(unsigned char*& p, char val) {
 		buffer_write<char>(p, val);
 	}
 	// return: string length
 	template<typename T1, typename T2>
-	inline static int CopyWStr(const T1* src, T2* pstr, int bufsize) {
+	static int CopyWStr(const T1* src, T2* pstr, int bufsize) {
 		int l = 0;
 		while(src[l] && l < bufsize - 1) {
 			pstr[l] = (T2)src[l];
@@ -39,7 +39,7 @@ public:
 		return l;
 	}
 	template<typename T1, typename T2>
-	inline static int CopyWStrRef(const T1* src, T2*& pstr, int bufsize) {
+	static int CopyWStrRef(const T1* src, T2*& pstr, int bufsize) {
 		int l = 0;
 		while(src[l] && l < bufsize - 1) {
 			pstr[l] = (T2)src[l];

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -49,6 +49,14 @@ public:
 		*pstr = 0;
 		return l;
 	}
+	template<typename T>
+	static bool CheckStringSize(const T* str, int len) {
+		for (int i = 0; i < len; ++i) {
+			if (str[i] == 0)
+				return false;
+		}
+		return true;
+	}
 	// UTF-16/UTF-32 to UTF-8
 	// return: string length
 	static int EncodeUTF8String(const wchar_t* wsrc, char* str, int size) {

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -57,6 +57,21 @@ public:
 		}
 		return true;
 	}
+	static bool IsHighSurrogate(unsigned int c) {
+		return (c >= 0xd800U && c <= 0xdbffU);
+	}
+	static bool IsLowSurrogate(unsigned int c) {
+		return (c >= 0xdc00U && c <= 0xdfffU);
+	}
+	static bool IsUnicodeChar(unsigned int c) {
+		if(IsHighSurrogate(c))
+			return false;
+		if (IsLowSurrogate(c))
+			return false;
+		if (c > 0x10ffffU)
+			return false;
+		return true;
+	}
 	// UTF-16/UTF-32 to UTF-8
 	// return: string length
 	static int EncodeUTF8String(const wchar_t* wsrc, char* str, int size) {


### PR DESCRIPTION
UTF-16
High surrogate: 0xD800 ~ 0xDBFF
Low surrogate: 0xDC00 ~ 0xDFFF
Surrogate pair: 1 High + 1 Low

EncodeUTF8String 
Windows: sizeof(wchar_t)=2, wchar_t[] is treated as UTF-16
Other: sizeof(wchar_t)=4, wchar_t[] is treated as UTF-32

On Windows
- If the last code unit in wchar_t[] is a lone surrogate, it will read out-of bounds.
It will try to read a[10] in this example:
```cpp
wchar_t a[10]={0xd800,0xd800,0xd800,0xd800,0xd800,0xd800,0xd800,0xd800,0xd800,0}; 
char dest[256]{};
EncodeUTF8String(a, dest, sizeof dest);
```

- It does not check surrogate pairs.
2 lone surrogate: 0xd800,0xd800
Low surrogate first: 0xdc00, 0xd800
It will accept these sequences, which are ill-formed UTF-16 sequences.


DecodeUTF8String
- If the last byte in char[] is a leading byte, it will read out-of bounds.
Example:
```cpp
char a[3] = {0xE0, 0xA4, 0};
wchar_t dest[256]{};
DecodeUTF8String(a, dest, 256);
```

- If the decoded Unicode code point is in Surrogate Area, it will write a lone surrogate.
Example:
UTF8: 0xED 0xA0 0x80
Unicode code point: High Surrogates (U+D800)
It will write a lone surrogate, but it shouldn't.

Solution:
```cpp
template<typename T>
bool CheckUTF8Byte(const T* str, int len)
```
Check if there are `len` continuation byte in the UTF-8 string.

```cpp
bool IsUnicodeChar(unsigned int c)
```
Check if the code point is a Unicode character.

@mercury233 
@purerosefallen 


@edo9300 
I believe that the UTF8 functions in edopro have the same problems.


Reference:
https://en.wikipedia.org/wiki/UTF-8
https://en.wikipedia.org/wiki/UTF-16
https://www.compart.com/en/unicode
