### PR TITLE
remove wcscpy, wcscat

### DIFF
--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -2,6 +2,7 @@
 #define BUFFERIO_H
 
 #include <cstdint>
+#include <cwchar>
 #include "../ocgcore/buffer.h"
 
 class BufferIO {
@@ -48,6 +49,16 @@ public:
 		pstr += l;
 		*pstr = 0;
 		return l;
+	}
+	template<size_t N>
+	static void CopyString(const char* src, wchar_t(&dst)[N]) {
+		dst[0] = 0;
+		std::strncat(dst, src, N - 1);
+	}
+	template<size_t N>
+	static void CopyWideString(const wchar_t* src, wchar_t(&dst)[N]) {
+		dst[0] = 0;
+		std::wcsncat(dst, src, N - 1);
 	}
 	template<typename T>
 	static bool CheckUTF8Byte(const T* str, int len) {

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -540,7 +540,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					const wchar_t* newcatename = mainGame->cbDMCategory->getText();
 					const wchar_t* olddeckname = mainGame->lstDecks->getListItem(decksel);
 					wchar_t deckname[256];
-					BufferIO::CopyWStr(olddeckname, deckname, 256);
+					BufferIO::CopyWideString(olddeckname, deckname);
 					wchar_t oldfilepath[256];
 					deckManager.GetDeckFile(oldfilepath, mainGame->cbDBCategory, mainGame->cbDBDecks);
 					wchar_t newfilepath[256];
@@ -580,7 +580,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					const wchar_t* newcatename = mainGame->cbDMCategory->getText();
 					const wchar_t* olddeckname = mainGame->lstDecks->getListItem(decksel);
 					wchar_t deckname[256];
-					BufferIO::CopyWStr(olddeckname, deckname, 256);
+					BufferIO::CopyWideString(olddeckname, deckname);
 					wchar_t newfilepath[256];
 					if(oldcatesel != 2 && newcatesel == 0) {
 						myswprintf(newfilepath, L"./deck/%ls.ydk", deckname);

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -105,11 +105,11 @@ void DeckBuilder::Terminate() {
 	mainGame->scrPackCards->setVisible(false);
 	mainGame->scrPackCards->setPos(0);
 	int catesel = mainGame->cbDBCategory->getSelected();
-	if(catesel >= 0)
-		BufferIO::CopyWStr(mainGame->cbDBCategory->getItem(catesel), mainGame->gameConf.lastcategory, 64);
+	if (catesel >= 0)
+		BufferIO::CopyWideString(mainGame->cbDBCategory->getItem(catesel), mainGame->gameConf.lastcategory);
 	int decksel = mainGame->cbDBDecks->getSelected();
-	if(decksel >= 0)
-		BufferIO::CopyWStr(mainGame->cbDBDecks->getItem(decksel), mainGame->gameConf.lastdeck, 64);
+	if (decksel >= 0)
+		BufferIO::CopyWideString(mainGame->cbDBDecks->getItem(decksel), mainGame->gameConf.lastdeck);
 	if(exit_on_return)
 		mainGame->device->closeDevice();
 }

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -237,7 +237,7 @@ void DeckManager::GetCategoryPath(wchar_t* ret, int index, const wchar_t* text) 
 		myswprintf(catepath, L"./pack");
 		break;
 	case 1:
-		myswprintf(catepath, mainGame->gameConf.bot_deck_path);
+		BufferIO::CopyWideString(mainGame->gameConf.bot_deck_path, catepath);
 		break;
 	case -1:
 	case 2:

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1274,52 +1274,50 @@ void Game::DrawDeckBd() {
 		if(deckBuilder.hovered_pos == 4 && deckBuilder.hovered_seq == (int)i)
 			driver->draw2DRectangle(0x80000000, Resize(806, 164 + i * 66, 1019, 230 + i * 66));
 		DrawThumb(ptr, position2di(810, 165 + i * 66), deckBuilder.filterList);
+		const wchar_t* availBuffer = L"";
+		if ((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_OCG)
+			availBuffer = L" [OCG]";
+		else if ((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_TCG)
+			availBuffer = L" [TCG]";
+		else if ((ptr->second.ot & AVAIL_CUSTOM) == AVAIL_CUSTOM)
+			availBuffer = L" [Custom]";
 		if(ptr->second.type & TYPE_MONSTER) {
 			myswprintf(textBuffer, L"%ls", dataManager.GetName(ptr->first));
 			DrawShadowText(textFont, textBuffer, Resize(860, 165 + i * 66, 955, 185 + i * 66), Resize(1, 1, 0, 0));
+			const wchar_t* form = L"\u2605";
+			wchar_t adBuffer[32]{};
+			wchar_t scaleBuffer[16]{};
 			if(!(ptr->second.type & TYPE_LINK)) {
-				const wchar_t* form = L"\u2605";
-				if(ptr->second.type & TYPE_XYZ) form = L"\u2606";
-				myswprintf(textBuffer, L"%ls/%ls %ls%d", dataManager.FormatAttribute(ptr->second.attribute), dataManager.FormatRace(ptr->second.race), form, ptr->second.level);
-				DrawShadowText(textFont, textBuffer, Resize(860, 187 + i * 66, 955, 207 + i * 66), Resize(1, 1, 0, 0));
+				if(ptr->second.type & TYPE_XYZ)
+					form = L"\u2606";
 				if(ptr->second.attack < 0 && ptr->second.defense < 0)
-					myswprintf(textBuffer, L"?/?");
+					myswprintf(adBuffer, L"?/?");
 				else if(ptr->second.attack < 0)
-					myswprintf(textBuffer, L"?/%d", ptr->second.defense);
+					myswprintf(adBuffer, L"?/%d", ptr->second.defense);
 				else if(ptr->second.defense < 0)
-					myswprintf(textBuffer, L"%d/?", ptr->second.attack);
-				else myswprintf(textBuffer, L"%d/%d", ptr->second.attack, ptr->second.defense);
+					myswprintf(adBuffer, L"%d/?", ptr->second.attack);
+				else
+					myswprintf(adBuffer, L"%d/%d", ptr->second.attack, ptr->second.defense);
 			} else {
-				myswprintf(textBuffer, L"%ls/%ls LINK-%d", dataManager.FormatAttribute(ptr->second.attribute), dataManager.FormatRace(ptr->second.race), ptr->second.level);
-				DrawShadowText(textFont, textBuffer, Resize(860, 187 + i * 66, 955, 207 + i * 66), Resize(1, 1, 0, 0));
+				form = L"LINK-";
 				if(ptr->second.attack < 0)
-					myswprintf(textBuffer, L"?/-");
-				else myswprintf(textBuffer, L"%d/-", ptr->second.attack);
+					myswprintf(adBuffer, L"?/-");
+				else
+					myswprintf(adBuffer, L"%d/-", ptr->second.attack);
 			}
+			myswprintf(textBuffer, L"%ls/%ls %ls%d", dataManager.FormatAttribute(ptr->second.attribute), dataManager.FormatRace(ptr->second.race), form, ptr->second.level);
+			DrawShadowText(textFont, textBuffer, Resize(860, 187 + i * 66, 955, 207 + i * 66), Resize(1, 1, 0, 0));
 			if(ptr->second.type & TYPE_PENDULUM) {
-				wchar_t scaleBuffer[16];
 				myswprintf(scaleBuffer, L" %d/%d", ptr->second.lscale, ptr->second.rscale);
-				wcscat(textBuffer, scaleBuffer);
 			}
-			if((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_OCG)
-				wcscat(textBuffer, L" [OCG]");
-			else if((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_TCG)
-				wcscat(textBuffer, L" [TCG]");
-			else if((ptr->second.ot & AVAIL_CUSTOM) == AVAIL_CUSTOM)
-				wcscat(textBuffer, L" [Custom]");
+			myswprintf(textBuffer, L"%ls%ls%ls", adBuffer, scaleBuffer, availBuffer);
 			DrawShadowText(textFont, textBuffer, Resize(860, 209 + i * 66, 955, 229 + i * 66), Resize(1, 1, 0, 0));
 		} else {
 			myswprintf(textBuffer, L"%ls", dataManager.GetName(ptr->first));
 			DrawShadowText(textFont, textBuffer, Resize(860, 165 + i * 66, 955, 185 + i * 66), Resize(1, 1, 0, 0));
 			const wchar_t* ptype = dataManager.FormatType(ptr->second.type);
 			DrawShadowText(textFont, ptype, Resize(860, 187 + i * 66, 955, 207 + i * 66), Resize(1, 1, 0, 0));
-			textBuffer[0] = 0;
-			if((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_OCG)
-				wcscat(textBuffer, L"[OCG]");
-			else if((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_TCG)
-				wcscat(textBuffer, L"[TCG]");
-			else if((ptr->second.ot & AVAIL_CUSTOM) == AVAIL_CUSTOM)
-				wcscat(textBuffer, L"[Custom]");
+			myswprintf(textBuffer, L"%ls", availBuffer);
 			DrawShadowText(textFont, textBuffer, Resize(860, 209 + i * 66, 955, 229 + i * 66), Resize(1, 1, 0, 0));
 		}
 	}

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1582,8 +1582,8 @@ void Game::ShowCardInfo(int code, bool resize) {
 			offset_info = 15;
 		if(!(cd.type & TYPE_LINK)) {
 			const wchar_t* form = L"\u2605";
-			if(cd.type & TYPE_XYZ) form = L"\u2606";
-			myswprintf(formatBuffer, L"[%ls%d] ", form, cd.level);
+			if(cd.type & TYPE_XYZ)
+				form = L"\u2606";
 			wchar_t adBuffer[16];
 			if(cd.attack < 0 && cd.defense < 0)
 				myswprintf(adBuffer, L"?/?");
@@ -1593,16 +1593,14 @@ void Game::ShowCardInfo(int code, bool resize) {
 				myswprintf(adBuffer, L"%d/?", cd.attack);
 			else
 				myswprintf(adBuffer, L"%d/%d", cd.attack, cd.defense);
-			wcscat(formatBuffer, adBuffer);
+			myswprintf(formatBuffer, L"[%ls%d] %ls", form, cd.level, adBuffer);
 		} else {
-			myswprintf(formatBuffer, L"[LINK-%d] ", cd.level);
 			wchar_t adBuffer[16];
 			if(cd.attack < 0)
 				myswprintf(adBuffer, L"?/-   ");
 			else
 				myswprintf(adBuffer, L"%d/-   ", cd.attack);
-			wcscat(formatBuffer, adBuffer);
-			wcscat(formatBuffer, dataManager.FormatLinkMarker(cd.link_marker));
+			myswprintf(formatBuffer, L"[LINK-%d] %ls%ls", cd.level, adBuffer, dataManager.FormatLinkMarker(cd.link_marker));
 		}
 		if(cd.type & TYPE_PENDULUM) {
 			wchar_t scaleBuffer[16];

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1580,11 +1580,12 @@ void Game::ShowCardInfo(int code, bool resize) {
 		irr::core::dimension2d<unsigned int> dtxt = guiFont->getDimension(formatBuffer);
 		if(dtxt.Width > (300 * xScale - 13) - 15)
 			offset_info = 15;
+		const wchar_t* form = L"\u2605";
+		wchar_t adBuffer[64]{};
+		wchar_t scaleBuffer[16]{};
 		if(!(cd.type & TYPE_LINK)) {
-			const wchar_t* form = L"\u2605";
 			if(cd.type & TYPE_XYZ)
 				form = L"\u2606";
-			wchar_t adBuffer[16];
 			if(cd.attack < 0 && cd.defense < 0)
 				myswprintf(adBuffer, L"?/?");
 			else if(cd.attack < 0)
@@ -1593,20 +1594,17 @@ void Game::ShowCardInfo(int code, bool resize) {
 				myswprintf(adBuffer, L"%d/?", cd.attack);
 			else
 				myswprintf(adBuffer, L"%d/%d", cd.attack, cd.defense);
-			myswprintf(formatBuffer, L"[%ls%d] %ls", form, cd.level, adBuffer);
 		} else {
-			wchar_t adBuffer[16];
+			form = L"LINK-";
 			if(cd.attack < 0)
-				myswprintf(adBuffer, L"?/-   ");
+				myswprintf(adBuffer, L"?/-   %ls", dataManager.FormatLinkMarker(cd.link_marker));
 			else
-				myswprintf(adBuffer, L"%d/-   ", cd.attack);
-			myswprintf(formatBuffer, L"[LINK-%d] %ls%ls", cd.level, adBuffer, dataManager.FormatLinkMarker(cd.link_marker));
+				myswprintf(adBuffer, L"%d/-   %ls", cd.attack, dataManager.FormatLinkMarker(cd.link_marker));
 		}
 		if(cd.type & TYPE_PENDULUM) {
-			wchar_t scaleBuffer[16];
 			myswprintf(scaleBuffer, L"   %d/%d", cd.lscale, cd.rscale);
-			wcscat(formatBuffer, scaleBuffer);
 		}
+		myswprintf(formatBuffer, L"[%ls%d] %ls%ls", form, cd.level, adBuffer, scaleBuffer);
 		stDataInfo->setText(formatBuffer);
 		int offset_arrows = offset_info;
 		dtxt = guiFont->getDimension(formatBuffer);

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -22,7 +22,8 @@
 #include <mutex>
 #include <functional>
 
-#define DEFAULT_DUEL_RULE 5
+constexpr int DEFAULT_DUEL_RULE = 5;
+constexpr int CONFIG_LINE_SIZE = 1024;
 
 namespace ygo {
 
@@ -36,12 +37,13 @@ struct Config {
 	wchar_t lastport[10]{};
 	wchar_t nickname[20]{};
 	wchar_t gamename[20]{};
-	wchar_t lastcategory[64]{};
-	wchar_t lastdeck[64]{};
+	wchar_t roompass[20]{};
+	//path
+	wchar_t lastcategory[256]{};
+	wchar_t lastdeck[256]{};
 	wchar_t textfont[256]{};
 	wchar_t numfont[256]{};
-	wchar_t roompass[20]{};
-	wchar_t bot_deck_path[64]{};
+	wchar_t bot_deck_path[256]{};
 	//settings
 	int chkMAutoPos{ 0 };
 	int chkSTAutoPos{ 1 };

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -135,7 +135,7 @@ int main(int argc, char* argv[]) {
 						myswprintf(open_file_name, L"%ls/%ls", ygo::mainGame->gameConf.lastcategory, wargv[i]);
 #endif
 					} else {
-						wcscpy(open_file_name, wargv[i]);
+						BufferIO::CopyWideString(wargv[i], open_file_name);
 					}
 				}
 				ClickButton(ygo::mainGame->btnDeckEdit);
@@ -156,7 +156,7 @@ int main(int argc, char* argv[]) {
 			++i;
 			if(i < wargc) {
 				open_file = true;
-				wcscpy(open_file_name, wargv[i]);
+				BufferIO::CopyWideString(wargv[i], open_file_name);
 			}
 			ClickButton(ygo::mainGame->btnReplayMode);
 			if(open_file)
@@ -167,7 +167,7 @@ int main(int argc, char* argv[]) {
 			++i;
 			if(i < wargc) {
 				open_file = true;
-				wcscpy(open_file_name, wargv[i]);
+				BufferIO::CopyWideString(wargv[i], open_file_name);
 			}
 			ClickButton(ygo::mainGame->btnSingleMode);
 			if(open_file)
@@ -177,14 +177,14 @@ int main(int argc, char* argv[]) {
 			wchar_t* pstrext = wargv[1] + wcslen(wargv[1]) - 4;
 			if(!mywcsncasecmp(pstrext, L".ydk", 4)) {
 				open_file = true;
-				wcscpy(open_file_name, wargv[i]);
+				BufferIO::CopyWideString(wargv[i], open_file_name);
 				exit_on_return = !keep_on_return;
 				ClickButton(ygo::mainGame->btnDeckEdit);
 				break;
 			}
 			if(!mywcsncasecmp(pstrext, L".yrp", 4)) {
 				open_file = true;
-				wcscpy(open_file_name, wargv[i]);
+				BufferIO::CopyWideString(wargv[i], open_file_name);
 				exit_on_return = !keep_on_return;
 				ClickButton(ygo::mainGame->btnReplayMode);
 				ClickButton(ygo::mainGame->btnLoadReplay);

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -115,16 +115,14 @@ int main(int argc, char* argv[]) {
 			++i;
 			if(i < wargc) {
 				deckCategorySpecified = true;
-				wcsncpy(ygo::mainGame->gameConf.lastcategory, wargv[i], sizeof ygo::mainGame->gameConf.lastcategory / sizeof ygo::mainGame->gameConf.lastcategory[0]);
-				BufferIO::NullTerminate(ygo::mainGame->gameConf.lastcategory);
+				wcscpy(ygo::mainGame->gameConf.lastcategory, wargv[i]);
 			}
 		} else if(!wcscmp(wargv[i], L"-d")) { // Deck
 			++i;
 			if(!deckCategorySpecified)
 				ygo::mainGame->gameConf.lastcategory[0] = 0;
 			if(i + 1 < wargc) { // select deck
-				wcsncpy(ygo::mainGame->gameConf.lastdeck, wargv[i], sizeof ygo::mainGame->gameConf.lastdeck / sizeof ygo::mainGame->gameConf.lastdeck[0]);
-				BufferIO::NullTerminate(ygo::mainGame->gameConf.lastdeck);
+				wcscpy(ygo::mainGame->gameConf.lastdeck, wargv[i]);
 				continue;
 			} else { // open deck
 				exit_on_return = !keep_on_return;
@@ -137,8 +135,7 @@ int main(int argc, char* argv[]) {
 						myswprintf(open_file_name, L"%ls/%ls", ygo::mainGame->gameConf.lastcategory, wargv[i]);
 #endif
 					} else {
-						wcsncpy(open_file_name, wargv[i], sizeof open_file_name / sizeof open_file_name[0]);
-						BufferIO::NullTerminate(open_file_name);
+						wcscpy(open_file_name, wargv[i]);
 					}
 				}
 				ClickButton(ygo::mainGame->btnDeckEdit);
@@ -159,8 +156,7 @@ int main(int argc, char* argv[]) {
 			++i;
 			if(i < wargc) {
 				open_file = true;
-				wcsncpy(open_file_name, wargv[i], sizeof open_file_name / sizeof open_file_name[0]);
-				BufferIO::NullTerminate(open_file_name);
+				wcscpy(open_file_name, wargv[i]);
 			}
 			ClickButton(ygo::mainGame->btnReplayMode);
 			if(open_file)
@@ -171,8 +167,7 @@ int main(int argc, char* argv[]) {
 			++i;
 			if(i < wargc) {
 				open_file = true;
-				wcsncpy(open_file_name, wargv[i], sizeof open_file_name / sizeof open_file_name[0]);
-				BufferIO::NullTerminate(open_file_name);
+				wcscpy(open_file_name, wargv[i]);
 			}
 			ClickButton(ygo::mainGame->btnSingleMode);
 			if(open_file)
@@ -182,16 +177,14 @@ int main(int argc, char* argv[]) {
 			wchar_t* pstrext = wargv[1] + wcslen(wargv[1]) - 4;
 			if(!mywcsncasecmp(pstrext, L".ydk", 4)) {
 				open_file = true;
-				wcsncpy(open_file_name, wargv[i], sizeof open_file_name / sizeof open_file_name[0]);
-				BufferIO::NullTerminate(open_file_name);
+				wcscpy(open_file_name, wargv[i]);
 				exit_on_return = !keep_on_return;
 				ClickButton(ygo::mainGame->btnDeckEdit);
 				break;
 			}
 			if(!mywcsncasecmp(pstrext, L".yrp", 4)) {
 				open_file = true;
-				wcsncpy(open_file_name, wargv[i], sizeof open_file_name / sizeof open_file_name[0]);
-				BufferIO::NullTerminate(open_file_name);
+				wcscpy(open_file_name, wargv[i]);
 				exit_on_return = !keep_on_return;
 				ClickButton(ygo::mainGame->btnReplayMode);
 				ClickButton(ygo::mainGame->btnLoadReplay);

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -115,14 +115,14 @@ int main(int argc, char* argv[]) {
 			++i;
 			if(i < wargc) {
 				deckCategorySpecified = true;
-				wcscpy(ygo::mainGame->gameConf.lastcategory, wargv[i]);
+				BufferIO::CopyWideString(wargv[i], ygo::mainGame->gameConf.lastcategory);
 			}
 		} else if(!wcscmp(wargv[i], L"-d")) { // Deck
 			++i;
 			if(!deckCategorySpecified)
 				ygo::mainGame->gameConf.lastcategory[0] = 0;
 			if(i + 1 < wargc) { // select deck
-				wcscpy(ygo::mainGame->gameConf.lastdeck, wargv[i]);
+				BufferIO::CopyWideString(wargv[i], ygo::mainGame->gameConf.lastdeck);
 				continue;
 			} else { // open deck
 				exit_on_return = !keep_on_return;

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -115,14 +115,16 @@ int main(int argc, char* argv[]) {
 			++i;
 			if(i < wargc) {
 				deckCategorySpecified = true;
-				wcscpy(ygo::mainGame->gameConf.lastcategory, wargv[i]);
+				wcsncpy(ygo::mainGame->gameConf.lastcategory, wargv[i], sizeof ygo::mainGame->gameConf.lastcategory / sizeof ygo::mainGame->gameConf.lastcategory[0]);
+				BufferIO::NullTerminate(ygo::mainGame->gameConf.lastcategory);
 			}
 		} else if(!wcscmp(wargv[i], L"-d")) { // Deck
 			++i;
 			if(!deckCategorySpecified)
 				ygo::mainGame->gameConf.lastcategory[0] = 0;
 			if(i + 1 < wargc) { // select deck
-				wcscpy(ygo::mainGame->gameConf.lastdeck, wargv[i]);
+				wcsncpy(ygo::mainGame->gameConf.lastdeck, wargv[i], sizeof ygo::mainGame->gameConf.lastdeck / sizeof ygo::mainGame->gameConf.lastdeck[0]);
+				BufferIO::NullTerminate(ygo::mainGame->gameConf.lastdeck);
 				continue;
 			} else { // open deck
 				exit_on_return = !keep_on_return;
@@ -135,7 +137,8 @@ int main(int argc, char* argv[]) {
 						myswprintf(open_file_name, L"%ls/%ls", ygo::mainGame->gameConf.lastcategory, wargv[i]);
 #endif
 					} else {
-						wcscpy(open_file_name, wargv[i]);
+						wcsncpy(open_file_name, wargv[i], sizeof open_file_name / sizeof open_file_name[0]);
+						BufferIO::NullTerminate(open_file_name);
 					}
 				}
 				ClickButton(ygo::mainGame->btnDeckEdit);
@@ -156,7 +159,8 @@ int main(int argc, char* argv[]) {
 			++i;
 			if(i < wargc) {
 				open_file = true;
-				wcscpy(open_file_name, wargv[i]);
+				wcsncpy(open_file_name, wargv[i], sizeof open_file_name / sizeof open_file_name[0]);
+				BufferIO::NullTerminate(open_file_name);
 			}
 			ClickButton(ygo::mainGame->btnReplayMode);
 			if(open_file)
@@ -167,7 +171,8 @@ int main(int argc, char* argv[]) {
 			++i;
 			if(i < wargc) {
 				open_file = true;
-				wcscpy(open_file_name, wargv[i]);
+				wcsncpy(open_file_name, wargv[i], sizeof open_file_name / sizeof open_file_name[0]);
+				BufferIO::NullTerminate(open_file_name);
 			}
 			ClickButton(ygo::mainGame->btnSingleMode);
 			if(open_file)
@@ -177,14 +182,16 @@ int main(int argc, char* argv[]) {
 			wchar_t* pstrext = wargv[1] + wcslen(wargv[1]) - 4;
 			if(!mywcsncasecmp(pstrext, L".ydk", 4)) {
 				open_file = true;
-				wcscpy(open_file_name, wargv[i]);
+				wcsncpy(open_file_name, wargv[i], sizeof open_file_name / sizeof open_file_name[0]);
+				BufferIO::NullTerminate(open_file_name);
 				exit_on_return = !keep_on_return;
 				ClickButton(ygo::mainGame->btnDeckEdit);
 				break;
 			}
 			if(!mywcsncasecmp(pstrext, L".yrp", 4)) {
 				open_file = true;
-				wcscpy(open_file_name, wargv[i]);
+				wcsncpy(open_file_name, wargv[i], sizeof open_file_name / sizeof open_file_name[0]);
+				BufferIO::NullTerminate(open_file_name);
 				exit_on_return = !keep_on_return;
 				ClickButton(ygo::mainGame->btnReplayMode);
 				ClickButton(ygo::mainGame->btnLoadReplay);

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -448,7 +448,8 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 						wcsncpy(deck_name, dash + 1, 256);
 						for(size_t i = 0; i < mainGame->cbDBDecks->getItemCount(); ++i) {
 							if(!wcscmp(mainGame->cbDBDecks->getItem(i), deck_name)) {
-								wcscpy(mainGame->gameConf.lastdeck, deck_name);
+								wcsncpy(mainGame->gameConf.lastdeck, deck_name, sizeof mainGame->gameConf.lastdeck / sizeof mainGame->gameConf.lastdeck[0]);
+								BufferIO::NullTerminate(mainGame->gameConf.lastdeck);
 								mainGame->cbDBDecks->setSelected(i);
 								break;
 							}
@@ -456,7 +457,8 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					} else { // only deck name
 						for(size_t i = 0; i < mainGame->cbDBDecks->getItemCount(); ++i) {
 							if(!wcscmp(mainGame->cbDBDecks->getItem(i), open_file_name)) {
-								wcscpy(mainGame->gameConf.lastdeck, open_file_name);
+								wcsncpy(mainGame->gameConf.lastdeck, open_file_name, sizeof mainGame->gameConf.lastdeck / sizeof mainGame->gameConf.lastdeck[0]);
+								BufferIO::NullTerminate(mainGame->gameConf.lastdeck);
 								mainGame->cbDBDecks->setSelected(i);
 								break;
 							}

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -70,14 +70,17 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				mainGame->TrimText(mainGame->ebJoinHost);
 				mainGame->TrimText(mainGame->ebJoinPort);
 				char ip[20];
-				const wchar_t* pstr = mainGame->ebJoinHost->getText();
-				BufferIO::CopyWStr(pstr, ip, 16);
+				wchar_t pstr[100];
+				wchar_t portstr[10];
+				BufferIO::CopyWideString(mainGame->ebJoinHost->getText(), pstr);
+				BufferIO::CopyWideString(mainGame->ebJoinPort->getText(), portstr);
+				BufferIO::EncodeUTF8(pstr, ip);
 				unsigned int remote_addr = htonl(inet_addr(ip));
 				if(remote_addr == -1) {
 					char hostname[100];
 					char port[6];
-					BufferIO::CopyWStr(pstr, hostname, 100);
-					BufferIO::CopyWStr(mainGame->ebJoinPort->getText(), port, 6);
+					BufferIO::EncodeUTF8(pstr, hostname);
+					BufferIO::EncodeUTF8(portstr, port);
 					struct evutil_addrinfo hints;
 					struct evutil_addrinfo *answer = NULL;
 					std::memset(&hints, 0, sizeof hints);
@@ -99,9 +102,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 						evutil_freeaddrinfo(answer);
 					}
 				}
-				unsigned int remote_port = wcstol(mainGame->ebJoinPort->getText(), nullptr, 10);
-				BufferIO::CopyWStr(pstr, mainGame->gameConf.lasthost, 100);
-				BufferIO::CopyWStr(mainGame->ebJoinPort->getText(), mainGame->gameConf.lastport, 20);
+				unsigned int remote_port = wcstol(portstr, nullptr, 10);
+				BufferIO::CopyWideString(pstr, mainGame->gameConf.lasthost);
+				BufferIO::CopyWideString(portstr, mainGame->gameConf.lastport);
 				if(DuelClient::StartClient(remote_addr, remote_port, false)) {
 					mainGame->btnCreateHost->setEnabled(false);
 					mainGame->btnJoinHost->setEnabled(false);
@@ -129,7 +132,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_HOST_CONFIRM: {
 				bot_mode = false;
-				BufferIO::CopyWStr(mainGame->ebServerName->getText(), mainGame->gameConf.gamename, 20);
+				BufferIO::CopyWideString(mainGame->ebServerName->getText(), mainGame->gameConf.gamename);
 				if(!NetServer::StartServer(mainGame->gameConf.serverport)) {
 					soundManager.PlaySoundEffect(SOUND_INFO);
 					mainGame->env->addMessageBox(L"", dataManager.GetSysString(1402));

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -448,8 +448,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 						wcsncpy(deck_name, dash + 1, 256);
 						for(size_t i = 0; i < mainGame->cbDBDecks->getItemCount(); ++i) {
 							if(!wcscmp(mainGame->cbDBDecks->getItem(i), deck_name)) {
-								wcsncpy(mainGame->gameConf.lastdeck, deck_name, sizeof mainGame->gameConf.lastdeck / sizeof mainGame->gameConf.lastdeck[0]);
-								BufferIO::NullTerminate(mainGame->gameConf.lastdeck);
+								wcscpy(mainGame->gameConf.lastdeck, deck_name);
 								mainGame->cbDBDecks->setSelected(i);
 								break;
 							}
@@ -457,8 +456,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					} else { // only deck name
 						for(size_t i = 0; i < mainGame->cbDBDecks->getItemCount(); ++i) {
 							if(!wcscmp(mainGame->cbDBDecks->getItem(i), open_file_name)) {
-								wcsncpy(mainGame->gameConf.lastdeck, open_file_name, sizeof mainGame->gameConf.lastdeck / sizeof mainGame->gameConf.lastdeck[0]);
-								BufferIO::NullTerminate(mainGame->gameConf.lastdeck);
+								wcscpy(mainGame->gameConf.lastdeck, open_file_name);
 								mainGame->cbDBDecks->setSelected(i);
 								break;
 							}

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -13,11 +13,13 @@
 namespace ygo {
 
 void UpdateDeck() {
-	BufferIO::CopyWStr(mainGame->cbCategorySelect->getItem(mainGame->cbCategorySelect->getSelected()),
-		mainGame->gameConf.lastcategory, 64);
-	BufferIO::CopyWStr(mainGame->cbDeckSelect->getItem(mainGame->cbDeckSelect->getSelected()),
-		mainGame->gameConf.lastdeck, 64);
-	unsigned char deckbuf[1024];
+	auto category = mainGame->cbCategorySelect->getItem(mainGame->cbCategorySelect->getSelected());
+	if (category)
+		BufferIO::CopyWideString(category, mainGame->gameConf.lastcategory);
+	auto deckname = mainGame->cbDeckSelect->getItem(mainGame->cbDeckSelect->getSelected());
+	if (deckname)
+		BufferIO::CopyWideString(deckname, mainGame->gameConf.lastdeck);
+	unsigned char deckbuf[1024]{};
 	auto pdeck = deckbuf;
 	BufferIO::WriteInt32(pdeck, deckManager.current_deck.main.size() + deckManager.current_deck.extra.size());
 	BufferIO::WriteInt32(pdeck, deckManager.current_deck.side.size());
@@ -448,7 +450,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 						wcsncpy(deck_name, dash + 1, 256);
 						for(size_t i = 0; i < mainGame->cbDBDecks->getItemCount(); ++i) {
 							if(!wcscmp(mainGame->cbDBDecks->getItem(i), deck_name)) {
-								wcscpy(mainGame->gameConf.lastdeck, deck_name);
+								BufferIO::CopyWideString(deck_name, mainGame->gameConf.lastdeck);
 								mainGame->cbDBDecks->setSelected(i);
 								break;
 							}
@@ -456,14 +458,15 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					} else { // only deck name
 						for(size_t i = 0; i < mainGame->cbDBDecks->getItemCount(); ++i) {
 							if(!wcscmp(mainGame->cbDBDecks->getItem(i), open_file_name)) {
-								wcscpy(mainGame->gameConf.lastdeck, open_file_name);
+								BufferIO::CopyWideString(open_file_name, mainGame->gameConf.lastdeck);
 								mainGame->cbDBDecks->setSelected(i);
 								break;
 							}
 						}
 					}
 					open_file = false;
-				} else if(mainGame->cbDBCategory->getSelected() != -1 && mainGame->cbDBDecks->getSelected() != -1) {
+				} 
+				else if(mainGame->cbDBCategory->getSelected() != -1 && mainGame->cbDBDecks->getSelected() != -1) {
 					deckManager.LoadCurrentDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
 					mainGame->ebDeckname->setText(L"");
 				}

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -499,7 +499,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				mainGame->HideElement(mainGame->wReplaySave);
 				if(prev_operation == BUTTON_RENAME_REPLAY) {
 					wchar_t newname[256];
-					BufferIO::CopyWStr(mainGame->ebRSName->getText(), newname, 256);
+					BufferIO::CopyWideString(mainGame->ebRSName->getText(), newname);
 					if(mywcsncasecmp(newname + wcslen(newname) - 4, L".yrp", 4)) {
 						myswprintf(newname, L"%ls.yrp", mainGame->ebRSName->getText());
 					}

--- a/gframe/myfilesystem.h
+++ b/gframe/myfilesystem.h
@@ -71,7 +71,7 @@ public:
 
 	static bool DeleteDir(const wchar_t* wdir) {
 		wchar_t pdir[256];
-		BufferIO::CopyWStr(wdir, pdir, 256);
+		BufferIO::CopyWideString(wdir, pdir);
 		pdir[wcslen(wdir) + 1] = 0;
 		SHFILEOPSTRUCTW lpFileOp;
 		lpFileOp.hwnd = NULL;

--- a/gframe/myfilesystem.h
+++ b/gframe/myfilesystem.h
@@ -14,6 +14,7 @@
 
 #ifdef _WIN32
 
+#include <wchar.h>
 #define NOMINMAX
 #include <Windows.h>
 
@@ -89,8 +90,7 @@ public:
 
 	static void TraversalDir(const wchar_t* wpath, const std::function<void(const wchar_t*, bool)>& cb) {
 		wchar_t findstr[1024];
-		wcscpy(findstr, wpath);
-		wcscat(findstr, L"/*");
+		swprintf(findstr, 1024, L"%s/*", wpath);
 		WIN32_FIND_DATAW fdataw;
 		HANDLE fh = FindFirstFileW(findstr, &fdataw);
 		if(fh == INVALID_HANDLE_VALUE)


### PR DESCRIPTION
https://en.cppreference.com/w/c/string/wide/wcscpy
The behavior is undefined if the dest array is not large enough. 

https://en.cppreference.com/w/c/string/wide/wcscat
The behavior is undefined if the destination array is not large enough for the contents of both str and dest and the terminating null wide character.

`wcscpy` and `wcscat` may cause buffer overflow and should be avoided.

Example:
run ygopro in command line
```
YGOPro.exe --deck-category 123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
```
Now `mainGame->gameConf` is corrupted.

When the process ends, it will write `mainGame->gameConf` to `system.conf`.
Now `system.conf` is corrupted.

Solution:
Use `wcsncpy`, `swprintf` instead.

@mercury233 
@purerosefallen 


