### PR TITLE
use LUA_USE_APICHECK for debug

### DIFF
--- a/premake/lua/premake5.lua
+++ b/premake/lua/premake5.lua
@@ -10,6 +10,9 @@ project "lua"
     filter "not action:vs*"
         buildoptions { "-x c++" }
 
+    filter "configurations:Debug"
+        defines { "LUA_USE_APICHECK" }
+
     filter "system:bsd"
         defines { "LUA_USE_POSIX" }
 


### PR DESCRIPTION
>As in most C libraries, the Lua API functions do not check their arguments for validity or consistency. However, you can change this behavior by compiling Lua with the macro LUA_USE_APICHECK defined.
https://www.lua.org/manual/5.4/manual.html

We can use this since https://github.com/Fluorohydride/ygopro/issues/2406 is fixed