### PR TITLE
update card search trycode

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1348,6 +1348,7 @@ void DeckBuilder::FilterCards() {
 		element_t(): type(type_t::all), exclude(false) {}
 	};
 	const wchar_t* pstr = mainGame->ebCardName->getText();
+	int trycode = BufferIO::GetVal(pstr);
 	std::wstring str = std::wstring(pstr);
 	std::vector<element_t> query_elements;
 	if(mainGame->gameConf.search_multiple_keywords) {
@@ -1492,16 +1493,12 @@ void DeckBuilder::FilterCards() {
 				match = CardNameContains(text.name.c_str(), elements_iterator->keyword.c_str());
 			} else if (elements_iterator->type == element_t::type_t::setcode) {
 				match = data.is_setcodes(elements_iterator->setcodes);
+			} else if (trycode && (data.code == trycode || data.alias == trycode && data.is_alternative())){
+				match = true;
 			} else {
-				int trycode = BufferIO::GetVal(elements_iterator->keyword.c_str());
-				bool tryresult = dataManager.GetData(trycode, 0);
-				if(!tryresult) {
-					match = CardNameContains(text.name.c_str(), elements_iterator->keyword.c_str())
-						|| text.text.find(elements_iterator->keyword) != std::wstring::npos
-						|| data.is_setcodes(elements_iterator->setcodes);
-				} else {
-					match = data.code == trycode || data.alias == trycode;
-				}
+				match = CardNameContains(text.name.c_str(), elements_iterator->keyword.c_str())
+					|| text.text.find(elements_iterator->keyword) != std::wstring::npos
+					|| data.is_setcodes(elements_iterator->setcodes);
 			}
 			if(elements_iterator->exclude)
 				match = !match;


### PR DESCRIPTION
1. Formerly it was supporting to search something like `青眼 -89631139`, which mean name or desc include _青眼_ but password is not _89631139_.
I don't think this is necessary, and it make the program run `BufferIO::GetVal` and `dataManager.GetData` over 10,000 times on each search.
Now it only support to use the password as entire search string.


2. We was seeing results which don't has relation to the password.
![image](https://github.com/user-attachments/assets/fa7b98ea-d54b-419d-bbee-ba14cd4e8c6b)
Now this problem is fixed.
