### PR TITLE
DataManager: fix GetNumString

### DIFF
--- a/gframe/CGUITTFont.cpp
+++ b/gframe/CGUITTFont.cpp
@@ -269,7 +269,7 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 
 	// Log.
 	if (logger)
-		logger->log(L"CGUITTFont", core::stringw(core::stringw(L"Creating new font: ") + core::ustring(filename).toWCHAR_s() + L" " + core::stringc(size) + L"pt " + (antialias ? L"+antialias " : L"-antialias ") + (transparency ? L"+transparency" : L"-transparency")).c_str(), irr::ELL_INFORMATION);
+		logger->log(L"CGUITTFont", core::stringw(core::stringw(L"Creating new font: ") + core::stringc(filename) + L" " + core::stringc(size) + L"pt " + (antialias ? L"+antialias " : L"-antialias ") + (transparency ? L"+transparency" : L"-transparency")).c_str(), irr::ELL_INFORMATION);
 
 	// Grab the face.
 	SGUITTFace* face = 0;
@@ -304,15 +304,12 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 				return false;
 			}
 		} else {
-			core::ustring converter(filename);
-			if (FT_New_Face(c_library, reinterpret_cast<const char*>(converter.toUTF8_s().c_str()), 0, &face->face)) {
-				if (logger) logger->log(L"CGUITTFont", L"FT_New_Face failed.", irr::ELL_INFORMATION);
+			if (logger) logger->log(L"CGUITTFont", L"FT_New_Face failed.", irr::ELL_INFORMATION);
 
-				c_faces.remove(filename);
-				delete face;
-				face = 0;
-				return false;
-			}
+			c_faces.remove(filename);
+			delete face;
+			face = 0;
+			return false;
 		}
 	} else {
 		// Using another instance of this face.
@@ -493,6 +490,12 @@ void CGUITTFont::setFontHinting(const bool enable, const bool enable_auto_hintin
 void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position, video::SColor color, bool hcenter, bool vcenter, const core::rect<s32>* clip) {
 	if (!Driver)
 		return;
+	drawUstring(text, position, color, hcenter, vcenter, clip);
+}
+
+void CGUITTFont::drawUstring(const core::ustring& utext, const core::rect<s32>&position, video::SColor color, bool hcenter, bool vcenter, const core::rect<s32>*clip) {
+	if (!Driver)
+		return;
 
 	// Clear the glyph pages of their render information.
 	for (u32 i = 0; i < Glyph_Pages.size(); ++i) {
@@ -506,7 +509,7 @@ void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position
 
 	// Determine offset positions.
 	if (hcenter || vcenter) {
-		textDimension = getDimension(text.c_str());
+		textDimension = getDimension(utext);
 
 		if (hcenter)
 			offset.X = ((position.getWidth() - textDimension.Width) >> 1) + offset.X;
@@ -514,9 +517,6 @@ void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position
 		if (vcenter)
 			offset.Y = ((position.getHeight() - textDimension.Height) >> 1) + offset.Y;
 	}
-
-	// Convert to a unicode string.
-	core::ustring utext(text);
 
 	// Set up our render map.
 	core::map<u32, CGUITTGlyphPage*> Render_Map;

--- a/gframe/CGUITTFont.h
+++ b/gframe/CGUITTFont.h
@@ -263,9 +263,12 @@ public:
 	virtual void setFontHinting(const bool enable, const bool enable_auto_hinting = true);
 
 	//! Draws some text and clips it to the specified rectangle if wanted.
-	virtual void draw(const core::stringw& text, const core::rect<s32>& position,
+	void draw(const core::stringw& text, const core::rect<s32>& position,
 	                  video::SColor color, bool hcenter = false, bool vcenter = false,
-	                  const core::rect<s32>* clip = 0);
+	                  const core::rect<s32>* clip = 0) override;
+	void drawUstring(const core::ustring& text, const core::rect<s32>& position,
+					video::SColor color, bool hcenter = false, bool vcenter = false,
+					const core::rect<s32>* clip = 0);
 
 	//! Returns the dimension of a character produced by this font.
 	virtual core::dimension2d<u32> getCharDimension(const wchar_t ch) const;

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -360,26 +360,25 @@ std::wstring DataManager::FormatSetName(const uint16_t setcode[]) const {
 		return std::wstring(unknown_string);
 	return buffer;
 }
-const wchar_t* DataManager::FormatLinkMarker(int link_marker) {
-	wchar_t* p = lmBuffer;
-	*p = 0;
-	if(link_marker & LINK_MARKER_TOP_LEFT)
-		BufferIO::CopyWStrRef(L"[\u2196]", p, 4);
-	if(link_marker & LINK_MARKER_TOP)
-		BufferIO::CopyWStrRef(L"[\u2191]", p, 4);
-	if(link_marker & LINK_MARKER_TOP_RIGHT)
-		BufferIO::CopyWStrRef(L"[\u2197]", p, 4);
-	if(link_marker & LINK_MARKER_LEFT)
-		BufferIO::CopyWStrRef(L"[\u2190]", p, 4);
-	if(link_marker & LINK_MARKER_RIGHT)
-		BufferIO::CopyWStrRef(L"[\u2192]", p, 4);
-	if(link_marker & LINK_MARKER_BOTTOM_LEFT)
-		BufferIO::CopyWStrRef(L"[\u2199]", p, 4);
-	if(link_marker & LINK_MARKER_BOTTOM)
-		BufferIO::CopyWStrRef(L"[\u2193]", p, 4);
-	if(link_marker & LINK_MARKER_BOTTOM_RIGHT)
-		BufferIO::CopyWStrRef(L"[\u2198]", p, 4);
-	return lmBuffer;
+std::wstring DataManager::FormatLinkMarker(unsigned int link_marker) const {
+	std::wstring buffer;
+	if (link_marker & LINK_MARKER_TOP_LEFT)
+		buffer.append(L"[\u2196]");
+	if (link_marker & LINK_MARKER_TOP)
+		buffer.append(L"[\u2191]");
+	if (link_marker & LINK_MARKER_TOP_RIGHT)
+		buffer.append(L"[\u2197]");
+	if (link_marker & LINK_MARKER_LEFT)
+		buffer.append(L"[\u2190]");
+	if (link_marker & LINK_MARKER_RIGHT)
+		buffer.append(L"[\u2192]");
+	if (link_marker & LINK_MARKER_BOTTOM_LEFT)
+		buffer.append(L"[\u2199]");
+	if (link_marker & LINK_MARKER_BOTTOM)
+		buffer.append(L"[\u2193]");
+	if (link_marker & LINK_MARKER_BOTTOM_RIGHT)
+		buffer.append(L"[\u2198]");
+	return buffer;
 }
 uint32 DataManager::CardReader(uint32 code, card_data* pData) {
 	if (!dataManager.GetData(code, pData))

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -330,22 +330,19 @@ std::wstring DataManager::FormatRace(unsigned int race) const {
 		return std::wstring(unknown_string);
 	return buffer;
 }
-const wchar_t* DataManager::FormatType(int type) {
-	wchar_t* p = tpBuffer;
-	unsigned filter = 1;
+std::wstring DataManager::FormatType(unsigned int type) const {
+	std::wstring buffer;
 	int i = 1050;
-	for(; filter != 0x8000000; filter <<= 1, ++i) {
-		if(type & filter) {
-			BufferIO::CopyWStrRef(GetSysString(i), p, 16);
-			*p = L'|';
-			*++p = 0;
+	for (unsigned filter = TYPE_MONSTER; filter <= TYPE_LINK; filter <<= 1, ++i) {
+		if (type & filter) {
+			if (!buffer.empty())
+				buffer.push_back(L'|');
+			buffer.append(GetSysString(i));
 		}
 	}
-	if(p != tpBuffer)
-		*(p - 1) = 0;
-	else
-		return unknown_string;
-	return tpBuffer;
+	if (buffer.empty())
+		return std::wstring(unknown_string);
+	return buffer;
 }
 const wchar_t* DataManager::FormatSetName(const uint16_t setcode[]) {
 	wchar_t* p = scBuffer;

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -344,23 +344,21 @@ std::wstring DataManager::FormatType(unsigned int type) const {
 		return std::wstring(unknown_string);
 	return buffer;
 }
-const wchar_t* DataManager::FormatSetName(const uint16_t setcode[]) {
-	wchar_t* p = scBuffer;
+std::wstring DataManager::FormatSetName(const uint16_t setcode[]) const {
+	std::wstring buffer;
 	for(int i = 0; i < 10; ++i) {
 		if (!setcode[i])
 			break;
 		const wchar_t* setname = GetSetName(setcode[i]);
 		if(setname) {
-			BufferIO::CopyWStrRef(setname, p, 32);
-			*p = L'|';
-			*++p = 0;
+			if (!buffer.empty())
+				buffer.push_back(L'|');
+			buffer.append(setname);
 		}
 	}
-	if(p != scBuffer)
-		*(p - 1) = 0;
-	else
-		return unknown_string;
-	return scBuffer;
+	if (buffer.empty())
+		return std::wstring(unknown_string);
+	return buffer;
 }
 const wchar_t* DataManager::FormatLinkMarker(int link_marker) {
 	wchar_t* p = lmBuffer;

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -117,8 +117,6 @@ bool DataManager::LoadStrings(const char* file) {
 		ReadStringConfLine(linebuf);
 	}
 	fclose(fp);
-	for(int i = 0; i < 301; ++i)
-		myswprintf(numStrings[i], L"%d", i);
 	return true;
 }
 bool DataManager::LoadStrings(IReadFile* reader) {
@@ -272,14 +270,12 @@ std::vector<unsigned int> DataManager::GetSetCodes(std::wstring setname) const {
 	}
 	return matchingCodes;
 }
-const wchar_t* DataManager::GetNumString(int num, bool bracket) {
+std::wstring DataManager::GetNumString(int num, bool bracket) const {
 	if(!bracket)
-		return numStrings[num];
-	wchar_t* p = numBuffer;
-	*p++ = L'(';
-	BufferIO::CopyWStrRef(numStrings[num], p, 4);
-	*p = L')';
-	*++p = 0;
+		return std::to_wstring(num);
+	std::wstring numBuffer{ L"(" };
+	numBuffer.append(std::to_wstring(num));
+	numBuffer.push_back(L')');
 	return numBuffer;
 }
 const wchar_t* DataManager::FormatLocation(int location, int sequence) const {

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -304,39 +304,31 @@ const wchar_t* DataManager::FormatLocation(int location, int sequence) const {
 	else
 		return unknown_string;
 }
-const wchar_t* DataManager::FormatAttribute(int attribute) {
-	wchar_t* p = attBuffer;
-	unsigned filter = 1;
-	int i = 1010;
-	for(; filter != 0x80; filter <<= 1, ++i) {
-		if(attribute & filter) {
-			BufferIO::CopyWStrRef(GetSysString(i), p, 16);
-			*p = L'|';
-			*++p = 0;
+std::wstring DataManager::FormatAttribute(unsigned int attribute) const {
+	std::wstring buffer;
+	for (int i = 0; i < ATTRIBUTES_COUNT; ++i) {
+		if (attribute & (0x1U << i)) {
+			if (!buffer.empty())
+				buffer.push_back(L'|');
+			buffer.append(GetSysString(1010 + i));
 		}
 	}
-	if(p != attBuffer)
-		*(p - 1) = 0;
-	else
-		return unknown_string;
-	return attBuffer;
+	if (buffer.empty())
+		return std::wstring(unknown_string);
+	return buffer;
 }
-const wchar_t* DataManager::FormatRace(int race) {
-	wchar_t* p = racBuffer;
-	unsigned filter = 1;
-	int i = 1020;
-	for(; filter < (1 << RACES_COUNT); filter <<= 1, ++i) {
-		if(race & filter) {
-			BufferIO::CopyWStrRef(GetSysString(i), p, 16);
-			*p = L'|';
-			*++p = 0;
+std::wstring DataManager::FormatRace(unsigned int race) const {
+	std::wstring buffer;
+	for(int i = 0; i < RACES_COUNT; ++i) {
+		if(race & (0x1U << i)) {
+			if (!buffer.empty())
+				buffer.push_back(L'|');
+			buffer.append(GetSysString(1020 + i));
 		}
 	}
-	if(p != racBuffer)
-		*(p - 1) = 0;
-	else
-		return unknown_string;
-	return racBuffer;
+	if (buffer.empty())
+		return std::wstring(unknown_string);
+	return buffer;
 }
 const wchar_t* DataManager::FormatType(int type) {
 	wchar_t* p = tpBuffer;

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -37,7 +37,7 @@ public:
 	std::wstring FormatRace(unsigned int race) const;
 	std::wstring FormatType(unsigned int type) const;
 	std::wstring FormatSetName(const uint16_t setcode[]) const;
-	const wchar_t* FormatLinkMarker(int link_marker);
+	std::wstring FormatLinkMarker(unsigned int link_marker) const;
 
 	std::unordered_map<unsigned int, std::wstring> _counterStrings;
 	std::unordered_map<unsigned int, std::wstring> _victoryStrings;
@@ -50,7 +50,6 @@ public:
 
 	wchar_t numStrings[301][4]{};
 	wchar_t numBuffer[6]{};
-	wchar_t lmBuffer[32]{};
 
 	static byte scriptBuffer[0x20000];
 	static const wchar_t* unknown_string;

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -36,7 +36,7 @@ public:
 	std::wstring FormatAttribute(unsigned int attribute) const;
 	std::wstring FormatRace(unsigned int race) const;
 	std::wstring FormatType(unsigned int type) const;
-	const wchar_t* FormatSetName(const uint16_t setcode[]);
+	std::wstring FormatSetName(const uint16_t setcode[]) const;
 	const wchar_t* FormatLinkMarker(int link_marker);
 
 	std::unordered_map<unsigned int, std::wstring> _counterStrings;
@@ -50,7 +50,6 @@ public:
 
 	wchar_t numStrings[301][4]{};
 	wchar_t numBuffer[6]{};
-	wchar_t scBuffer[128]{};
 	wchar_t lmBuffer[32]{};
 
 	static byte scriptBuffer[0x20000];

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -31,7 +31,7 @@ public:
 	const wchar_t* GetCounterName(int code) const;
 	const wchar_t* GetSetName(int code) const;
 	std::vector<unsigned int> GetSetCodes(std::wstring setname) const;
-	const wchar_t* GetNumString(int num, bool bracket = false);
+	std::wstring GetNumString(int num, bool bracket = false) const;
 	const wchar_t* FormatLocation(int location, int sequence) const;
 	std::wstring FormatAttribute(unsigned int attribute) const;
 	std::wstring FormatRace(unsigned int race) const;
@@ -47,9 +47,6 @@ public:
 	code_pointer datas_end;
 	string_pointer strings_begin;
 	string_pointer strings_end;
-
-	wchar_t numStrings[301][4]{};
-	wchar_t numBuffer[6]{};
 
 	static byte scriptBuffer[0x20000];
 	static const wchar_t* unknown_string;

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -35,7 +35,7 @@ public:
 	const wchar_t* FormatLocation(int location, int sequence) const;
 	std::wstring FormatAttribute(unsigned int attribute) const;
 	std::wstring FormatRace(unsigned int race) const;
-	const wchar_t* FormatType(int type);
+	std::wstring FormatType(unsigned int type) const;
 	const wchar_t* FormatSetName(const uint16_t setcode[]);
 	const wchar_t* FormatLinkMarker(int link_marker);
 
@@ -50,7 +50,6 @@ public:
 
 	wchar_t numStrings[301][4]{};
 	wchar_t numBuffer[6]{};
-	wchar_t tpBuffer[128]{};
 	wchar_t scBuffer[128]{};
 	wchar_t lmBuffer[32]{};
 

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -33,8 +33,8 @@ public:
 	std::vector<unsigned int> GetSetCodes(std::wstring setname) const;
 	const wchar_t* GetNumString(int num, bool bracket = false);
 	const wchar_t* FormatLocation(int location, int sequence) const;
-	const wchar_t* FormatAttribute(int attribute);
-	const wchar_t* FormatRace(int race);
+	std::wstring FormatAttribute(unsigned int attribute) const;
+	std::wstring FormatRace(unsigned int race) const;
 	const wchar_t* FormatType(int type);
 	const wchar_t* FormatSetName(const uint16_t setcode[]);
 	const wchar_t* FormatLinkMarker(int link_marker);
@@ -50,8 +50,6 @@ public:
 
 	wchar_t numStrings[301][4]{};
 	wchar_t numBuffer[6]{};
-	wchar_t attBuffer[128]{};
-	wchar_t racBuffer[128]{};
 	wchar_t tpBuffer[128]{};
 	wchar_t scBuffer[128]{};
 	wchar_t lmBuffer[32]{};

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -186,7 +186,7 @@ int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_p
 }
 int DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist) {
 	int ct = 0, mainc = 0, sidec = 0, code = 0;
-	int cardlist[300]{};
+	int cardlist[PACK_MAX_SIZE]{};
 	bool is_side = false;
 	std::string linebuf;
 	while (std::getline(deckStream, linebuf, '\n') && ct < (int)(sizeof cardlist / sizeof cardlist[0])) {

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -12,6 +12,7 @@ namespace ygo {
 	constexpr int DECK_MIN_SIZE = 40;
 	constexpr int EXTRA_MAX_SIZE = 15;
 	constexpr int SIDE_MAX_SIZE = 15;
+	constexpr int PACK_MAX_SIZE = 1000;
 
 struct LFList {
 	unsigned int hash{};

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1190,7 +1190,7 @@ void Game::DrawDeckBd() {
 	driver->draw2DRectangle(Resize(310, 137, 410, 157), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 	driver->draw2DRectangleOutline(Resize(309, 136, 410, 157));
 	DrawShadowText(textFont, dataManager.GetSysString(deckBuilder.showing_pack ? 1477 : 1330), Resize(315, 137, 410, 157), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
-	DrawShadowText(numFont, dataManager.numStrings[mainsize], Resize(380, 138, 440, 158), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
+	DrawShadowText(numFont, dataManager.GetNumString(mainsize), Resize(380, 138, 440, 158), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
 	driver->draw2DRectangle(Resize(310, 160, 797, deckBuilder.showing_pack ? 630 : 436), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 	driver->draw2DRectangleOutline(Resize(309, 159, 797, deckBuilder.showing_pack ? 630 : 436));
 	int lx;
@@ -1224,7 +1224,7 @@ void Game::DrawDeckBd() {
 		driver->draw2DRectangle(Resize(310, 440, 410, 460), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 		driver->draw2DRectangleOutline(Resize(309, 439, 410, 460));
 		DrawShadowText(textFont, dataManager.GetSysString(1331), Resize(315, 440, 410, 460), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
-		DrawShadowText(numFont, dataManager.numStrings[deckManager.current_deck.extra.size()], Resize(380, 441, 440, 461), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
+		DrawShadowText(numFont, dataManager.GetNumString(deckManager.current_deck.extra.size()), Resize(380, 441, 440, 461), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
 		driver->draw2DRectangle(Resize(310, 463, 797, 533), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 		driver->draw2DRectangleOutline(Resize(309, 462, 797, 533));
 		if(deckManager.current_deck.extra.size() <= 10)
@@ -1239,7 +1239,7 @@ void Game::DrawDeckBd() {
 		driver->draw2DRectangle(Resize(310, 537, 410, 557), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 		driver->draw2DRectangleOutline(Resize(309, 536, 410, 557));
 		DrawShadowText(textFont, dataManager.GetSysString(1332), Resize(315, 537, 410, 557), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
-		DrawShadowText(numFont, dataManager.numStrings[deckManager.current_deck.side.size()], Resize(380, 538, 440, 558), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
+		DrawShadowText(numFont, dataManager.GetNumString(deckManager.current_deck.side.size()), Resize(380, 538, 440, 558), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
 		driver->draw2DRectangle(Resize(310, 560, 797, 630), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 		driver->draw2DRectangleOutline(Resize(309, 559, 797, 630));
 		if(deckManager.current_deck.side.size() <= 10)

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -564,7 +564,7 @@ void Game::DrawMisc() {
 		lpccolor -= 0x19000000;
 		lpframe--;
 	}
-	if(lpcstring) {
+	if(lpcstring.size()) {
 		if(lpplayer == 0) {
 			DrawShadowText(lpcFont, lpcstring, Resize(400, 472, 922, 520), Resize(0, 2, 2, 0), lpccolor, lpccolor | 0x00ffffff, true, false, 0);
 		} else {

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -957,7 +957,7 @@ void Game::DrawSpec() {
 				DrawShadowText(lpcFont, lstr, ResizePhaseHint(660 - (9 - showcardp) * 40, 290, 960, 370, pos.Width), Resize(-1, -1, 0, 0), alpha | 0xffffff, alpha);
 			} else if(showcardp < showcarddif) {
 				DrawShadowText(lpcFont, lstr, ResizePhaseHint(660, 290, 960, 370, pos.Width), Resize(-1, -1, 0, 0), 0xffffffff);
-				if(dInfo.vic_string && (showcardcode == 1 || showcardcode == 2)) {
+				if(dInfo.vic_string.size() && (showcardcode == 1 || showcardcode == 2)) {
 					int w = guiFont->getDimension(dInfo.vic_string).Width;
 					if(w < 200)
 						w = 200;

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -583,17 +583,17 @@ void Game::DrawMisc() {
 		recti p1size = Resize(335, 31, 629, 50);
 		recti p2size = Resize(986, 31, 986, 50);
 		if(!dInfo.isTag || !dInfo.tag_player[0])
-			textFont->draw(dInfo.hostname, p1size, 0xffffffff, false, false, 0);
+			textFont->drawUstring(dInfo.hostname, p1size, 0xffffffff, false, false, 0);
 		else
-			textFont->draw(dInfo.hostname_tag, p1size, 0xffffffff, false, false, 0);
+			textFont->drawUstring(dInfo.hostname_tag, p1size, 0xffffffff, false, false, 0);
 		if(!dInfo.isTag || !dInfo.tag_player[1]) {
 			auto cld = textFont->getDimension(dInfo.clientname);
 			p2size.UpperLeftCorner.X -= cld.Width;
-			textFont->draw(dInfo.clientname, p2size, 0xffffffff, false, false, 0);
+			textFont->drawUstring(dInfo.clientname, p2size, 0xffffffff, false, false, 0);
 		} else {
 			auto cld = textFont->getDimension(dInfo.clientname_tag);
 			p2size.UpperLeftCorner.X -= cld.Width;
-			textFont->draw(dInfo.clientname_tag, p2size, 0xffffffff, false, false, 0);
+			textFont->drawUstring(dInfo.clientname_tag, p2size, 0xffffffff, false, false, 0);
 		}
 	}
 	driver->draw2DRectangle(Resize(632, 10, 688, 30), 0x00000000, 0x00000000, 0xffffffff, 0xffffffff);
@@ -1021,8 +1021,8 @@ void Game::DrawSpec() {
 			recti shadowloc = msgloc + position2di(1, 1);
 
 			driver->draw2DRectangle(rectloc, 0xa0000000, 0xa0000000, 0xa0000000, 0xa0000000);
-			guiFont->draw(msg.c_str(), msgloc, 0xff000000, false, false);
-			guiFont->draw(msg.c_str(), shadowloc, chatColor[chatType[i]], false, false);
+			guiFont->drawUstring(msg, msgloc, 0xff000000, false, false);
+			guiFont->drawUstring(msg, shadowloc, chatColor[chatType[i]], false, false);
 
 			chatRectY += h;
 		}

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1305,7 +1305,8 @@ void Game::DrawDeckBd() {
 				else
 					myswprintf(adBuffer, L"%d/-", ptr->second.attack);
 			}
-			myswprintf(textBuffer, L"%ls/%ls %ls%d", dataManager.FormatAttribute(ptr->second.attribute), dataManager.FormatRace(ptr->second.race), form, ptr->second.level);
+			myswprintf(textBuffer, L"%ls/%ls %ls%d", dataManager.FormatAttribute(ptr->second.attribute).c_str(), dataManager.FormatRace(ptr->second.race).c_str(),
+				form, ptr->second.level);
 			DrawShadowText(textFont, textBuffer, Resize(860, 187 + i * 66, 955, 207 + i * 66), Resize(1, 1, 0, 0));
 			if(ptr->second.type & TYPE_PENDULUM) {
 				myswprintf(scaleBuffer, L" %d/%d", ptr->second.lscale, ptr->second.rscale);
@@ -1315,8 +1316,8 @@ void Game::DrawDeckBd() {
 		} else {
 			myswprintf(textBuffer, L"%ls", dataManager.GetName(ptr->first));
 			DrawShadowText(textFont, textBuffer, Resize(860, 165 + i * 66, 955, 185 + i * 66), Resize(1, 1, 0, 0));
-			const wchar_t* ptype = dataManager.FormatType(ptr->second.type);
-			DrawShadowText(textFont, ptype, Resize(860, 187 + i * 66, 955, 207 + i * 66), Resize(1, 1, 0, 0));
+			myswprintf(textBuffer, L"%ls", dataManager.FormatType(ptr->second.type).c_str());
+			DrawShadowText(textFont, textBuffer, Resize(860, 187 + i * 66, 955, 207 + i * 66), Resize(1, 1, 0, 0));
 			myswprintf(textBuffer, L"%ls", availBuffer);
 			DrawShadowText(textFont, textBuffer, Resize(860, 209 + i * 66, 955, 229 + i * 66), Resize(1, 1, 0, 0));
 		}

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -411,12 +411,13 @@ void Game::DrawCard(ClientCard* pcard) {
 		driver->drawVertexPrimitiveList(matManager.vSymbol, 4, matManager.iRectangle, 2);
 	}
 }
-void Game::DrawShadowText(CGUITTFont * font, const core::stringw & text, const core::rect<s32>& position, const core::rect<s32>& padding,
-						  video::SColor color, video::SColor shadowcolor, bool hcenter, bool vcenter, const core::rect<s32>* clip) {
+template<typename T>
+inline void DrawShadowText(irr::gui::CGUITTFont* font, const T& text, const core::rect<s32>& position, const core::rect<s32>& padding,
+			video::SColor color = 0xffffffff, video::SColor shadowcolor = 0xff000000, bool hcenter = false, bool vcenter = false, const core::rect<s32>* clip = nullptr) {
 	core::rect<s32> shadowposition = recti(position.UpperLeftCorner.X - padding.UpperLeftCorner.X, position.UpperLeftCorner.Y - padding.UpperLeftCorner.Y, 
 										   position.LowerRightCorner.X - padding.LowerRightCorner.X, position.LowerRightCorner.Y - padding.LowerRightCorner.Y);
-	font->draw(text, shadowposition, shadowcolor, hcenter, vcenter, clip);
-	font->draw(text, position, color, hcenter, vcenter, clip);
+	font->drawUstring(text, shadowposition, shadowcolor, hcenter, vcenter, clip);
+	font->drawUstring(text, position, color, hcenter, vcenter, clip);
 }
 void Game::DrawMisc() {
 	static irr::core::vector3df act_rot(0, 0, 0);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1104,7 +1104,7 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case HINT_RACE: {
-			myswprintf(textBuffer, dataManager.GetSysString(1511), dataManager.FormatRace(data));
+			myswprintf(textBuffer, dataManager.GetSysString(1511), dataManager.FormatRace(data).c_str());
 			mainGame->AddLog(textBuffer);
 			mainGame->gMutex.lock();
 			mainGame->SetStaticText(mainGame->stACMessage, 310, mainGame->guiFont, textBuffer);
@@ -1114,7 +1114,7 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case HINT_ATTRIB: {
-			myswprintf(textBuffer, dataManager.GetSysString(1511), dataManager.FormatAttribute(data));
+			myswprintf(textBuffer, dataManager.GetSysString(1511), dataManager.FormatAttribute(data).c_str());
 			mainGame->AddLog(textBuffer);
 			mainGame->gMutex.lock();
 			mainGame->SetStaticText(mainGame->stACMessage, 310, mainGame->guiFont, textBuffer);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1201,7 +1201,7 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 		int type = BufferIO::ReadUInt8(pbuf);
 		mainGame->showcarddif = 110;
 		mainGame->showcardp = 0;
-		mainGame->dInfo.vic_string = 0;
+		mainGame->dInfo.vic_string = L"";
 		wchar_t vic_buf[256];
 		if(player == 2)
 			mainGame->showcardcode = 3;
@@ -1227,7 +1227,7 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		mainGame->showcard = 101;
 		mainGame->WaitFrameSignal(120);
-		mainGame->dInfo.vic_string = 0;
+		mainGame->dInfo.vic_string = L"";
 		mainGame->showcard = 0;
 		break;
 	}

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -3184,7 +3184,7 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 		mainGame->WaitFrameSignal(30);
 		mainGame->lpframe = 10;
 		mainGame->WaitFrameSignal(11);
-		mainGame->lpcstring = 0;
+		mainGame->lpcstring = L"";
 		mainGame->dInfo.lp[player] = final;
 		mainGame->gMutex.lock();
 		myswprintf(mainGame->dInfo.strLP[player], L"%d", mainGame->dInfo.lp[player]);
@@ -3213,7 +3213,7 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 		mainGame->WaitFrameSignal(30);
 		mainGame->lpframe = 10;
 		mainGame->WaitFrameSignal(11);
-		mainGame->lpcstring = 0;
+		mainGame->lpcstring = L"";
 		mainGame->dInfo.lp[player] = final;
 		mainGame->gMutex.lock();
 		myswprintf(mainGame->dInfo.strLP[player], L"%d", mainGame->dInfo.lp[player]);
@@ -3365,7 +3365,7 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 		mainGame->WaitFrameSignal(30);
 		mainGame->lpframe = 10;
 		mainGame->WaitFrameSignal(11);
-		mainGame->lpcstring = 0;
+		mainGame->lpcstring = L"";
 		mainGame->dInfo.lp[player] = final;
 		mainGame->gMutex.lock();
 		myswprintf(mainGame->dInfo.strLP[player], L"%d", mainGame->dInfo.lp[player]);

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -1600,7 +1600,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 									myswprintf(formatBuffer, L"\nLINK-%d", mcard->link);
 									str.append(formatBuffer);
 								}
-								myswprintf(formatBuffer, L" %ls/%ls", dataManager.FormatRace(mcard->race), dataManager.FormatAttribute(mcard->attribute));
+								myswprintf(formatBuffer, L" %ls/%ls", dataManager.FormatRace(mcard->race).c_str(), dataManager.FormatAttribute(mcard->attribute).c_str());
 								str.append(formatBuffer);
 								if(mcard->location == LOCATION_HAND && (mcard->type & TYPE_PENDULUM)) {
 									myswprintf(formatBuffer, L"\n%d/%d", mcard->lscale, mcard->rscale);
@@ -1626,9 +1626,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 								else if(mcard->cHint == CHINT_CARD)
 									myswprintf(formatBuffer, L"\n%ls%ls", dataManager.GetSysString(212), dataManager.GetName(mcard->chValue));
 								else if(mcard->cHint == CHINT_RACE)
-									myswprintf(formatBuffer, L"\n%ls%ls", dataManager.GetSysString(213), dataManager.FormatRace(mcard->chValue));
+									myswprintf(formatBuffer, L"\n%ls%ls", dataManager.GetSysString(213), dataManager.FormatRace(mcard->chValue).c_str());
 								else if(mcard->cHint == CHINT_ATTRIBUTE)
-									myswprintf(formatBuffer, L"\n%ls%ls", dataManager.GetSysString(214), dataManager.FormatAttribute(mcard->chValue));
+									myswprintf(formatBuffer, L"\n%ls%ls", dataManager.GetSysString(214), dataManager.FormatAttribute(mcard->chValue).c_str());
 								else if(mcard->cHint == CHINT_NUMBER)
 									myswprintf(formatBuffer, L"\n%ls%d", dataManager.GetSysString(215), mcard->chValue);
 								str.append(formatBuffer);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1586,9 +1586,9 @@ void Game::ShowCardInfo(int code, bool resize) {
 		} else {
 			form = L"LINK-";
 			if(cd.attack < 0)
-				myswprintf(adBuffer, L"?/-   %ls", dataManager.FormatLinkMarker(cd.link_marker));
+				myswprintf(adBuffer, L"?/-   %ls", dataManager.FormatLinkMarker(cd.link_marker).c_str());
 			else
-				myswprintf(adBuffer, L"%d/-   %ls", cd.attack, dataManager.FormatLinkMarker(cd.link_marker));
+				myswprintf(adBuffer, L"%d/-   %ls", cd.attack, dataManager.FormatLinkMarker(cd.link_marker).c_str());
 		}
 		if(cd.type & TYPE_PENDULUM) {
 			myswprintf(scaleBuffer, L"   %d/%d", cd.lscale, cd.rscale);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -43,7 +43,6 @@ void DuelInfo::Clear() {
 	clientname_tag[0] = 0;
 	strLP[0][0] = 0;
 	strLP[1][0] = 0;
-	vic_string = 0;
 	player_type = 0;
 	time_player = 0;
 	time_limit = 0;

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1552,7 +1552,7 @@ void Game::ShowCardInfo(int code, bool resize) {
 		}
 		if (target->second.setcode[0]) {
 			offset = 23;// *yScale;
-			myswprintf(formatBuffer, L"%ls%ls", dataManager.GetSysString(1329), dataManager.FormatSetName(target->second.setcode));
+			myswprintf(formatBuffer, L"%ls%ls", dataManager.GetSysString(1329), dataManager.FormatSetName(target->second.setcode).c_str());
 			stSetName->setText(formatBuffer);
 		}
 		else

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -613,14 +613,14 @@ bool Game::Initialize() {
 	wANAttribute->setVisible(false);
 	for(int filter = 0x1, i = 0; i < 7; filter <<= 1, ++i)
 		chkAttribute[i] = env->addCheckBox(false, rect<s32>(10 + (i % 4) * 80, 25 + (i / 4) * 25, 90 + (i % 4) * 80, 50 + (i / 4) * 25),
-		                                   wANAttribute, CHECK_ATTRIBUTE, dataManager.FormatAttribute(filter));
+		                                   wANAttribute, CHECK_ATTRIBUTE, dataManager.FormatAttribute(filter).c_str());
 	//announce race
 	wANRace = env->addWindow(rect<s32>(480, 200, 850, 410), false, dataManager.GetSysString(563));
 	wANRace->getCloseButton()->setVisible(false);
 	wANRace->setVisible(false);
 	for(int filter = 0x1, i = 0; i < RACES_COUNT; filter <<= 1, ++i)
 		chkRace[i] = env->addCheckBox(false, rect<s32>(10 + (i % 4) * 90, 25 + (i / 4) * 25, 100 + (i % 4) * 90, 50 + (i / 4) * 25),
-		                              wANRace, CHECK_RACE, dataManager.FormatRace(filter));
+		                              wANRace, CHECK_RACE, dataManager.FormatRace(filter).c_str());
 	//selection hint
 	stHintMsg = env->addStaticText(L"", rect<s32>(500, 60, 820, 90), true, false, 0, -1, false);
 	stHintMsg->setBackgroundColor(0xc0ffffff);
@@ -750,13 +750,13 @@ bool Game::Initialize() {
 	cbAttribute->setMaxSelectionRows(10);
 	cbAttribute->addItem(dataManager.GetSysString(1310), 0);
 	for(int filter = 0x1; filter != 0x80; filter <<= 1)
-		cbAttribute->addItem(dataManager.FormatAttribute(filter), filter);
+		cbAttribute->addItem(dataManager.FormatAttribute(filter).c_str(), filter);
 	stRace = env->addStaticText(dataManager.GetSysString(1321), rect<s32>(10, 42 + 75 / 6, 70, 62 + 75 / 6), false, false, wFilter);
 	cbRace = env->addComboBox(rect<s32>(60, 40 + 75 / 6, 195, 60 + 75 / 6), wFilter, COMBOBOX_RACE);
 	cbRace->setMaxSelectionRows(10);
 	cbRace->addItem(dataManager.GetSysString(1310), 0);
 	for(int filter = 0x1; filter < (1 << RACES_COUNT); filter <<= 1)
-		cbRace->addItem(dataManager.FormatRace(filter), filter);
+		cbRace->addItem(dataManager.FormatRace(filter).c_str(), filter);
 	stAttack = env->addStaticText(dataManager.GetSysString(1322), rect<s32>(205, 22 + 50 / 6, 280, 42 + 50 / 6), false, false, wFilter);
 	ebAttack = env->addEditBox(L"", rect<s32>(260, 20 + 50 / 6, 340, 40 + 50 / 6), true, wFilter, EDITBOX_INPUTS);
 	ebAttack->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
@@ -1563,7 +1563,7 @@ void Game::ShowCardInfo(int code, bool resize) {
 	}
 	if(is_valid && cit->second.type & TYPE_MONSTER) {
 		auto& cd = cit->second;
-		myswprintf(formatBuffer, L"[%ls] %ls/%ls", dataManager.FormatType(cd.type), dataManager.FormatRace(cd.race), dataManager.FormatAttribute(cd.attribute));
+		myswprintf(formatBuffer, L"[%ls] %ls/%ls", dataManager.FormatType(cd.type), dataManager.FormatRace(cd.race).c_str(), dataManager.FormatAttribute(cd.attribute).c_str());
 		stInfo->setText(formatBuffer);
 		int offset_info = 0;
 		irr::core::dimension2d<unsigned int> dtxt = guiFont->getDimension(formatBuffer);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -77,7 +77,6 @@ bool Game::Initialize() {
 	showcard = 0;
 	is_attacking = false;
 	lpframe = 0;
-	lpcstring = 0;
 	always_chain = false;
 	ignore_chain = false;
 	chain_when_avail = false;

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1563,7 +1563,7 @@ void Game::ShowCardInfo(int code, bool resize) {
 	}
 	if(is_valid && cit->second.type & TYPE_MONSTER) {
 		auto& cd = cit->second;
-		myswprintf(formatBuffer, L"[%ls] %ls/%ls", dataManager.FormatType(cd.type), dataManager.FormatRace(cd.race).c_str(), dataManager.FormatAttribute(cd.attribute).c_str());
+		myswprintf(formatBuffer, L"[%ls] %ls/%ls", dataManager.FormatType(cd.type).c_str(), dataManager.FormatRace(cd.race).c_str(), dataManager.FormatAttribute(cd.attribute).c_str());
 		stInfo->setText(formatBuffer);
 		int offset_info = 0;
 		irr::core::dimension2d<unsigned int> dtxt = guiFont->getDimension(formatBuffer);
@@ -1607,9 +1607,9 @@ void Game::ShowCardInfo(int code, bool resize) {
 	}
 	else {
 		if (is_valid)
-			myswprintf(formatBuffer, L"[%ls]", dataManager.FormatType(cit->second.type));
+			myswprintf(formatBuffer, L"[%ls]", dataManager.FormatType(cit->second.type).c_str());
 		else
-			myswprintf(formatBuffer, L"[%ls]", dataManager.FormatType(0));
+			myswprintf(formatBuffer, L"[%ls]", dataManager.unknown_string);
 		stInfo->setText(formatBuffer);
 		stDataInfo->setText(L"");
 		stSetName->setRelativePosition(rect<s32>(15, 60, 296 * xScale, 60 + offset));

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -257,7 +257,7 @@ public:
 	int lpd;
 	int lpplayer;
 	int lpccolor;
-	wchar_t* lpcstring;
+	std::wstring lpcstring;
 	bool always_chain;
 	bool ignore_chain;
 	bool chain_when_avail;

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -104,7 +104,7 @@ struct DuelInfo {
 	wchar_t hostname_tag[20]{};
 	wchar_t clientname_tag[20]{};
 	wchar_t strLP[2][16]{};
-	wchar_t* vic_string{ nullptr };
+	std::wstring vic_string;
 	unsigned char player_type{ 0 };
 	unsigned char time_player{ 0 };
 	unsigned short time_limit{ 0 };

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -157,7 +157,6 @@ public:
 	void CheckMutual(ClientCard* pcard, int mark);
 	void DrawCards();
 	void DrawCard(ClientCard* pcard);
-	void DrawShadowText(irr::gui::CGUITTFont* font, const core::stringw& text, const core::rect<s32>& position, const core::rect<s32>& padding, video::SColor color = 0xffffffff, video::SColor shadowcolor = 0xff000000, bool hcenter = false, bool vcenter = false, const core::rect<s32>* clip = 0);
 	void DrawMisc();
 	void DrawStatus(ClientCard* pcard, int x1, int y1, int x2, int y2);
 	void DrawGUI();

--- a/gframe/irrUString.h
+++ b/gframe/irrUString.h
@@ -1,6 +1,7 @@
 /*
    Basic Unicode string class for Irrlicht.
    Copyright (c) 2009-2011 John Norman
+   Copyright (c) 2022 Edoardo Lolletti
 
    This software is provided 'as-is', without any express or implied
    warranty. In no event will the authors be held liable for any
@@ -11,15 +12,15 @@
    redistribute it freely, subject to the following restrictions:
 
    1. The origin of this software must not be misrepresented; you
-      must not claim that you wrote the original software. If you use
-      this software in a product, an acknowledgment in the product
-      documentation would be appreciated but is not required.
+	  must not claim that you wrote the original software. If you use
+	  this software in a product, an acknowledgment in the product
+	  documentation would be appreciated but is not required.
 
    2. Altered source versions must be plainly marked as such, and
-      must not be misrepresented as being the original software.
+	  must not be misrepresented as being the original software.
 
    3. This notice may not be removed or altered from any source
-      distribution.
+	  distribution.
 
    The original version of this class can be located at:
    http://irrlicht.suckerfreegames.com/
@@ -31,444 +32,118 @@
 #ifndef __IRR_USTRING_H_INCLUDED__
 #define __IRR_USTRING_H_INCLUDED__
 
-#define USTRING_CPP0X
-#define USTRING_CPP0X_NEWLITERALS
+#include <cstring>
+#include <cstdlib>
+#include <cstdint>
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stddef.h>
-
-#ifdef USTRING_CPP0X
-#	include <utility>
-#endif
-
-#ifndef USTRING_NO_STL
-#	include <string>
-#	include <iterator>
-#	include <ostream>
-#endif
-
-#include "irrTypes.h"
-#include "irrAllocator.h"
-#include "irrArray.h"
-#include "irrMath.h"
-#include "irrString.h"
-#include "path.h"
-
-//! UTF-16 surrogate start values.
-static const irr::u16 UTF16_HI_SURROGATE = 0xD800;
-static const irr::u16 UTF16_LO_SURROGATE = 0xDC00;
-
-//! Is a UTF-16 code point a surrogate?
-#define UTF16_IS_SURROGATE(c)		(((c) & 0xF800) == 0xD800)
-#define UTF16_IS_SURROGATE_HI(c)	(((c) & 0xFC00) == 0xD800)
-#define UTF16_IS_SURROGATE_LO(c)	(((c) & 0xFC00) == 0xDC00)
+#include <utility>
+#include <iterator>
 
 
 namespace irr {
 
-// Define our character types.
-#ifdef USTRING_CPP0X_NEWLITERALS	// C++0x
 typedef char32_t uchar32_t;
 typedef char16_t uchar16_t;
 typedef char uchar8_t;
-#else
-typedef u32 uchar32_t;
-typedef u16 uchar16_t;
-typedef u8 uchar8_t;
-#endif
 
 namespace core {
 
 namespace unicode {
 
 //! The unicode replacement character.  Used to replace invalid characters.
-const irr::u16 UTF_REPLACEMENT_CHARACTER = 0xFFFD;
+constexpr uchar32_t UTF_REPLACEMENT_CHARACTER = 0xFFFD;
 
 //! Convert a UTF-16 surrogate pair into a UTF-32 character.
 //! \param high The high value of the pair.
 //! \param low The low value of the pair.
 //! \return The UTF-32 character expressed by the surrogate pair.
-inline uchar32_t toUTF32(uchar16_t high, uchar16_t low) {
+inline constexpr uchar32_t toUTF32(uchar16_t high, uchar16_t low) {
 	// Convert the surrogate pair into a single UTF-32 character.
 	uchar32_t x = ((high & ((1 << 6) - 1)) << 10) | (low & ((1 << 10) - 1));
 	uchar32_t wu = ((high >> 6) & ((1 << 5) - 1)) + 1;
 	return (wu << 16) | x;
 }
 
-//! Swaps the endianness of a 16-bit value.
-//! \return The new value.
-inline uchar16_t swapEndian16(const uchar16_t& c) {
-	return ((c >> 8) & 0x00FF) | ((c << 8) & 0xFF00);
-}
-
-//! Swaps the endianness of a 32-bit value.
-//! \return The new value.
-inline uchar32_t swapEndian32(const uchar32_t& c) {
-	return  ((c >> 24) & 0x000000FF) |
-			((c >> 8)  & 0x0000FF00) |
-			((c << 8)  & 0x00FF0000) |
-			((c << 24) & 0xFF000000);
-}
-
-//! The Unicode byte order mark.
-const u16 BOM = 0xFEFF;
-
-//! The size of the Unicode byte order mark in terms of the Unicode character size.
-const u8 BOM_UTF8_LEN = 3;
-const u8 BOM_UTF16_LEN = 1;
-const u8 BOM_UTF32_LEN = 1;
-
-//! Unicode byte order marks for file operations.
-const u8 BOM_ENCODE_UTF8[3] = { 0xEF, 0xBB, 0xBF };
-const u8 BOM_ENCODE_UTF16_BE[2] = { 0xFE, 0xFF };
-const u8 BOM_ENCODE_UTF16_LE[2] = { 0xFF, 0xFE };
-const u8 BOM_ENCODE_UTF32_BE[4] = { 0x00, 0x00, 0xFE, 0xFF };
-const u8 BOM_ENCODE_UTF32_LE[4] = { 0xFF, 0xFE, 0x00, 0x00 };
-
-//! The size in bytes of the Unicode byte marks for file operations.
-const u8 BOM_ENCODE_UTF8_LEN = 3;
-const u8 BOM_ENCODE_UTF16_LEN = 2;
-const u8 BOM_ENCODE_UTF32_LEN = 4;
-
-//! Unicode encoding type.
-enum EUTF_ENCODE {
-	EUTFE_NONE		= 0,
-	EUTFE_UTF8,
-	EUTFE_UTF16,
-	EUTFE_UTF16_LE,
-	EUTFE_UTF16_BE,
-	EUTFE_UTF32,
-	EUTFE_UTF32_LE,
-	EUTFE_UTF32_BE
-};
-
-//! Unicode endianness.
-enum EUTF_ENDIAN {
-	EUTFEE_NATIVE	= 0,
-	EUTFEE_LITTLE,
-	EUTFEE_BIG
-};
-
-//! Returns the specified unicode byte order mark in a byte array.
-//! The byte order mark is the first few bytes in a text file that signifies its encoding.
-/** \param mode The Unicode encoding method that we want to get the byte order mark for.
-		If EUTFE_UTF16 or EUTFE_UTF32 is passed, it uses the native system endianness. **/
-//! \return An array that contains a byte order mark.
-inline core::array<u8> getUnicodeBOM(EUTF_ENCODE mode) {
-#define COPY_ARRAY(source, size) \
-	memcpy(ret.pointer(), source, size); \
-	ret.set_used(size)
-
-	core::array<u8> ret(4);
-	switch (mode) {
-	case EUTFE_UTF8:
-		COPY_ARRAY(BOM_ENCODE_UTF8, BOM_ENCODE_UTF8_LEN);
-		break;
-	case EUTFE_UTF16:
-#ifdef __BIG_ENDIAN__
-		COPY_ARRAY(BOM_ENCODE_UTF16_BE, BOM_ENCODE_UTF16_LEN);
-#else
-		COPY_ARRAY(BOM_ENCODE_UTF16_LE, BOM_ENCODE_UTF16_LEN);
-#endif
-		break;
-	case EUTFE_UTF16_BE:
-		COPY_ARRAY(BOM_ENCODE_UTF16_BE, BOM_ENCODE_UTF16_LEN);
-		break;
-	case EUTFE_UTF16_LE:
-		COPY_ARRAY(BOM_ENCODE_UTF16_LE, BOM_ENCODE_UTF16_LEN);
-		break;
-	case EUTFE_UTF32:
-#ifdef __BIG_ENDIAN__
-		COPY_ARRAY(BOM_ENCODE_UTF32_BE, BOM_ENCODE_UTF32_LEN);
-#else
-		COPY_ARRAY(BOM_ENCODE_UTF32_LE, BOM_ENCODE_UTF32_LEN);
-#endif
-		break;
-	case EUTFE_UTF32_BE:
-		COPY_ARRAY(BOM_ENCODE_UTF32_BE, BOM_ENCODE_UTF32_LEN);
-		break;
-	case EUTFE_UTF32_LE:
-		COPY_ARRAY(BOM_ENCODE_UTF32_LE, BOM_ENCODE_UTF32_LEN);
-		break;
-	default: break;
-	}
-	return ret;
-
-#undef COPY_ARRAY
-}
-
-//! Detects if the given data stream starts with a unicode BOM.
-//! \param data The data stream to check.
-//! \return The unicode BOM associated with the data stream, or EUTFE_NONE if none was found.
-inline EUTF_ENCODE determineUnicodeBOM(const char* data) {
-	if (memcmp(data, BOM_ENCODE_UTF8, 3) == 0) return EUTFE_UTF8;
-	if (memcmp(data, BOM_ENCODE_UTF16_BE, 2) == 0) return EUTFE_UTF16_BE;
-	if (memcmp(data, BOM_ENCODE_UTF16_LE, 2) == 0) return EUTFE_UTF16_LE;
-	if (memcmp(data, BOM_ENCODE_UTF32_BE, 4) == 0) return EUTFE_UTF32_BE;
-	if (memcmp(data, BOM_ENCODE_UTF32_LE, 4) == 0) return EUTFE_UTF32_LE;
-	return EUTFE_NONE;
-}
-
 } // end namespace unicode
 
 
 //! UTF-16 string class.
-template <typename TAlloc = irrAllocator<uchar16_t> >
 class ustring16 {
 public:
+	//! UTF-16 surrogate start values.
+	static constexpr uint16_t UTF16_HI_SURROGATE = 0xD800;
+	static constexpr uint16_t UTF16_LO_SURROGATE = 0xDC00;
 
-	///------------------///
-	/// iterator classes ///
-	///------------------///
+	//! Is a UTF-16 code point a surrogate?
+	static constexpr bool UTF16_IS_SURROGATE(uchar16_t c) {
+		return (c & 0xF800) == UTF16_HI_SURROGATE;
+	}
+	static constexpr bool UTF16_IS_SURROGATE_HI(uchar16_t c) {
+		return (c & 0xFC00) == UTF16_HI_SURROGATE;
+	}
+	static constexpr bool UTF16_IS_SURROGATE_LO(uchar16_t c) {
+		return (c & 0xFC00) == UTF16_LO_SURROGATE;
+	}
+	static constexpr bool UTF16_IS_VALID_SURROGATE_PAIR(uchar16_t lo, uchar16_t hi) {
+		return UTF16_IS_SURROGATE_HI(hi) && UTF16_IS_SURROGATE_LO(lo);
+	}
 
-	//! Access an element in a unicode string, allowing one to change it.
-	class _ustring16_iterator_access {
-	public:
-		_ustring16_iterator_access(const ustring16<TAlloc>* s, u32 p) : ref(s), pos(p) {}
-
-		//! Allow the class to be interpreted as a single UTF-32 character.
-		operator uchar32_t() const {
-			return _get();
-		}
-
-		//! Allow one to change the character in the unicode string.
-		//! \param c The new character to use.
-		//! \return Myself.
-		_ustring16_iterator_access& operator=(const uchar32_t c) {
-			_set(c);
-			return *this;
-		}
-
-		//! Increments the value by 1.
-		//! \return Myself.
-		_ustring16_iterator_access& operator++() {
-			_set(_get() + 1);
-			return *this;
-		}
-
-		//! Increments the value by 1, returning the old value.
-		//! \return A unicode character.
-		uchar32_t operator++(int) {
-			uchar32_t old = _get();
-			_set(old + 1);
-			return old;
-		}
-
-		//! Decrements the value by 1.
-		//! \return Myself.
-		_ustring16_iterator_access& operator--() {
-			_set(_get() - 1);
-			return *this;
-		}
-
-		//! Decrements the value by 1, returning the old value.
-		//! \return A unicode character.
-		uchar32_t operator--(int) {
-			uchar32_t old = _get();
-			_set(old - 1);
-			return old;
-		}
-
-		//! Adds to the value by a specified amount.
-		//! \param val The amount to add to this character.
-		//! \return Myself.
-		_ustring16_iterator_access& operator+=(int val) {
-			_set(_get() + val);
-			return *this;
-		}
-
-		//! Subtracts from the value by a specified amount.
-		//! \param val The amount to subtract from this character.
-		//! \return Myself.
-		_ustring16_iterator_access& operator-=(int val) {
-			_set(_get() - val);
-			return *this;
-		}
-
-		//! Multiples the value by a specified amount.
-		//! \param val The amount to multiply this character by.
-		//! \return Myself.
-		_ustring16_iterator_access& operator*=(int val) {
-			_set(_get() * val);
-			return *this;
-		}
-
-		//! Divides the value by a specified amount.
-		//! \param val The amount to divide this character by.
-		//! \return Myself.
-		_ustring16_iterator_access& operator/=(int val) {
-			_set(_get() / val);
-			return *this;
-		}
-
-		//! Modulos the value by a specified amount.
-		//! \param val The amount to modulo this character by.
-		//! \return Myself.
-		_ustring16_iterator_access& operator%=(int val) {
-			_set(_get() % val);
-			return *this;
-		}
-
-		//! Adds to the value by a specified amount.
-		//! \param val The amount to add to this character.
-		//! \return A unicode character.
-		uchar32_t operator+(int val) const {
-			return _get() + val;
-		}
-
-		//! Subtracts from the value by a specified amount.
-		//! \param val The amount to subtract from this character.
-		//! \return A unicode character.
-		uchar32_t operator-(int val) const {
-			return _get() - val;
-		}
-
-		//! Multiplies the value by a specified amount.
-		//! \param val The amount to multiply this character by.
-		//! \return A unicode character.
-		uchar32_t operator*(int val) const {
-			return _get() * val;
-		}
-
-		//! Divides the value by a specified amount.
-		//! \param val The amount to divide this character by.
-		//! \return A unicode character.
-		uchar32_t operator/(int val) const {
-			return _get() / val;
-		}
-
-		//! Modulos the value by a specified amount.
-		//! \param val The amount to modulo this character by.
-		//! \return A unicode character.
-		uchar32_t operator%(int val) const {
-			return _get() % val;
-		}
-
-	private:
-		//! Gets a uchar32_t from our current position.
-		uchar32_t _get() const {
-			const uchar16_t* a = ref->c_str();
-			if (!UTF16_IS_SURROGATE(a[pos]))
-				return static_cast<uchar32_t>(a[pos]);
-			else {
-				if (pos + 1 >= ref->size_raw())
-					return 0;
-
-				return unicode::toUTF32(a[pos], a[pos + 1]);
-			}
-		}
-
-		//! Sets a uchar32_t at our current position.
-		void _set(uchar32_t c) {
-			ustring16<TAlloc>* ref2 = const_cast<ustring16<TAlloc>*>(ref);
-			const uchar16_t* a = ref2->c_str();
-			if (c > 0xFFFF) {
-				// c will be multibyte, so split it up into the high and low surrogate pairs.
-				uchar16_t x = static_cast<uchar16_t>(c);
-				uchar16_t vh = UTF16_HI_SURROGATE | ((((c >> 16) & ((1 << 5) - 1)) - 1) << 6) | (x >> 10);
-				uchar16_t vl = UTF16_LO_SURROGATE | (x & ((1 << 10) - 1));
-
-				// If the previous position was a surrogate pair, just replace them.  Else, insert the low pair.
-				if (UTF16_IS_SURROGATE_HI(a[pos]) && pos + 1 != ref2->size_raw())
-					ref2->replace_raw(vl, static_cast<u32>(pos) + 1);
-				else ref2->insert_raw(vl, static_cast<u32>(pos) + 1);
-
-				ref2->replace_raw(vh, static_cast<u32>(pos));
-			} else {
-				// c will be a single byte.
-				uchar16_t vh = static_cast<uchar16_t>(c);
-
-				// If the previous position was a surrogate pair, remove the extra byte.
-				if (UTF16_IS_SURROGATE_HI(a[pos]))
-					ref2->erase_raw(static_cast<u32>(pos) + 1);
-
-				ref2->replace_raw(vh, static_cast<u32>(pos));
-			}
-		}
-
-		const ustring16<TAlloc>* ref;
-		u32 pos;
-	};
-	typedef typename ustring16<TAlloc>::_ustring16_iterator_access access;
+	typedef uchar32_t access;
 
 
 	//! Iterator to iterate through a UTF-16 string.
-#ifndef USTRING_NO_STL
-	class _ustring16_const_iterator : public std::iterator <
-		std::bidirectional_iterator_tag,	// iterator_category
-		access,								// value_type
-		ptrdiff_t,							// difference_type
-		const access,						// pointer
-		const access						// reference
-		>
-#else
 	class _ustring16_const_iterator
-#endif
 	{
 	public:
 		typedef _ustring16_const_iterator _Iter;
-		typedef std::iterator<std::bidirectional_iterator_tag, access, ptrdiff_t, const access, const access> _Base;
 		typedef const access const_pointer;
 		typedef const access const_reference;
-
-#ifndef USTRING_NO_STL
-		typedef typename _Base::value_type value_type;
-		typedef typename _Base::difference_type difference_type;
-		typedef typename _Base::difference_type distance_type;
-		typedef typename _Base::pointer pointer;
-		typedef const_reference reference;
-#else
+		typedef ptrdiff_t distance_type;
+		// stuff for std::iterator_traits
+		typedef std::bidirectional_iterator_tag iterator_category;
 		typedef access value_type;
-		typedef u32 difference_type;
-		typedef u32 distance_type;
-		typedef const_pointer pointer;
+		typedef distance_type difference_type;
+		typedef const access pointer;
 		typedef const_reference reference;
-#endif
 
 		//! Constructors.
 		_ustring16_const_iterator(const _Iter& i) : ref(i.ref), pos(i.pos) {}
-		_ustring16_const_iterator(const ustring16<TAlloc>& s) : ref(&s), pos(0) {}
-		_ustring16_const_iterator(const ustring16<TAlloc>& s, const u32 p) : ref(&s), pos(0) {
-			if (ref->size_raw() == 0 || p == 0)
+		_ustring16_const_iterator(const ustring16& s) : ref(&s), pos(0) {}
+		_ustring16_const_iterator(const ustring16& s, const u32 p) : ref(&s), pos(0) {
+			if(ref->size_raw() == 0 || p == 0)
 				return;
 
 			// Go to the appropriate position.
-			u32 i = p;
-			u32 sr = ref->size_raw();
-			const uchar16_t* a = ref->c_str();
-			while (i != 0 && pos < sr) {
-				if (UTF16_IS_SURROGATE_HI(a[pos]))
-					pos += 2;
-				else ++pos;
-				--i;
-			}
+
+			advance(p);
 		}
 
 		//! Test for equalness.
 		bool operator==(const _Iter& iter) const {
-			if (ref == iter.ref && pos == iter.pos)
+			if(ref == iter.ref && pos == iter.pos)
 				return true;
 			return false;
 		}
 
 		//! Test for unequalness.
 		bool operator!=(const _Iter& iter) const {
-			if (ref != iter.ref || pos != iter.pos)
-				return true;
-			return false;
+			return !operator==(iter);
 		}
 
 		//! Switch to the next full character in the string.
 		_Iter& operator++() {
 			// ++iterator
-			if (pos == ref->size_raw()) return *this;
-			const uchar16_t* a = ref->c_str();
-			if (UTF16_IS_SURROGATE_HI(a[pos]))
-				pos += 2;			// TODO: check for valid low surrogate?
-			else ++pos;
-			if (pos > ref->size_raw()) pos = ref->size_raw();
+			if(pos == ref->size_raw()) return *this;
+			if(is_utf32) {
+				pos++;
+			} else {
+				if(isNextCodepointValidSurrogatePair())
+					pos += 2;
+				else
+					pos++;
+				if(pos > ref->size_raw())
+					pos = ref->size_raw();
+			}
 			return *this;
 		}
 
@@ -483,11 +158,15 @@ public:
 		//! Switch to the previous full character in the string.
 		_Iter& operator--() {
 			// --iterator
-			if (pos == 0) return *this;
-			const uchar16_t* a = ref->c_str();
-			--pos;
-			if (UTF16_IS_SURROGATE_LO(a[pos]) && pos != 0)	// low surrogate, go back one more.
+			if(pos == 0) return *this;
+			if(is_utf32) {
 				--pos;
+			} else {
+				const uchar16_t* a = reinterpret_cast<const uchar16_t*>(ref->data());
+				--pos;
+				if(UTF16_IS_SURROGATE_LO(a[pos]) && pos != 0 && UTF16_IS_SURROGATE_HI(a[pos - 1]))	// low surrogate, go back one more.
+					--pos;
+			}
 			return *this;
 		}
 
@@ -502,25 +181,13 @@ public:
 		//! Advance a specified number of full characters in the string.
 		//! \return Myself.
 		_Iter& operator+=(const difference_type v) {
-			if (v == 0) return *this;
-			if (v < 0) return operator-=(v * -1);
+			if(v == 0) return *this;
+			if(v < 0) return operator-=(v * -1);
 
-			if (pos >= ref->size_raw())
+			if(pos >= ref->size_raw())
 				return *this;
 
-			// Go to the appropriate position.
-			// TODO: Don't force u32 on an x64 OS.  Make it agnostic.
-			u32 i = (u32)v;
-			u32 sr = ref->size_raw();
-			const uchar16_t* a = ref->c_str();
-			while (i != 0 && pos < sr) {
-				if (UTF16_IS_SURROGATE_HI(a[pos]))
-					pos += 2;
-				else ++pos;
-				--i;
-			}
-			if (pos > sr)
-				pos = sr;
+			advance(v);
 
 			return *this;
 		}
@@ -528,22 +195,13 @@ public:
 		//! Go back a specified number of full characters in the string.
 		//! \return Myself.
 		_Iter& operator-=(const difference_type v) {
-			if (v == 0) return *this;
-			if (v > 0) return operator+=(v * -1);
+			if(v == 0) return *this;
+			if(v > 0) return operator+=(v * -1);
 
-			if (pos == 0)
+			if(pos == 0)
 				return *this;
 
-			// Go to the appropriate position.
-			// TODO: Don't force u32 on an x64 OS.  Make it agnostic.
-			u32 i = (u32)v;
-			const uchar16_t* a = ref->c_str();
-			while (i != 0 && pos != 0) {
-				--pos;
-				if (UTF16_IS_SURROGATE_LO(a[pos]) != 0 && pos != 0)
-					--pos;
-				--i;
-			}
+			go_back(v);
 
 			return *this;
 		}
@@ -565,15 +223,15 @@ public:
 		//! Returns the distance between two iterators.
 		difference_type operator-(const _Iter& iter) const {
 			// Make sure we reference the same object!
-			if (ref != iter.ref)
+			if(ref != iter.ref)
 				return difference_type();
 
 			_Iter i = iter;
-			difference_type ret;
+			difference_type ret = 0;
 
 			// Walk up.
-			if (pos > i.pos) {
-				while (pos > i.pos) {
+			if(pos > i.pos) {
+				while(pos > i.pos) {
 					++i;
 					++ret;
 				}
@@ -581,7 +239,7 @@ public:
 			}
 
 			// Walk down.
-			while (pos < i.pos) {
+			while(pos < i.pos) {
 				--i;
 				--ret;
 			}
@@ -590,30 +248,28 @@ public:
 
 		//! Accesses the full character at the iterator's position.
 		const_reference operator*() const {
-			if (pos >= ref->size_raw()) {
-				const uchar16_t* a = ref->c_str();
-				u32 p = ref->size_raw();
-				if (UTF16_IS_SURROGATE_LO(a[p]))
-					--p;
-				reference ret(ref, p);
-				return ret;
+			auto size = ref->size_raw();
+			_IRR_DEBUG_BREAK_IF(pos >= size);
+			if(is_utf32) {
+				const uchar32_t* data = reinterpret_cast<const uchar32_t*>(ref->data());
+				auto ch = data[pos];
+				if(ch >= 0xFDD0 && ch <= 0xFDEF)
+					return unicode::UTF_REPLACEMENT_CHARACTER;
+				return ch;
 			}
-			const_reference ret(ref, pos);
-			return ret;
-		}
-
-		//! Accesses the full character at the iterator's position.
-		reference operator*() {
-			if (pos >= ref->size_raw()) {
-				const uchar16_t* a = ref->c_str();
-				u32 p = ref->size_raw();
-				if (UTF16_IS_SURROGATE_LO(a[p]))
-					--p;
-				reference ret(ref, p);
-				return ret;
+			const uchar16_t* data = reinterpret_cast<const uchar16_t*>(ref->data());
+			auto hi = data[pos];
+			if(!UTF16_IS_SURROGATE(hi)) {
+				if(hi >= 0xFDD0 && hi <= 0xFDEF)
+					return unicode::UTF_REPLACEMENT_CHARACTER;
+				return static_cast<uchar32_t>(hi);
 			}
-			reference ret(ref, pos);
-			return ret;
+			if((pos + 1 >= size) || !UTF16_IS_SURROGATE_HI(hi))
+				return unicode::UTF_REPLACEMENT_CHARACTER;
+			auto lo = data[pos + 1];
+			if(!UTF16_IS_SURROGATE_LO(lo))
+				return unicode::UTF_REPLACEMENT_CHARACTER;
+			return unicode::toUTF32(hi, lo);
 		}
 
 		//! Accesses the full character at the iterator's position.
@@ -633,10 +289,7 @@ public:
 
 		//! Is the iterator at the end of the string?
 		bool atEnd() const {
-			const uchar16_t* a = ref->c_str();
-			if (UTF16_IS_SURROGATE(a[pos]))
-				return (pos + 1) >= ref->size_raw();
-			else return pos >= ref->size_raw();
+			return pos >= ref->size_raw();
 		}
 
 		//! Moves the iterator to the start of the string.
@@ -656,73 +309,60 @@ public:
 		}
 
 	protected:
-		const ustring16<TAlloc>* ref;
+		const ustring16* ref;
 		u32 pos;
-	};
+		static constexpr bool is_utf32 = sizeof(wchar_t) == 4;
 
-	//! Iterator to iterate through a UTF-16 string.
-	class _ustring16_iterator : public _ustring16_const_iterator {
-	public:
-		typedef _ustring16_iterator _Iter;
-		typedef _ustring16_const_iterator _Base;
-		typedef typename _Base::const_pointer const_pointer;
-		typedef typename _Base::const_reference const_reference;
+		bool isNextCodepointValidSurrogatePair() const {
+			if(is_utf32)
+				return true;
+			const uchar16_t* data = reinterpret_cast<const uchar16_t*>(ref->data());
+			if(!UTF16_IS_SURROGATE_HI(data[pos]))
+				return false;
+			if((pos + 1) >= ref->size_raw())
+				return false;
+			return UTF16_IS_SURROGATE_LO(data[pos + 1]);
+		}
 
-		typedef typename _Base::value_type value_type;
-		typedef typename _Base::difference_type difference_type;
-		typedef typename _Base::distance_type distance_type;
-		typedef access pointer;
-		typedef access reference;
-
-		using _Base::pos;
-		using _Base::ref;
-
-		//! Constructors.
-		_ustring16_iterator(const _Iter& i) : _ustring16_const_iterator(i) {}
-		_ustring16_iterator(const ustring16<TAlloc>& s) : _ustring16_const_iterator(s) {}
-		_ustring16_iterator(const ustring16<TAlloc>& s, const u32 p) : _ustring16_const_iterator(s, p) {}
-
-		//! Accesses the full character at the iterator's position.
-		reference operator*() const {
-			if (pos >= ref->size_raw()) {
-				const uchar16_t* a = ref->c_str();
-				u32 p = ref->size_raw();
-				if (UTF16_IS_SURROGATE_LO(a[p]))
-					--p;
-				reference ret(ref, p);
-				return ret;
+		void advance(const difference_type v) {
+			u32 sr = ref->size_raw();
+			if(is_utf32) {
+				pos += (u32)v;
+			} else {
+				u32 i = (u32)v;
+				while(i != 0 && pos < sr) {
+					if(isNextCodepointValidSurrogatePair()) {
+						pos += 2;
+					} else
+						pos++;
+					--i;
+				}
 			}
-			reference ret(ref, pos);
-			return ret;
+			if(pos > sr)
+				pos = sr;
 		}
 
-		//! Accesses the full character at the iterator's position.
-		reference operator*() {
-			if (pos >= ref->size_raw()) {
-				const uchar16_t* a = ref->c_str();
-				u32 p = ref->size_raw();
-				if (UTF16_IS_SURROGATE_LO(a[p]))
-					--p;
-				reference ret(ref, p);
-				return ret;
+		void go_back(const difference_type v) {
+			// Go to the appropriate position.
+			// TODO: Don't force u32 on an x64 OS.  Make it agnostic.
+			auto i = static_cast<u32>(v);
+			if(is_utf32) {
+				if(pos < i)
+					pos = 0;
+				pos -= i;
+			} else {
+				const uchar16_t* a = reinterpret_cast<const uchar16_t*>(ref->data());
+				while(i != 0 && pos != 0) {
+					--pos;
+					if(UTF16_IS_SURROGATE_LO(a[pos]) && pos != 0 && UTF16_IS_SURROGATE_HI(a[pos - 1]))
+						--pos;
+					--i;
+				}
 			}
-			reference ret(ref, pos);
-			return ret;
-		}
-
-		//! Accesses the full character at the iterator's position.
-		pointer operator->() const {
-			return operator*();
-		}
-
-		//! Accesses the full character at the iterator's position.
-		pointer operator->() {
-			return operator*();
 		}
 	};
 
-	typedef typename ustring16<TAlloc>::_ustring16_iterator iterator;
-	typedef typename ustring16<TAlloc>::_ustring16_const_iterator const_iterator;
+	typedef typename ustring16::_ustring16_const_iterator const_iterator;
 
 	///----------------------///
 	/// end iterator classes ///
@@ -730,347 +370,56 @@ public:
 
 	//! Default constructor
 	ustring16()
-		: array(0), allocated(1), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-		array = allocator.allocate(1); // new u16[1];
-		array[0] = 0x0;
-	}
-
-
-	//! Constructor
-	ustring16(const ustring16<TAlloc>& other)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-		*this = other;
+		: data_(nullptr), size_(0xffffffff), size_raw_(0) {
 	}
 
 
 	//! Constructor from other string types
-	template <class B, class A>
-	ustring16(const string<B, A>& other)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-		*this = other;
+	ustring16(const ustring16& other)
+		: data_(nullptr), size_(0xffffffff), size_raw_(0) {
+		data_ = other.data();
+		size_raw_ = other.size_raw();
 	}
 
-
-#ifndef USTRING_NO_STL
-	//! Constructor from std::string
-	template <class B, class A, typename Alloc>
-	ustring16(const std::basic_string<B, A, Alloc>& other)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-		*this = other.c_str();
-	}
-
-
-	//! Constructor from iterator.
-	template <typename Itr>
-	ustring16(Itr first, Itr last)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-		reserve(std::distance(first, last));
-		array[used] = 0;
-
-		for (; first != last; ++first)
-			append((uchar32_t)*first);
-	}
-#endif
-
-
-#ifndef USTRING_CPP0X_NEWLITERALS
-	//! Constructor for copying a character string from a pointer.
-	ustring16(const char* const c)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-
-		loadDataStream(c, strlen(c));
-		//append((uchar8_t*)c);
-	}
-
-
-	//! Constructor for copying a character string from a pointer with a given length.
-	ustring16(const char* const c, u32 length)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-
-		loadDataStream(c, length);
-	}
-#endif
-
-
-	//! Constructor for copying a UTF-8 string from a pointer.
-	ustring16(const uchar8_t* const c)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-
-		append(c);
-	}
-
-
-	//! Constructor for copying a UTF-8 string from a pointer with a given length.
-	ustring16(const uchar8_t* const c, u32 length)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-
-		append(c, length);
-	}
-
-
-	//! Constructor for copying a UTF-16 string from a pointer.
-	ustring16(const uchar16_t* const c)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-
-		append(c);
-	}
-
-
-	//! Constructor for copying a UTF-16 string from a pointer with a given length
-	ustring16(const uchar16_t* const c, u32 length)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-
-		append(c, length);
+	template <class T>
+	ustring16(const T& other)
+		: data_(nullptr), size_(0), size_raw_(0) {
+		assign(other.data(), static_cast<u32>(other.size()));
 	}
 
 
 	//! Constructor for copying a UTF-32 string from a pointer.
-	ustring16(const uchar32_t* const c)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-
-		append(c);
+	ustring16(const wchar_t* const c)
+		: data_(nullptr), size_(0), size_raw_(0) {
+		assign(c);
 	}
 
 
 	//! Constructor for copying a UTF-32 from a pointer with a given length.
-	ustring16(const uchar32_t* const c, u32 length)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-
-		append(c, length);
-	}
-
-
-	//! Constructor for copying a wchar_t string from a pointer.
-	ustring16(const wchar_t* const c)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-
-		if (sizeof(wchar_t) == 4)
-			append(reinterpret_cast<const uchar32_t * const>(c));
-		else if (sizeof(wchar_t) == 2)
-			append(reinterpret_cast<const uchar16_t * const>(c));
-		else if (sizeof(wchar_t) == 1)
-			append(reinterpret_cast<const uchar8_t * const>(c));
-	}
-
-
-	//! Constructor for copying a wchar_t string from a pointer with a given length.
 	ustring16(const wchar_t* const c, u32 length)
-		: array(0), allocated(0), used(0) {
-#if __BIG_ENDIAN__
-		encoding = unicode::EUTFE_UTF16_BE;
-#else
-		encoding = unicode::EUTFE_UTF16_LE;
-#endif
-
-		if (sizeof(wchar_t) == 4)
-			append(reinterpret_cast<const uchar32_t * const>(c), length);
-		else if (sizeof(wchar_t) == 2)
-			append(reinterpret_cast<const uchar16_t * const>(c), length);
-		else if (sizeof(wchar_t) == 1)
-			append(reinterpret_cast<const uchar8_t * const>(c), length);
+		: data_(nullptr), size_(0), size_raw_(0) {
+		assign(c, length);
 	}
-
-
-#ifdef USTRING_CPP0X
-	//! Constructor for moving a ustring16
-	ustring16(ustring16<TAlloc> && other)
-		: array(other.array), encoding(other.encoding), allocated(other.allocated), used(other.used) {
-		//std::cout << "MOVE constructor" << std::endl;
-		other.array = 0;
-		other.allocated = 0;
-		other.used = 0;
-	}
-#endif
-
-
-	//! Destructor
-	~ustring16() {
-		allocator.deallocate(array); // delete [] array;
-	}
-
-
-	//! Assignment operator
-	ustring16& operator=(const ustring16<TAlloc>& other) {
-		if (this == &other)
-			return *this;
-
-		used = other.size_raw();
-		if (used >= allocated) {
-			allocator.deallocate(array); // delete [] array;
-			allocated = used + 1;
-			array = allocator.allocate(used + 1); //new u16[used];
-		}
-
-		const uchar16_t* p = other.c_str();
-		for (u32 i = 0; i <= used; ++i, ++p)
-			array[i] = *p;
-
-		array[used] = 0;
-
-		// Validate our new UTF-16 string.
-		validate();
-
-		return *this;
-	}
-
-
-#ifdef USTRING_CPP0X
-	//! Move assignment operator
-	ustring16& operator=(ustring16<TAlloc> && other) {
-		if (this != &other) {
-			//std::cout << "MOVE operator=" << std::endl;
-			allocator.deallocate(array);
-
-			array = other.array;
-			allocated = other.allocated;
-			encoding = other.encoding;
-			used = other.used;
-			other.array = 0;
-			other.used = 0;
-		}
-		return *this;
-	}
-#endif
 
 
 	//! Assignment operator for other string types
-	template <class B, class A>
-	ustring16<TAlloc>& operator=(const string<B, A>& other) {
-		*this = other.c_str();
+	ustring16& operator=(const ustring16& other) {
+		data_ = other.data();
+		size_raw_ = other.size_raw();
+		size_ = 0xffffffff;
 		return *this;
 	}
 
-
-	//! Assignment operator for UTF-8 strings
-	ustring16<TAlloc>& operator=(const uchar8_t* const c) {
-		if (!array) {
-			array = allocator.allocate(1); //new u16[1];
-			allocated = 1;
-		}
-		used = 0;
-		array[used] = 0x0;
-		if (!c) return *this;
-
-		//! Append our string now.
-		append(c);
+	template <class T>
+	ustring16& operator=(const T& other) {
+		assign(other.data(), static_cast<u32>(other.size()));
 		return *this;
 	}
 
 
 	//! Assignment operator for UTF-16 strings
-	ustring16<TAlloc>& operator=(const uchar16_t* const c) {
-		if (!array) {
-			array = allocator.allocate(1); //new u16[1];
-			allocated = 1;
-		}
-		used = 0;
-		array[used] = 0x0;
-		if (!c) return *this;
-
-		//! Append our string now.
-		append(c);
-		return *this;
-	}
-
-
-	//! Assignment operator for UTF-32 strings
-	ustring16<TAlloc>& operator=(const uchar32_t* const c) {
-		if (!array) {
-			array = allocator.allocate(1); //new u16[1];
-			allocated = 1;
-		}
-		used = 0;
-		array[used] = 0x0;
-		if (!c) return *this;
-
-		//! Append our string now.
-		append(c);
-		return *this;
-	}
-
-
-	//! Assignment operator for wchar_t strings.
-	/** Note that this assumes that a correct unicode string is stored in the wchar_t string.
-		Since wchar_t changes depending on its platform, it could either be a UTF-8, -16, or -32 string.
-		This function assumes you are storing the correct unicode encoding inside the wchar_t string. **/
-	ustring16<TAlloc>& operator=(const wchar_t* const c) {
-		if (sizeof(wchar_t) == 4)
-			*this = reinterpret_cast<const uchar32_t * const>(c);
-		else if (sizeof(wchar_t) == 2)
-			*this = reinterpret_cast<const uchar16_t * const>(c);
-		else if (sizeof(wchar_t) == 1)
-			*this = reinterpret_cast<const uchar8_t * const>(c);
-
+	ustring16& operator=(const wchar_t* const c) {
+		assign(c);
 		return *this;
 	}
 
@@ -1078,92 +427,34 @@ public:
 	//! Assignment operator for other strings.
 	/** Note that this assumes that a correct unicode string is stored in the string. **/
 	template <class B>
-	ustring16<TAlloc>& operator=(const B* const c) {
-		if (sizeof(B) == 4)
-			*this = reinterpret_cast<const uchar32_t * const>(c);
-		else if (sizeof(B) == 2)
-			*this = reinterpret_cast<const uchar16_t * const>(c);
-		else if (sizeof(B) == 1)
-			*this = reinterpret_cast<const uchar8_t * const>(c);
+	ustring16& operator=(const B* const c) {
+		static_assert(sizeof(B) == sizeof(wchar_t), "unsupported character size");
+		*this = reinterpret_cast<const wchar_t* const>(c);
 
 		return *this;
-	}
-
-
-	//! Direct access operator
-	access operator [](const u32 index) {
-		_IRR_DEBUG_BREAK_IF(index >= size()) // bad index
-		iterator iter(*this, index);
-		return iter.operator * ();
-	}
-
-
-	//! Direct access operator
-	const access operator [](const u32 index) const {
-		_IRR_DEBUG_BREAK_IF(index >= size()) // bad index
-		const_iterator iter(*this, index);
-		return iter.operator * ();
-	}
-
-
-	//! Equality operator
-	bool operator ==(const uchar16_t* const str) const {
-		if (!str)
-			return false;
-
-		u32 i;
-		for(i = 0; array[i] && str[i]; ++i)
-			if (array[i] != str[i])
-				return false;
-
-		return !array[i] && !str[i];
-	}
-
-
-	//! Equality operator
-	bool operator ==(const ustring16<TAlloc>& other) const {
-		for(u32 i = 0; array[i] && other.array[i]; ++i)
-			if (array[i] != other.array[i])
-				return false;
-
-		return used == other.used;
-	}
-
-
-	//! Is smaller comparator
-	bool operator <(const ustring16<TAlloc>& other) const {
-		for(u32 i = 0; array[i] && other.array[i]; ++i) {
-			s32 diff = array[i] - other.array[i];
-			if ( diff )
-				return diff < 0;
-		}
-
-		return used < other.used;
-	}
-
-
-	//! Inequality operator
-	bool operator !=(const uchar16_t* const str) const {
-		return !(*this == str);
-	}
-
-
-	//! Inequality operator
-	bool operator !=(const ustring16<TAlloc>& other) const {
-		return !(*this == other);
 	}
 
 
 	//! Returns the length of a ustring16 in full characters.
 	//! \return Length of a ustring16 in full characters.
 	u32 size() const {
-		const_iterator i(*this, 0);
-		u32 pos = 0;
-		while (!i.atEnd()) {
-			++i;
-			++pos;
+		if (sizeof(wchar_t) == 4) {
+			return size_raw_;
+		} else {
+			if(size_ != 0xffffffff)
+				return size_;
+
+			const uchar16_t* array = reinterpret_cast<const uchar16_t*>(data_);
+			size_ = 0;
+			for(u32 i = 0; i < size_raw_; ++i, ++size_) {
+				if(UTF16_IS_SURROGATE_HI(array[i])) {
+					if((i + 1) >= size_raw_)
+						break;
+					++i;
+				}
+			}
+			return size_;
 		}
-		return pos;
 	}
 
 
@@ -1176,421 +467,30 @@ public:
 
 	//! Returns a pointer to the raw UTF-16 string data.
 	//! \return pointer to C-style NUL terminated array of UTF-16 code points.
-	const uchar16_t* c_str() const {
-		return array;
+	const wchar_t* data() const {
+		return data_;
 	}
 
 
-	//! Compares the first n characters of this string with another.
-	//! \param other Other string to compare to.
-	//! \param n Number of characters to compare.
-	//! \return True if the n first characters of both strings are equal.
-	bool equalsn(const ustring16<TAlloc>& other, u32 n) const {
-		u32 i;
-		const uchar16_t* oa = other.c_str();
-		for(i = 0; array[i] && oa[i] && i < n; ++i)
-			if (array[i] != oa[i])
-				return false;
-
-		// if one (or both) of the strings was smaller then they
-		// are only equal if they have the same length
-		return (i == n) || (used == other.used);
-	}
-
-
-	//! Compares the first n characters of this string with another.
-	//! \param str Other string to compare to.
-	//! \param n Number of characters to compare.
-	//! \return True if the n first characters of both strings are equal.
-	bool equalsn(const uchar16_t* const str, u32 n) const {
-		if (!str)
-			return false;
-		u32 i;
-		for(i = 0; array[i] && str[i] && i < n; ++i)
-			if (array[i] != str[i])
-				return false;
-
-		// if one (or both) of the strings was smaller then they
-		// are only equal if they have the same length
-		return (i == n) || (array[i] == 0 && str[i] == 0);
-	}
-
-
-	//! Appends a character to this ustring16
-	//! \param character The character to append.
+	//! assigns a UTF-16 string to this ustring16
+	//! \param other The UTF-16 string to assign.
+	//! \param length The length of the string to assign.
 	//! \return A reference to our current string.
-	ustring16<TAlloc>& append(uchar32_t character) {
-		if (used + 2 >= allocated)
-			reallocate(used + 2);
-
-		if (character > 0xFFFF) {
-			used += 2;
-
-			// character will be multibyte, so split it up into a surrogate pair.
-			uchar16_t x = static_cast<uchar16_t>(character);
-			uchar16_t vh = UTF16_HI_SURROGATE | ((((character >> 16) & ((1 << 5) - 1)) - 1) << 6) | (x >> 10);
-			uchar16_t vl = UTF16_LO_SURROGATE | (x & ((1 << 10) - 1));
-			array[used - 2] = vh;
-			array[used - 1] = vl;
-		} else {
-			++used;
-			array[used - 1] = character;
-		}
-		array[used] = 0;
-
-		return *this;
-	}
-
-
-	//! Appends a UTF-8 string to this ustring16
-	//! \param other The UTF-8 string to append.
-	//! \param length The length of the string to append.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& append(const uchar8_t* const other, u32 length = 0xffffffff) {
-		if (!other)
-			return *this;
-
-		// Determine if the string is long enough for a BOM.
-		u32 len = 0;
-		const uchar8_t* p = other;
-		do {
-			++len;
-		} while (*p++ && len < unicode::BOM_ENCODE_UTF8_LEN);
-
-		// Check for BOM.
-		unicode::EUTF_ENCODE c_bom = unicode::EUTFE_NONE;
-		if (len == unicode::BOM_ENCODE_UTF8_LEN) {
-			if (memcmp(other, unicode::BOM_ENCODE_UTF8, unicode::BOM_ENCODE_UTF8_LEN) == 0)
-				c_bom = unicode::EUTFE_UTF8;
-		}
-
-		// If a BOM was found, don't include it in the string.
-		const uchar8_t* c2 = other;
-		if (c_bom != unicode::EUTFE_NONE) {
-			c2 = other + unicode::BOM_UTF8_LEN;
-			length -= unicode::BOM_UTF8_LEN;
-		}
+	void assign(const wchar_t* const other, u32 length = 0xffffffff) {
 
 		// Calculate the size of the string to read in.
-		len = 0;
-		p = c2;
-		do {
-			++len;
-		} while(*p++ && len < length);
-		if (len > length)
-			len = length;
-
-		// If we need to grow the array, do it now.
-		if (used + len >= allocated)
-			reallocate(used + (len * 2));
-		u32 start = used;
-
-		// Convert UTF-8 to UTF-16.
-		u32 pos = start;
-		for (u32 l = 0; l < len;) {
-			++used;
-			if (((c2[l] >> 6) & 0x03) == 0x02) {
-				// Invalid continuation byte.
-				array[pos++] = unicode::UTF_REPLACEMENT_CHARACTER;
-				++l;
-			} else if (c2[l] == 0xC0 || c2[l] == 0xC1) {
-				// Invalid byte - overlong encoding.
-				array[pos++] = unicode::UTF_REPLACEMENT_CHARACTER;
-				++l;
-			} else if ((c2[l] & 0xF8) == 0xF0) {
-				// 4 bytes UTF-8, 2 bytes UTF-16.
-				// Check for a full string.
-				if ((l + 3) >= len) {
-					array[pos++] = unicode::UTF_REPLACEMENT_CHARACTER;
-					l += 3;
-					break;
-				}
-
-				// Validate.
-				bool valid = true;
-				u8 l2 = 0;
-				if (valid && (((c2[l + 1] >> 6) & 0x03) == 0x02)) ++l2;
-				else valid = false;
-				if (valid && (((c2[l + 2] >> 6) & 0x03) == 0x02)) ++l2;
-				else valid = false;
-				if (valid && (((c2[l + 3] >> 6) & 0x03) == 0x02)) ++l2;
-				else valid = false;
-				if (!valid) {
-					array[pos++] = unicode::UTF_REPLACEMENT_CHARACTER;
-					l += l2;
-					continue;
-				}
-
-				// Decode.
-				uchar8_t b1 = ((c2[l] & 0x7) << 2) | ((c2[l + 1] >> 4) & 0x3);
-				uchar8_t b2 = ((c2[l + 1] & 0xF) << 4) | ((c2[l + 2] >> 2) & 0xF);
-				uchar8_t b3 = ((c2[l + 2] & 0x3) << 6) | (c2[l + 3] & 0x3F);
-				uchar32_t v = b3 | ((uchar32_t)b2 << 8) | ((uchar32_t)b1 << 16);
-
-				// Split v up into a surrogate pair.
-				uchar16_t x = static_cast<uchar16_t>(v);
-				uchar16_t vh = UTF16_HI_SURROGATE | ((((v >> 16) & ((1 << 5) - 1)) - 1) << 6) | (x >> 10);
-				uchar16_t vl = UTF16_LO_SURROGATE | (x & ((1 << 10) - 1));
-
-				array[pos++] = vh;
-				array[pos++] = vl;
-				l += 4;
-				++used;		// Using two shorts this time, so increase used by 1.
-			} else if ((c2[l] & 0xF0) == 0xE0) {
-				// 3 bytes UTF-8, 1 byte UTF-16.
-				// Check for a full string.
-				if ((l + 2) >= len) {
-					array[pos++] = unicode::UTF_REPLACEMENT_CHARACTER;
-					l += 2;
-					break;
-				}
-
-				// Validate.
-				bool valid = true;
-				u8 l2 = 0;
-				if (valid && (((c2[l + 1] >> 6) & 0x03) == 0x02)) ++l2;
-				else valid = false;
-				if (valid && (((c2[l + 2] >> 6) & 0x03) == 0x02)) ++l2;
-				else valid = false;
-				if (!valid) {
-					array[pos++] = unicode::UTF_REPLACEMENT_CHARACTER;
-					l += l2;
-					continue;
-				}
-
-				// Decode.
-				uchar8_t b1 = ((c2[l] & 0xF) << 4) | ((c2[l + 1] >> 2) & 0xF);
-				uchar8_t b2 = ((c2[l + 1] & 0x3) << 6) | (c2[l + 2] & 0x3F);
-				uchar16_t ch = b2 | ((uchar16_t)b1 << 8);
-				array[pos++] = ch;
-				l += 3;
-			} else if ((c2[l] & 0xE0) == 0xC0) {
-				// 2 bytes UTF-8, 1 byte UTF-16.
-				// Check for a full string.
-				if ((l + 1) >= len) {
-					array[pos++] = unicode::UTF_REPLACEMENT_CHARACTER;
-					l += 1;
-					break;
-				}
-
-				// Validate.
-				if (((c2[l + 1] >> 6) & 0x03) != 0x02) {
-					array[pos++] = unicode::UTF_REPLACEMENT_CHARACTER;
-					++l;
-					continue;
-				}
-
-				// Decode.
-				uchar8_t b1 = (c2[l] >> 2) & 0x7;
-				uchar8_t b2 = ((c2[l] & 0x3) << 6) | (c2[l + 1] & 0x3F);
-				uchar16_t ch = b2 | ((uchar16_t)b1 << 8);
-				array[pos++] = ch;
-				l += 2;
-			} else {
-				// 1 byte UTF-8, 1 byte UTF-16.
-				// Validate.
-				if (c2[l] > 0x7F) {
-					// Values above 0xF4 are restricted and aren't used.  By now, anything above 0x7F is invalid.
-					array[pos++] = unicode::UTF_REPLACEMENT_CHARACTER;
-				} else array[pos++] = static_cast<uchar16_t>(c2[l]);
-				++l;
+		if(length == 0xffffffff) {
+			length = 0;
+			auto* p = other;
+			while(*p++) {
+				++length;
 			}
 		}
-		array[used] = 0;
 
-		// Validate our new UTF-16 string.
+		data_ = other;
+		size_raw_ = length;
+		size_ = 0xffffffff;
 		validate();
-
-		return *this;
-	}
-
-
-	//! Appends a UTF-16 string to this ustring16
-	//! \param other The UTF-16 string to append.
-	//! \param length The length of the string to append.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& append(const uchar16_t* const other, u32 length = 0xffffffff) {
-		if (!other)
-			return *this;
-
-		// Determine if the string is long enough for a BOM.
-		u32 len = 0;
-		const uchar16_t* p = other;
-		do {
-			++len;
-		} while (*p++ && len < unicode::BOM_ENCODE_UTF16_LEN);
-
-		// Check for the BOM to determine the string's endianness.
-		unicode::EUTF_ENDIAN c_end = unicode::EUTFEE_NATIVE;
-		if (memcmp(other, unicode::BOM_ENCODE_UTF16_LE, unicode::BOM_ENCODE_UTF16_LEN) == 0)
-			c_end = unicode::EUTFEE_LITTLE;
-		else if (memcmp(other, unicode::BOM_ENCODE_UTF16_BE, unicode::BOM_ENCODE_UTF16_LEN) == 0)
-			c_end = unicode::EUTFEE_BIG;
-
-		// If a BOM was found, don't include it in the string.
-		const uchar16_t* c2 = other;
-		if (c_end != unicode::EUTFEE_NATIVE) {
-			c2 = other + unicode::BOM_UTF16_LEN;
-			length -= unicode::BOM_UTF16_LEN;
-		}
-
-		// Calculate the size of the string to read in.
-		len = 0;
-		p = c2;
-		do {
-			++len;
-		} while(*p++ && len < length);
-		if (len > length)
-			len = length;
-
-		// If we need to grow the size of the array, do it now.
-		if (used + len >= allocated)
-			reallocate(used + (len * 2));
-		u32 start = used;
-		used += len;
-
-		// Copy the string now.
-		unicode::EUTF_ENDIAN m_end = getEndianness();
-		for (u32 l = start; l < start + len; ++l) {
-			array[l] = (uchar16_t)c2[l];
-			if (c_end != unicode::EUTFEE_NATIVE && c_end != m_end)
-				array[l] = unicode::swapEndian16(array[l]);
-		}
-
-		array[used] = 0;
-
-		// Validate our new UTF-16 string.
-		validate();
-		return *this;
-	}
-
-
-	//! Appends a UTF-32 string to this ustring16
-	//! \param other The UTF-32 string to append.
-	//! \param length The length of the string to append.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& append(const uchar32_t* const other, u32 length = 0xffffffff) {
-		if (!other)
-			return *this;
-
-		// Check for the BOM to determine the string's endianness.
-		unicode::EUTF_ENDIAN c_end = unicode::EUTFEE_NATIVE;
-		if (memcmp(other, unicode::BOM_ENCODE_UTF32_LE, unicode::BOM_ENCODE_UTF32_LEN) == 0)
-			c_end = unicode::EUTFEE_LITTLE;
-		else if (memcmp(other, unicode::BOM_ENCODE_UTF32_BE, unicode::BOM_ENCODE_UTF32_LEN) == 0)
-			c_end = unicode::EUTFEE_BIG;
-
-		// If a BOM was found, don't include it in the string.
-		const uchar32_t* c2 = other;
-		if (c_end != unicode::EUTFEE_NATIVE) {
-			c2 = other + unicode::BOM_UTF32_LEN;
-			length -= unicode::BOM_UTF32_LEN;
-		}
-
-		// Calculate the size of the string to read in.
-		u32 len = 0;
-		const uchar32_t* p = c2;
-		do {
-			++len;
-		} while(*p++ && len < length);
-		if (len > length)
-			len = length;
-
-		// If we need to grow the size of the array, do it now.
-		// In case all of the UTF-32 string is split into surrogate pairs, do len * 2.
-		if (used + (len * 2) >= allocated)
-			reallocate(used + ((len * 2) * 2));
-		u32 start = used;
-
-		// Convert UTF-32 to UTF-16.
-		unicode::EUTF_ENDIAN m_end = getEndianness();
-		u32 pos = start;
-		for (u32 l = 0; l < len; ++l) {
-			++used;
-
-			uchar32_t ch = c2[l];
-			if (c_end != unicode::EUTFEE_NATIVE && c_end != m_end)
-				ch = unicode::swapEndian32(ch);
-
-			if (ch > 0xFFFF) {
-				// Split ch up into a surrogate pair as it is over 16 bits long.
-				uchar16_t x = static_cast<uchar16_t>(ch);
-				uchar16_t vh = UTF16_HI_SURROGATE | ((((ch >> 16) & ((1 << 5) - 1)) - 1) << 6) | (x >> 10);
-				uchar16_t vl = UTF16_LO_SURROGATE | (x & ((1 << 10) - 1));
-				array[pos++] = vh;
-				array[pos++] = vl;
-				++used;		// Using two shorts, so increased used again.
-			} else if (ch >= 0xD800 && ch <= 0xDFFF) {
-				// Between possible UTF-16 surrogates (invalid!)
-				array[pos++] = unicode::UTF_REPLACEMENT_CHARACTER;
-			} else array[pos++] = static_cast<uchar16_t>(ch);
-		}
-		array[used] = 0;
-
-		// Validate our new UTF-16 string.
-		validate();
-
-		return *this;
-	}
-
-
-	//! Appends a ustring16 to this ustring16
-	//! \param other The string to append to this one.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& append(const ustring16<TAlloc>& other) {
-		const uchar16_t* oa = other.c_str();
-
-		u32 len = other.size_raw();
-
-		if (used + len >= allocated)
-			reallocate(used + len);
-
-		for (u32 l = 0; l < len; ++l)
-			array[used + l] = oa[l];
-
-		used += len;
-		array[used] = 0;
-
-		return *this;
-	}
-
-
-	//! Appends a certain amount of characters of a ustring16 to this ustring16.
-	//! \param other The string to append to this one.
-	//! \param length How many characters of the other string to add to this one.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& append(const ustring16<TAlloc>& other, u32 length) {
-		if (other.size() == 0)
-			return *this;
-
-		if (other.size() < length) {
-			append(other);
-			return *this;
-		}
-
-		if (used + length * 2 >= allocated)
-			reallocate(used + length * 2);
-
-		const_iterator iter(other, 0);
-		u32 l = length;
-		while (!iter.atEnd() && l) {
-			uchar32_t c = *iter;
-			append(c);
-			++iter;
-			--l;
-		}
-
-		return *this;
-	}
-
-
-	//! Reserves some memory.
-	//! \param count The amount of characters to reserve.
-	void reserve(u32 count) {
-		if (count < allocated)
-			return;
-
-		reallocate(count);
 	}
 
 
@@ -1598,833 +498,52 @@ public:
 	//! \param c The character to search for.
 	//! \return Position where the character has been found, or -1 if not found.
 	s32 findFirst(uchar32_t c) const {
-		const_iterator i(*this, 0);
-
 		s32 pos = 0;
-		while (!i.atEnd()) {
-			uchar32_t t = *i;
-			if (c == t)
+		for(auto t : *this) {
+			if(c == t)
 				return pos;
 			++pos;
-			++i;
 		}
 
 		return -1;
-	}
-
-	//! Finds first occurrence of a character of a list.
-	//! \param c A list of characters to find. For example if the method should find the first occurrence of 'a' or 'b', this parameter should be "ab".
-	//! \param count The amount of characters in the list. Usually, this should be strlen(c).
-	//! \return Position where one of the characters has been found, or -1 if not found.
-	s32 findFirstChar(const uchar32_t* const c, u32 count = 1) const {
-		if (!c || !count)
-			return -1;
-
-		const_iterator i(*this, 0);
-
-		s32 pos = 0;
-		while (!i.atEnd()) {
-			uchar32_t t = *i;
-			for (u32 j = 0; j < count; ++j)
-				if (t == c[j])
-					return pos;
-			++pos;
-			++i;
-		}
-
-		return -1;
-	}
-
-
-	//! Finds first position of a character not in a given list.
-	//! \param c A list of characters to NOT find. For example if the method should find the first occurrence of a character not 'a' or 'b', this parameter should be "ab".
-	//! \param count The amount of characters in the list. Usually, this should be strlen(c).
-	//! \return Position where the character has been found, or -1 if not found.
-	s32 findFirstCharNotInList(const uchar32_t* const c, u32 count = 1) const {
-		if (!c || !count)
-			return -1;
-
-		const_iterator i(*this, 0);
-
-		s32 pos = 0;
-		while (!i.atEnd()) {
-			uchar32_t t = *i;
-			u32 j;
-			for (j = 0; j < count; ++j)
-				if (t == c[j])
-					break;
-
-			if (j == count)
-				return pos;
-			++pos;
-			++i;
-		}
-
-		return -1;
-	}
-
-	//! Finds last position of a character not in a given list.
-	//! \param c A list of characters to NOT find. For example if the method should find the first occurrence of a character not 'a' or 'b', this parameter should be "ab".
-	//! \param count The amount of characters in the list. Usually, this should be strlen(c).
-	//! \return Position where the character has been found, or -1 if not found.
-	s32 findLastCharNotInList(const uchar32_t* const c, u32 count = 1) const {
-		if (!c || !count)
-			return -1;
-
-		const_iterator i(end());
-		--i;
-
-		s32 pos = size() - 1;
-		while (!i.atStart()) {
-			uchar32_t t = *i;
-			u32 j;
-			for (j = 0; j < count; ++j)
-				if (t == c[j])
-					break;
-
-			if (j == count)
-				return pos;
-			--pos;
-			--i;
-		}
-
-		return -1;
-	}
-
-	//! Finds next occurrence of character.
-	//! \param c The character to search for.
-	//! \param startPos The position in the string to start searching.
-	//! \return Position where the character has been found, or -1 if not found.
-	s32 findNext(uchar32_t c, u32 startPos) const {
-		const_iterator i(*this, startPos);
-
-		s32 pos = startPos;
-		while (!i.atEnd()) {
-			uchar32_t t = *i;
-			if (t == c)
-				return pos;
-			++pos;
-			++i;
-		}
-
-		return -1;
-	}
-
-
-	//! Finds last occurrence of character.
-	//! \param c The character to search for.
-	//! \param start The start position of the reverse search ( default = -1, on end ).
-	//! \return Position where the character has been found, or -1 if not found.
-	s32 findLast(uchar32_t c, s32 start = -1) const {
-		u32 s = size();
-		start = core::clamp ( start < 0 ? (s32)s : start, 0, (s32)s ) - 1;
-
-		const_iterator i(*this, start);
-		u32 pos = start;
-		while (!i.atStart()) {
-			uchar32_t t = *i;
-			if (t == c)
-				return pos;
-			--pos;
-			--i;
-		}
-
-		return -1;
-	}
-
-	//! Finds last occurrence of a character in a list.
-	//! \param c A list of strings to find. For example if the method should find the last occurrence of 'a' or 'b', this parameter should be "ab".
-	//! \param count The amount of characters in the list. Usually, this should be strlen(c).
-	//! \return Position where one of the characters has been found, or -1 if not found.
-	s32 findLastChar(const uchar32_t* const c, u32 count = 1) const {
-		if (!c || !count)
-			return -1;
-
-		const_iterator i(end());
-		--i;
-
-		s32 pos = size();
-		while (!i.atStart()) {
-			uchar32_t t = *i;
-			for (u32 j = 0; j < count; ++j)
-				if (t == c[j])
-					return pos;
-			--pos;
-			--i;
-		}
-
-		return -1;
-	}
-
-
-	//! Finds another ustring16 in this ustring16.
-	//! \param str The string to find.
-	//! \param start The start position of the search.
-	//! \return Positions where the ustring16 has been found, or -1 if not found.
-	s32 find(const ustring16<TAlloc>& str, const u32 start = 0) const {
-		u32 my_size = size();
-		u32 their_size = str.size();
-
-		if (their_size == 0 || my_size - start < their_size)
-			return -1;
-
-		const_iterator i(*this, start);
-
-		s32 pos = start;
-		while (!i.atEnd()) {
-			const_iterator i2(i);
-			const_iterator j(str, 0);
-			uchar32_t t1 = (uchar32_t) * i2;
-			uchar32_t t2 = (uchar32_t) * j;
-			while (t1 == t2) {
-				++i2;
-				++j;
-				if (j.atEnd())
-					return pos;
-				t1 = (uchar32_t) * i2;
-				t2 = (uchar32_t) * j;
-			}
-			++i;
-			++pos;
-		}
-
-		return -1;
-	}
-
-
-	//! Finds another ustring16 in this ustring16.
-	//! \param str The string to find.
-	//! \param start The start position of the search.
-	//! \return Positions where the string has been found, or -1 if not found.
-	s32 find_raw(const ustring16<TAlloc>& str, const u32 start = 0) const {
-		const uchar16_t* data = str.c_str();
-		if (data && *data) {
-			u32 len = 0;
-
-			while (data[len])
-				++len;
-
-			if (len > used)
-				return -1;
-
-			for (u32 i = start; i <= used - len; ++i) {
-				u32 j = 0;
-
-				while(data[j] && array[i + j] == data[j])
-					++j;
-
-				if (!data[j])
-					return i;
-			}
-		}
-
-		return -1;
-	}
-
-
-	//! Returns a substring.
-	//! \param begin: Start of substring.
-	//! \param length: Length of substring.
-	//! \return A reference to our current string.
-	ustring16<TAlloc> subString(u32 begin, s32 length) const {
-		u32 len = size();
-		// if start after ustring16
-		// or no proper substring length
-		if ((length <= 0) || (begin >= len))
-			return ustring16<TAlloc>("");
-		// clamp length to maximal value
-		if ((length + begin) > len)
-			length = len - begin;
-
-		ustring16<TAlloc> o;
-		o.reserve((length + 1) * 2);
-
-		const_iterator i(*this, begin);
-		while (!i.atEnd() && length) {
-			o.append(*i);
-			++i;
-			--length;
-		}
-
-		return o;
-	}
-
-
-	//! Appends a character to this ustring16.
-	//! \param c Character to append.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& operator += (uchar32_t c) {
-		append(c);
-		return *this;
-	}
-
-
-	//! Appends a char ustring16 to this ustring16.
-	//! \param c Char ustring16 to append.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& operator += (const uchar16_t* const c) {
-		append(c);
-		return *this;
-	}
-
-
-	//! Appends a ustring16 to this ustring16.
-	//! \param other ustring16 to append.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& operator += (const ustring16<TAlloc>& other) {
-		append(other);
-		return *this;
-	}
-
-
-	//! Replaces all characters of a given type with another one.
-	//! \param toReplace Character to replace.
-	//! \param replaceWith Character replacing the old one.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& replace(uchar32_t toReplace, uchar32_t replaceWith) {
-		iterator i(*this, 0);
-		while (!i.atEnd()) {
-			typename ustring16<TAlloc>::iterator::access a = *i;
-			if ((uchar32_t)a == toReplace)
-				a = replaceWith;
-			++i;
-		}
-		return *this;
-	}
-
-
-	//! Replaces all instances of a string with another one.
-	//! \param toReplace The string to replace.
-	//! \param replaceWith The string replacing the old one.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& replace(const ustring16<TAlloc>& toReplace, const ustring16<TAlloc>& replaceWith) {
-		if (toReplace.size() == 0)
-			return *this;
-
-		const uchar16_t* other = toReplace.c_str();
-		const uchar16_t* replace = replaceWith.c_str();
-		const u32 other_size = toReplace.size_raw();
-		const u32 replace_size = replaceWith.size_raw();
-
-		// Determine the delta.  The algorithm will change depending on the delta.
-		s32 delta = replace_size - other_size;
-
-		// A character for character replace.  The string will not shrink or grow.
-		if (delta == 0) {
-			s32 pos = 0;
-			while ((pos = find_raw(other, pos)) != -1) {
-				for (u32 i = 0; i < replace_size; ++i)
-					array[pos + i] = replace[i];
-				++pos;
-			}
-			return *this;
-		}
-
-		// We are going to be removing some characters.  The string will shrink.
-		if (delta < 0) {
-			u32 i = 0;
-			for (u32 pos = 0; pos <= used; ++i, ++pos) {
-				// Is this potentially a match?
-				if (array[pos] == *other) {
-					// Check to see if we have a match.
-					u32 j;
-					for (j = 0; j < other_size; ++j) {
-						if (array[pos + j] != other[j])
-							break;
-					}
-
-					// If we have a match, replace characters.
-					if (j == other_size) {
-						for (j = 0; j < replace_size; ++j)
-							array[i + j] = replace[j];
-						i += replace_size - 1;
-						pos += other_size - 1;
-						continue;
-					}
-				}
-
-				// No match found, just copy characters.
-				array[i - 1] = array[pos];
-			}
-			array[i] = 0;
-			used = i;
-
-			return *this;
-		}
-
-		// We are going to be adding characters, so the string size will increase.
-		// Count the number of times toReplace exists in the string so we can allocate the new size.
-		u32 find_count = 0;
-		s32 pos = 0;
-		while ((pos = find_raw(other, pos)) != -1) {
-			++find_count;
-			++pos;
-		}
-
-		// Re-allocate the string now, if needed.
-		u32 len = delta * find_count;
-		if (used + len >= allocated)
-			reallocate(used + len);
-
-		// Start replacing.
-		pos = 0;
-		while ((pos = find_raw(other, pos)) != -1) {
-			uchar16_t* start = array + pos + other_size - 1;
-			uchar16_t* ptr   = array + used;
-			uchar16_t* end   = array + used + delta;
-
-			// Shift characters to make room for the string.
-			while (ptr != start) {
-				*end = *ptr;
-				--ptr;
-				--end;
-			}
-
-			// Add the new string now.
-			for (u32 i = 0; i < replace_size; ++i)
-				array[pos + i] = replace[i];
-
-			pos += replace_size;
-			used += delta;
-		}
-
-		// Terminate the string and return ourself.
-		array[used] = 0;
-		return *this;
-	}
-
-
-	//! Removes characters from a ustring16..
-	//! \param c The character to remove.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& remove(uchar32_t c) {
-		u32 pos = 0;
-		u32 found = 0;
-		u32 len = (c > 0xFFFF ? 2 : 1);		// Remove characters equal to the size of c as a UTF-16 character.
-		for (u32 i = 0; i <= used; ++i) {
-			uchar32_t uc32 = 0;
-			if (!UTF16_IS_SURROGATE_HI(array[i]))
-				uc32 |= array[i];
-			else if (i + 1 <= used) {
-				// Convert the surrogate pair into a single UTF-32 character.
-				uc32 = unicode::toUTF32(array[i], array[i + 1]);
-			}
-			u32 len2 = (uc32 > 0xFFFF ? 2 : 1);
-
-			if (uc32 == c) {
-				found += len;
-				continue;
-			}
-
-			array[pos++] = array[i];
-			if (len2 == 2)
-				array[pos++] = array[++i];
-		}
-		used -= found;
-		array[used] = 0;
-		return *this;
-	}
-
-
-	//! Removes a ustring16 from the ustring16.
-	//! \param toRemove The string to remove.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& remove(const ustring16<TAlloc>& toRemove) {
-		u32 size = toRemove.size_raw();
-		if (size == 0) return *this;
-
-		const uchar16_t* tra = toRemove.c_str();
-		u32 pos = 0;
-		u32 found = 0;
-		for (u32 i = 0; i <= used; ++i) {
-			u32 j = 0;
-			while (j < size) {
-				if (array[i + j] != tra[j])
-					break;
-				++j;
-			}
-			if (j == size) {
-				found += size;
-				i += size - 1;
-				continue;
-			}
-
-			array[pos++] = array[i];
-		}
-		used -= found;
-		array[used] = 0;
-		return *this;
-	}
-
-
-	//! Removes characters from the ustring16.
-	//! \param characters The characters to remove.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& removeChars(const ustring16<TAlloc>& characters) {
-		if (characters.size_raw() == 0)
-			return *this;
-
-		u32 pos = 0;
-		u32 found = 0;
-		const_iterator iter(characters);
-		for (u32 i = 0; i <= used; ++i) {
-			uchar32_t uc32 = 0;
-			if (!UTF16_IS_SURROGATE_HI(array[i]))
-				uc32 |= array[i];
-			else if (i + 1 <= used) {
-				// Convert the surrogate pair into a single UTF-32 character.
-				uc32 = unicode::toUTF32(array[i], array[i + 1]);
-			}
-			u32 len2 = (uc32 > 0xFFFF ? 2 : 1);
-
-			bool cont = false;
-			iter.toStart();
-			while (!iter.atEnd()) {
-				uchar32_t c = *iter;
-				if (uc32 == c) {
-					found += (c > 0xFFFF ? 2 : 1);		// Remove characters equal to the size of c as a UTF-16 character.
-					++i;
-					cont = true;
-					break;
-				}
-				++iter;
-			}
-			if (cont) continue;
-
-			array[pos++] = array[i];
-			if (len2 == 2)
-				array[pos++] = array[++i];
-		}
-		used -= found;
-		array[used] = 0;
-		return *this;
-	}
-
-
-	//! Trims the ustring16.
-	//! Removes the specified characters (by default, Latin-1 whitespace) from the begining and the end of the ustring16.
-	//! \param whitespace The characters that are to be considered as whitespace.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& trim(const ustring16<TAlloc>& whitespace = " \t\n\r") {
-		core::array<uchar32_t> utf32white = whitespace.toUTF32();
-
-		// find start and end of the substring without the specified characters
-		const s32 begin = findFirstCharNotInList(utf32white.const_pointer(), whitespace.used + 1);
-		if (begin == -1)
-			return (*this = "");
-
-		const s32 end = findLastCharNotInList(utf32white.const_pointer(), whitespace.used + 1);
-
-		return (*this = subString(begin, (end + 1) - begin));
-	}
-
-
-	//! Erases a character from the ustring16.
-	//! May be slow, because all elements following after the erased element have to be copied.
-	//! \param index Index of element to be erased.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& erase(u32 index) {
-		_IRR_DEBUG_BREAK_IF(index > used) // access violation
-
-		iterator i(*this, index);
-
-		uchar32_t t = *i;
-		u32 len = (t > 0xFFFF ? 2 : 1);
-
-		for (u32 j = static_cast<u32>(i.getPos()) + len; j <= used; ++j)
-			array[j - len] = array[j];
-
-		used -= len;
-		array[used] = 0;
-
-		return *this;
 	}
 
 
 	//! Validate the existing ustring16, checking for valid surrogate pairs and checking for proper termination.
 	//! \return A reference to our current string.
-	ustring16<TAlloc>& validate() {
+	void validate() {
 		// Validate all unicode characters.
-		for (u32 i = 0; i < allocated; ++i) {
-			// Terminate on existing null.
-			if (array[i] == 0) {
-				used = i;
-				return *this;
-			}
-			if (UTF16_IS_SURROGATE(array[i])) {
-				if (((i + 1) >= allocated) || UTF16_IS_SURROGATE_LO(array[i]))
-					array[i] = unicode::UTF_REPLACEMENT_CHARACTER;
-				else if (UTF16_IS_SURROGATE_HI(array[i]) && !UTF16_IS_SURROGATE_LO(array[i + 1]))
-					array[i] = unicode::UTF_REPLACEMENT_CHARACTER;
-				++i;
-			}
-			if (array[i] >= 0xFDD0 && array[i] <= 0xFDEF)
-				array[i] = unicode::UTF_REPLACEMENT_CHARACTER;
-		}
-
-		// terminate
-		used = 0;
-		if (allocated > 0) {
-			used = allocated - 1;
-			array[used] = 0;
-		}
-		return *this;
-	}
-
-
-	//! Gets the last char of the ustring16, or 0.
-	//! \return The last char of the ustring16, or 0.
-	uchar32_t lastChar() const {
-		if (used < 1)
-			return 0;
-
-		if (UTF16_IS_SURROGATE_LO(array[used - 1])) {
-			// Make sure we have a paired surrogate.
-			if (used < 2)
-				return 0;
-
-			// Check for an invalid surrogate.
-			if (!UTF16_IS_SURROGATE_HI(array[used - 2]))
-				return 0;
-
-			// Convert the surrogate pair into a single UTF-32 character.
-			return unicode::toUTF32(array[used - 2], array[used - 1]);
-		} else {
-			return array[used - 1];
+		if (sizeof(wchar_t) == 4) {
+			size_ = size_raw_;
+			return;
 		}
 	}
-
-
-	//! Split the ustring16 into parts.
-	/** This method will split a ustring16 at certain delimiter characters
-	into the container passed in as reference. The type of the container
-	has to be given as template parameter. It must provide a push_back and
-	a size method.
-	\param ret The result container
-	\param c C-style ustring16 of delimiter characters
-	\param count Number of delimiter characters
-	\param ignoreEmptyTokens Flag to avoid empty substrings in the result
-	container. If two delimiters occur without a character in between, an
-	empty substring would be placed in the result. If this flag is set,
-	only non-empty strings are stored.
-	\param keepSeparators Flag which allows to add the separator to the
-	result ustring16. If this flag is true, the concatenation of the
-	substrings results in the original ustring16. Otherwise, only the
-	characters between the delimiters are returned.
-	\return The number of resulting substrings
-	*/
-	template<class container>
-	u32 split(container& ret, const uchar32_t* const c, u32 count = 1, bool ignoreEmptyTokens = true, bool keepSeparators = false) const {
-		if (!c)
-			return 0;
-
-		const_iterator i(*this);
-		const u32 oldSize = ret.size();
-		u32 pos = 0;
-		u32 lastpos = 0;
-		u32 lastpospos = 0;
-		bool lastWasSeparator = false;
-		while (!i.atEnd()) {
-			uchar32_t ch = *i;
-			bool foundSeparator = false;
-			for (u32 j = 0; j < count; ++j) {
-				if (ch == c[j]) {
-					if ((!ignoreEmptyTokens || pos - lastpos != 0) &&
-							!lastWasSeparator)
-						ret.push_back(ustring16<TAlloc>(&array[lastpospos], pos - lastpos));
-					foundSeparator = true;
-					lastpos = (keepSeparators ? pos : pos + 1);
-					lastpospos = (keepSeparators ? i.getPos() : i.getPos() + 1);
-					break;
-				}
-			}
-			lastWasSeparator = foundSeparator;
-			++pos;
-			++i;
-		}
-		u32 s = size() + 1;
-		if (s > lastpos)
-			ret.push_back(ustring16<TAlloc>(&array[lastpospos], s - lastpos));
-		return ret.size() - oldSize;
-	}
-
-
-	//! Split the ustring16 into parts.
-	/** This method will split a ustring16 at certain delimiter characters
-	into the container passed in as reference. The type of the container
-	has to be given as template parameter. It must provide a push_back and
-	a size method.
-	\param ret The result container
-	\param c A unicode string of delimiter characters
-	\param ignoreEmptyTokens Flag to avoid empty substrings in the result
-	container. If two delimiters occur without a character in between, an
-	empty substring would be placed in the result. If this flag is set,
-	only non-empty strings are stored.
-	\param keepSeparators Flag which allows to add the separator to the
-	result ustring16. If this flag is true, the concatenation of the
-	substrings results in the original ustring16. Otherwise, only the
-	characters between the delimiters are returned.
-	\return The number of resulting substrings
-	*/
-	template<class container>
-	u32 split(container& ret, const ustring16<TAlloc>& c, bool ignoreEmptyTokens = true, bool keepSeparators = false) const {
-		core::array<uchar32_t> v = c.toUTF32();
-		return split(ret, v.pointer(), v.size(), ignoreEmptyTokens, keepSeparators);
-	}
-
-
-	//! Gets the size of the allocated memory buffer for the string.
-	//! \return The size of the allocated memory buffer.
-	u32 capacity() const {
-		return allocated;
-	}
-
 
 	//! Returns the raw number of UTF-16 code points in the string which includes the individual surrogates.
 	//! \return The raw number of UTF-16 code points, excluding the trialing NUL.
 	u32 size_raw() const {
-		return used;
-	}
-
-
-	//! Inserts a character into the string.
-	//! \param c The character to insert.
-	//! \param pos The position to insert the character.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& insert(uchar32_t c, u32 pos) {
-		u8 len = (c > 0xFFFF ? 2 : 1);
-
-		if (used + len >= allocated)
-			reallocate(used + len);
-
-		used += len;
-
-		iterator iter(*this, pos);
-		for (u32 i = used - 2; i > iter.getPos(); --i)
-			array[i] = array[i - len];
-
-		if (c > 0xFFFF) {
-			// c will be multibyte, so split it up into a surrogate pair.
-			uchar16_t x = static_cast<uchar16_t>(c);
-			uchar16_t vh = UTF16_HI_SURROGATE | ((((c >> 16) & ((1 << 5) - 1)) - 1) << 6) | (x >> 10);
-			uchar16_t vl = UTF16_LO_SURROGATE | (x & ((1 << 10) - 1));
-			array[iter.getPos()] = vh;
-			array[iter.getPos() + 1] = vl;
-		} else {
-			array[iter.getPos()] = static_cast<uchar16_t>(c);
-		}
-		array[used] = 0;
-		return *this;
-	}
-
-
-	//! Inserts a string into the string.
-	//! \param c The string to insert.
-	//! \param pos The position to insert the string.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& insert(const ustring16<TAlloc>& c, u32 pos) {
-		u32 len = c.size_raw();
-		if (len == 0) return *this;
-
-		if (used + len >= allocated)
-			reallocate(used + len);
-
-		used += len;
-
-		iterator iter(*this, pos);
-		for (u32 i = used - 2; i > iter.getPos() + len; --i)
-			array[i] = array[i - len];
-
-		const uchar16_t* s = c.c_str();
-		for (u32 i = 0; i < len; ++i) {
-			array[pos++] = *s;
-			++s;
-		}
-
-		array[used] = 0;
-		return *this;
-	}
-
-
-	//! Inserts a character into the string.
-	//! \param c The character to insert.
-	//! \param pos The position to insert the character.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& insert_raw(uchar16_t c, u32 pos) {
-		if (used + 1 >= allocated)
-			reallocate(used + 1);
-
-		++used;
-
-		for (u32 i = used - 1; i > pos; --i)
-			array[i] = array[i - 1];
-
-		array[pos] = c;
-		array[used] = 0;
-		return *this;
-	}
-
-
-	//! Removes a character from string.
-	//! \param pos Position of the character to remove.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& erase_raw(u32 pos) {
-		for (u32 i = pos; i <= used; ++i) {
-			array[i] = array[i + 1];
-		}
-		--used;
-		array[used] = 0;
-		return *this;
-	}
-
-
-	//! Replaces a character in the string.
-	//! \param c The new character.
-	//! \param pos The position of the character to replace.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& replace_raw(uchar16_t c, u32 pos) {
-		array[pos] = c;
-		return *this;
-	}
-
-
-	//! Returns an iterator to the beginning of the string.
-	//! \return An iterator to the beginning of the string.
-	iterator begin() {
-		iterator i(*this, 0);
-		return i;
+		return size_raw_;
 	}
 
 
 	//! Returns an iterator to the beginning of the string.
 	//! \return An iterator to the beginning of the string.
 	const_iterator begin() const {
-		const_iterator i(*this, 0);
-		return i;
+		return { *this };
 	}
 
 
 	//! Returns an iterator to the beginning of the string.
 	//! \return An iterator to the beginning of the string.
 	const_iterator cbegin() const {
-		const_iterator i(*this, 0);
-		return i;
-	}
-
-
-	//! Returns an iterator to the end of the string.
-	//! \return An iterator to the end of the string.
-	iterator end() {
-		iterator i(*this, 0);
-		i.toEnd();
-		return i;
+		return begin();
 	}
 
 
 	//! Returns an iterator to the end of the string.
 	//! \return An iterator to the end of the string.
 	const_iterator end() const {
-		const_iterator i(*this, 0);
+		const_iterator i{ *this };
 		i.toEnd();
 		return i;
 	}
@@ -2433,642 +552,19 @@ public:
 	//! Returns an iterator to the end of the string.
 	//! \return An iterator to the end of the string.
 	const_iterator cend() const {
-		const_iterator i(*this, 0);
-		i.toEnd();
-		return i;
-	}
-
-
-	//! Converts the string to a UTF-8 encoded string.
-	//! \param addBOM If true, the proper unicode byte-order mark will be prefixed to the string.
-	//! \return A string containing the UTF-8 encoded string.
-	core::string<uchar8_t> toUTF8_s(const bool addBOM = false) const {
-		core::string<uchar8_t> ret;
-		ret.reserve(used * 4 + (addBOM ? unicode::BOM_UTF8_LEN : 0) + 1);
-		const_iterator iter(*this, 0);
-
-		// Add the byte order mark if the user wants it.
-		if (addBOM) {
-			ret.append(unicode::BOM_ENCODE_UTF8[0]);
-			ret.append(unicode::BOM_ENCODE_UTF8[1]);
-			ret.append(unicode::BOM_ENCODE_UTF8[2]);
-		}
-
-		while (!iter.atEnd()) {
-			uchar32_t c = *iter;
-			if (c > 0xFFFF) {
-				// 4 bytes
-				uchar8_t b1 = (0x1E << 3) | ((c >> 18) & 0x7);
-				uchar8_t b2 = (0x2 << 6) | ((c >> 12) & 0x3F);
-				uchar8_t b3 = (0x2 << 6) | ((c >> 6) & 0x3F);
-				uchar8_t b4 = (0x2 << 6) | (c & 0x3F);
-				ret.append(b1);
-				ret.append(b2);
-				ret.append(b3);
-				ret.append(b4);
-			} else if (c > 0x7FF) {
-				// 3 bytes
-				uchar8_t b1 = (0xE << 4) | ((c >> 12) & 0xF);
-				uchar8_t b2 = (0x2 << 6) | ((c >> 6) & 0x3F);
-				uchar8_t b3 = (0x2 << 6) | (c & 0x3F);
-				ret.append(b1);
-				ret.append(b2);
-				ret.append(b3);
-			} else if (c > 0x7F) {
-				// 2 bytes
-				uchar8_t b1 = (0x6 << 5) | ((c >> 6) & 0x1F);
-				uchar8_t b2 = (0x2 << 6) | (c & 0x3F);
-				ret.append(b1);
-				ret.append(b2);
-			} else {
-				// 1 byte
-				ret.append(static_cast<uchar8_t>(c));
-			}
-			++iter;
-		}
-		return ret;
-	}
-
-
-	//! Converts the string to a UTF-8 encoded string array.
-	//! \param addBOM If true, the proper unicode byte-order mark will be prefixed to the string.
-	//! \return An array containing the UTF-8 encoded string.
-	core::array<uchar8_t> toUTF8(const bool addBOM = false) const {
-		core::array<uchar8_t> ret(used * 4 + (addBOM ? unicode::BOM_UTF8_LEN : 0) + 1);
-		const_iterator iter(*this, 0);
-
-		// Add the byte order mark if the user wants it.
-		if (addBOM) {
-			ret.push_back(unicode::BOM_ENCODE_UTF8[0]);
-			ret.push_back(unicode::BOM_ENCODE_UTF8[1]);
-			ret.push_back(unicode::BOM_ENCODE_UTF8[2]);
-		}
-
-		while (!iter.atEnd()) {
-			uchar32_t c = *iter;
-			if (c > 0xFFFF) {
-				// 4 bytes
-				uchar8_t b1 = (0x1E << 3) | ((c >> 18) & 0x7);
-				uchar8_t b2 = (0x2 << 6) | ((c >> 12) & 0x3F);
-				uchar8_t b3 = (0x2 << 6) | ((c >> 6) & 0x3F);
-				uchar8_t b4 = (0x2 << 6) | (c & 0x3F);
-				ret.push_back(b1);
-				ret.push_back(b2);
-				ret.push_back(b3);
-				ret.push_back(b4);
-			} else if (c > 0x7FF) {
-				// 3 bytes
-				uchar8_t b1 = (0xE << 4) | ((c >> 12) & 0xF);
-				uchar8_t b2 = (0x2 << 6) | ((c >> 6) & 0x3F);
-				uchar8_t b3 = (0x2 << 6) | (c & 0x3F);
-				ret.push_back(b1);
-				ret.push_back(b2);
-				ret.push_back(b3);
-			} else if (c > 0x7F) {
-				// 2 bytes
-				uchar8_t b1 = (0x6 << 5) | ((c >> 6) & 0x1F);
-				uchar8_t b2 = (0x2 << 6) | (c & 0x3F);
-				ret.push_back(b1);
-				ret.push_back(b2);
-			} else {
-				// 1 byte
-				ret.push_back(static_cast<uchar8_t>(c));
-			}
-			++iter;
-		}
-		ret.push_back(0);
-		return ret;
-	}
-
-/*
-#ifdef USTRING_CPP0X_NEWLITERALS	// C++0x
-	//! Converts the string to a UTF-16 encoded string.
-	//! \param endian The desired endianness of the string.
-	//! \param addBOM If true, the proper unicode byte-order mark will be prefixed to the string.
-	//! \return A string containing the UTF-16 encoded string.
-	core::string<char16_t> toUTF16_s(const unicode::EUTF_ENDIAN endian = unicode::EUTFEE_NATIVE, const bool addBOM = false) const {
-		core::string<char16_t> ret;
-		ret.reserve(used + (addBOM ? unicode::BOM_UTF16_LEN : 0) + 1);
-
-		// Add the BOM if specified.
-		if (addBOM) {
-			if (endian == unicode::EUTFEE_NATIVE)
-				ret[0] = unicode::BOM;
-			else if (endian == unicode::EUTFEE_LITTLE) {
-				uchar8_t* ptr8 = reinterpret_cast<uchar8_t*>(ret.c_str());
-				*ptr8++ = unicode::BOM_ENCODE_UTF16_LE[0];
-				*ptr8 = unicode::BOM_ENCODE_UTF16_LE[1];
-			} else {
-				uchar8_t* ptr8 = reinterpret_cast<uchar8_t*>(ret.c_str());
-				*ptr8++ = unicode::BOM_ENCODE_UTF16_BE[0];
-				*ptr8 = unicode::BOM_ENCODE_UTF16_BE[1];
-			}
-		}
-
-		ret.append(array);
-		if (endian != unicode::EUTFEE_NATIVE && getEndianness() != endian) {
-			char16_t* ptr = ret.c_str();
-			for (u32 i = 0; i < ret.size(); ++i)
-				*ptr++ = unicode::swapEndian16(*ptr);
-		}
-		return ret;
-	}
-#endif
-*/
-
-	//! Converts the string to a UTF-16 encoded string array.
-	//! Unfortunately, no toUTF16_s() version exists due to limitations with Irrlicht's string class.
-	//! \param endian The desired endianness of the string.
-	//! \param addBOM If true, the proper unicode byte-order mark will be prefixed to the string.
-	//! \return An array containing the UTF-16 encoded string.
-	core::array<uchar16_t> toUTF16(const unicode::EUTF_ENDIAN endian = unicode::EUTFEE_NATIVE, const bool addBOM = false) const {
-		core::array<uchar16_t> ret(used + (addBOM ? unicode::BOM_UTF16_LEN : 0) + 1);
-		uchar16_t* ptr = ret.pointer();
-
-		// Add the BOM if specified.
-		if (addBOM) {
-			if (endian == unicode::EUTFEE_NATIVE)
-				*ptr = unicode::BOM;
-			else if (endian == unicode::EUTFEE_LITTLE) {
-				uchar8_t* ptr8 = reinterpret_cast<uchar8_t*>(ptr);
-				*ptr8++ = unicode::BOM_ENCODE_UTF16_LE[0];
-				*ptr8 = unicode::BOM_ENCODE_UTF16_LE[1];
-			} else {
-				uchar8_t* ptr8 = reinterpret_cast<uchar8_t*>(ptr);
-				*ptr8++ = unicode::BOM_ENCODE_UTF16_BE[0];
-				*ptr8 = unicode::BOM_ENCODE_UTF16_BE[1];
-			}
-			++ptr;
-		}
-
-		memcpy((void*)ptr, (void*)array, used * sizeof(uchar16_t));
-		if (endian != unicode::EUTFEE_NATIVE && getEndianness() != endian) {
-			for (u32 i = 0; i <= used; ++i, ++ptr)
-				*ptr = unicode::swapEndian16(*ptr);
-		}
-		ret.set_used(used + (addBOM ? unicode::BOM_UTF16_LEN : 0));
-		ret.push_back(0);
-		return ret;
-	}
-
-/*
-#ifdef USTRING_CPP0X_NEWLITERALS	// C++0x
-	//! Converts the string to a UTF-32 encoded string.
-	//! \param endian The desired endianness of the string.
-	//! \param addBOM If true, the proper unicode byte-order mark will be prefixed to the string.
-	//! \return A string containing the UTF-32 encoded string.
-	core::string<char32_t> toUTF32_s(const unicode::EUTF_ENDIAN endian = unicode::EUTFEE_NATIVE, const bool addBOM = false) const {
-		core::string<char32_t> ret;
-		ret.reserve(size() + 1 + (addBOM ? unicode::BOM_UTF32_LEN : 0));
-		const_iterator iter(*this, 0);
-
-		// Add the BOM if specified.
-		if (addBOM) {
-			if (endian == unicode::EUTFEE_NATIVE)
-				ret.append(unicode::BOM);
-			else {
-				union {
-					uchar32_t full;
-					u8 chunk[4];
-				} t;
-
-				if (endian == unicode::EUTFEE_LITTLE) {
-					t.chunk[0] = unicode::BOM_ENCODE_UTF32_LE[0];
-					t.chunk[1] = unicode::BOM_ENCODE_UTF32_LE[1];
-					t.chunk[2] = unicode::BOM_ENCODE_UTF32_LE[2];
-					t.chunk[3] = unicode::BOM_ENCODE_UTF32_LE[3];
-				} else {
-					t.chunk[0] = unicode::BOM_ENCODE_UTF32_BE[0];
-					t.chunk[1] = unicode::BOM_ENCODE_UTF32_BE[1];
-					t.chunk[2] = unicode::BOM_ENCODE_UTF32_BE[2];
-					t.chunk[3] = unicode::BOM_ENCODE_UTF32_BE[3];
-				}
-				ret.append(t.full);
-			}
-		}
-
-		while (!iter.atEnd()) {
-			uchar32_t c = *iter;
-			if (endian != unicode::EUTFEE_NATIVE && getEndianness() != endian)
-				c = unicode::swapEndian32(c);
-			ret.append(c);
-			++iter;
-		}
-		return ret;
-	}
-#endif
-*/
-
-	//! Converts the string to a UTF-32 encoded string array.
-	//! Unfortunately, no toUTF32_s() version exists due to limitations with Irrlicht's string class.
-	//! \param endian The desired endianness of the string.
-	//! \param addBOM If true, the proper unicode byte-order mark will be prefixed to the string.
-	//! \return An array containing the UTF-32 encoded string.
-	core::array<uchar32_t> toUTF32(const unicode::EUTF_ENDIAN endian = unicode::EUTFEE_NATIVE, const bool addBOM = false) const {
-		core::array<uchar32_t> ret(size() + (addBOM ? unicode::BOM_UTF32_LEN : 0) + 1);
-		const_iterator iter(*this, 0);
-
-		// Add the BOM if specified.
-		if (addBOM) {
-			if (endian == unicode::EUTFEE_NATIVE)
-				ret.push_back(unicode::BOM);
-			else {
-				union {
-					uchar32_t full;
-					u8 chunk[4];
-				} t;
-
-				if (endian == unicode::EUTFEE_LITTLE) {
-					t.chunk[0] = unicode::BOM_ENCODE_UTF32_LE[0];
-					t.chunk[1] = unicode::BOM_ENCODE_UTF32_LE[1];
-					t.chunk[2] = unicode::BOM_ENCODE_UTF32_LE[2];
-					t.chunk[3] = unicode::BOM_ENCODE_UTF32_LE[3];
-				} else {
-					t.chunk[0] = unicode::BOM_ENCODE_UTF32_BE[0];
-					t.chunk[1] = unicode::BOM_ENCODE_UTF32_BE[1];
-					t.chunk[2] = unicode::BOM_ENCODE_UTF32_BE[2];
-					t.chunk[3] = unicode::BOM_ENCODE_UTF32_BE[3];
-				}
-				ret.push_back(t.full);
-			}
-		}
-		ret.push_back(0);
-
-		while (!iter.atEnd()) {
-			uchar32_t c = *iter;
-			if (endian != unicode::EUTFEE_NATIVE && getEndianness() != endian)
-				c = unicode::swapEndian32(c);
-			ret.push_back(c);
-			++iter;
-		}
-		return ret;
-	}
-
-
-	//! Converts the string to a wchar_t encoded string.
-	/** The size of a wchar_t changes depending on the platform.  This function will store a
-	correct UTF-8, -16, or -32 encoded string depending on the size of a wchar_t. **/
-	//! \param endian The desired endianness of the string.
-	//! \param addBOM If true, the proper unicode byte-order mark will be prefixed to the string.
-	//! \return A string containing the wchar_t encoded string.
-	core::string<wchar_t> toWCHAR_s(const unicode::EUTF_ENDIAN endian = unicode::EUTFEE_NATIVE, const bool addBOM = false) const {
-		if (sizeof(wchar_t) == 4) {
-			core::array<uchar32_t> a(toUTF32(endian, addBOM));
-			core::stringw ret(a.pointer());
-			return ret;
-		} else if (sizeof(wchar_t) == 2) {
-			if (endian == unicode::EUTFEE_NATIVE && addBOM == false) {
-				core::stringw ret(array);
-				return ret;
-			} else {
-				core::array<uchar16_t> a(toUTF16(endian, addBOM));
-				core::stringw ret(a.pointer());
-				return ret;
-			}
-		} else if (sizeof(wchar_t) == 1) {
-			core::array<uchar8_t> a(toUTF8(addBOM));
-			core::stringw ret(a.pointer());
-			return ret;
-		}
-
-		// Shouldn't happen.
-		return core::stringw();
-	}
-
-
-	//! Converts the string to a wchar_t encoded string array.
-	/** The size of a wchar_t changes depending on the platform.  This function will store a
-	correct UTF-8, -16, or -32 encoded string depending on the size of a wchar_t. **/
-	//! \param endian The desired endianness of the string.
-	//! \param addBOM If true, the proper unicode byte-order mark will be prefixed to the string.
-	//! \return An array containing the wchar_t encoded string.
-	core::array<wchar_t> toWCHAR(const unicode::EUTF_ENDIAN endian = unicode::EUTFEE_NATIVE, const bool addBOM = false) const {
-		if (sizeof(wchar_t) == 4) {
-			core::array<uchar32_t> a(toUTF32(endian, addBOM));
-			core::array<wchar_t> ret(a.size());
-			ret.set_used(a.size());
-			memcpy((void*)ret.pointer(), (void*)a.pointer(), a.size() * sizeof(uchar32_t));
-			return ret;
-		}
-		if (sizeof(wchar_t) == 2) {
-			if (endian == unicode::EUTFEE_NATIVE && addBOM == false) {
-				core::array<wchar_t> ret(used);
-				ret.set_used(used);
-				memcpy((void*)ret.pointer(), (void*)array, used * sizeof(uchar16_t));
-				return ret;
-			} else {
-				core::array<uchar16_t> a(toUTF16(endian, addBOM));
-				core::array<wchar_t> ret(a.size());
-				ret.set_used(a.size());
-				memcpy((void*)ret.pointer(), (void*)a.pointer(), a.size() * sizeof(uchar16_t));
-				return ret;
-			}
-		}
-		if (sizeof(wchar_t) == 1) {
-			core::array<uchar8_t> a(toUTF8(addBOM));
-			core::array<wchar_t> ret(a.size());
-			ret.set_used(a.size());
-			memcpy((void*)ret.pointer(), (void*)a.pointer(), a.size() * sizeof(uchar8_t));
-			return ret;
-		}
-
-		// Shouldn't happen.
-		return core::array<wchar_t>();
-	}
-
-	//! Converts the string to a properly encoded io::path string.
-	//! \param endian The desired endianness of the string.
-	//! \param addBOM If true, the proper unicode byte-order mark will be prefixed to the string.
-	//! \return An io::path string containing the properly encoded string.
-	io::path toPATH_s(const unicode::EUTF_ENDIAN endian = unicode::EUTFEE_NATIVE, const bool addBOM = false) const {
-#if defined(_IRR_WCHAR_FILESYSTEM)
-		return toWCHAR_s(endian, addBOM);
-#else
-		return toUTF8_s(addBOM);
-#endif
-	}
-
-	//! Loads an unknown stream of data.
-	//! Will attempt to determine if the stream is unicode data.  Useful for loading from files.
-	//! \param data The data stream to load from.
-	//! \param data_size The length of the data string.
-	//! \return A reference to our current string.
-	ustring16<TAlloc>& loadDataStream(const char* data, size_t data_size) {
-		// Clear our string.
-		*this = "";
-		if (!data)
-			return *this;
-
-		unicode::EUTF_ENCODE e = unicode::determineUnicodeBOM(data);
-		switch (e) {
-		default:
-		case unicode::EUTFE_UTF8:
-			append((uchar8_t*)data, data_size);
-			break;
-
-		case unicode::EUTFE_UTF16:
-		case unicode::EUTFE_UTF16_BE:
-		case unicode::EUTFE_UTF16_LE:
-			append((uchar16_t*)data, data_size / 2);
-			break;
-
-		case unicode::EUTFE_UTF32:
-		case unicode::EUTFE_UTF32_BE:
-		case unicode::EUTFE_UTF32_LE:
-			append((uchar32_t*)data, data_size / 4);
-			break;
-		}
-
-		return *this;
-	}
-
-	//! Gets the encoding of the Unicode string this class contains.
-	//! \return An enum describing the current encoding of this string.
-	const unicode::EUTF_ENCODE getEncoding() const {
-		return encoding;
-	}
-
-	//! Gets the endianness of the Unicode string this class contains.
-	//! \return An enum describing the endianness of this string.
-	const unicode::EUTF_ENDIAN getEndianness() const {
-		if (encoding == unicode::EUTFE_UTF16_LE ||
-				encoding == unicode::EUTFE_UTF32_LE)
-			return unicode::EUTFEE_LITTLE;
-		else return unicode::EUTFEE_BIG;
+		return end();
 	}
 
 private:
 
-	//! Reallocate the string, making it bigger or smaller.
-	//! \param new_size The new size of the string.
-	void reallocate(u32 new_size) {
-		uchar16_t* old_array = array;
-
-		array = allocator.allocate(new_size + 1); //new u16[new_size];
-		allocated = new_size + 1;
-		if (old_array == 0) return;
-
-		u32 amount = used < new_size ? used : new_size;
-		for (u32 i = 0; i <= amount; ++i)
-			array[i] = old_array[i];
-
-		if (allocated <= used)
-			used = allocated - 1;
-
-		array[used] = 0;
-
-		allocator.deallocate(old_array); // delete [] old_array;
-	}
-
 	//--- member variables
 
-	uchar16_t* array;
-	unicode::EUTF_ENCODE encoding;
-	u32 allocated;
-	u32 used;
-	TAlloc allocator;
-	//irrAllocator<uchar16_t> allocator;
+	const wchar_t* data_;
+	mutable u32 size_;
+	u32 size_raw_;
 };
 
-typedef ustring16<irrAllocator<uchar16_t> > ustring;
-
-
-//! Appends two ustring16s.
-template <typename TAlloc>
-inline ustring16<TAlloc> operator+(const ustring16<TAlloc>& left, const ustring16<TAlloc>& right) {
-	ustring16<TAlloc> ret(left);
-	ret += right;
-	return ret;
-}
-
-
-//! Appends a ustring16 and a null-terminated unicode string.
-template <typename TAlloc, class B>
-inline ustring16<TAlloc> operator+(const ustring16<TAlloc>& left, const B* const right) {
-	ustring16<TAlloc> ret(left);
-	ret += right;
-	return ret;
-}
-
-
-//! Appends a ustring16 and a null-terminated unicode string.
-template <class B, typename TAlloc>
-inline ustring16<TAlloc> operator+(const B* const left, const ustring16<TAlloc>& right) {
-	ustring16<TAlloc> ret(left);
-	ret += right;
-	return ret;
-}
-
-
-//! Appends a ustring16 and an Irrlicht string.
-template <typename TAlloc, typename B, typename BAlloc>
-inline ustring16<TAlloc> operator+(const ustring16<TAlloc>& left, const string<B, BAlloc>& right) {
-	ustring16<TAlloc> ret(left);
-	ret += right;
-	return ret;
-}
-
-
-//! Appends a ustring16 and an Irrlicht string.
-template <typename TAlloc, typename B, typename BAlloc>
-inline ustring16<TAlloc> operator+(const string<B, BAlloc>& left, const ustring16<TAlloc>& right) {
-	ustring16<TAlloc> ret(left);
-	ret += right;
-	return ret;
-}
-
-
-//! Appends a ustring16 and a std::basic_string.
-template <typename TAlloc, typename B, typename A, typename BAlloc>
-inline ustring16<TAlloc> operator+(const ustring16<TAlloc>& left, const std::basic_string<B, A, BAlloc>& right) {
-	ustring16<TAlloc> ret(left);
-	ret += right;
-	return ret;
-}
-
-
-//! Appends a ustring16 and a std::basic_string.
-template <typename TAlloc, typename B, typename A, typename BAlloc>
-inline ustring16<TAlloc> operator+(const std::basic_string<B, A, BAlloc>& left, const ustring16<TAlloc>& right) {
-	ustring16<TAlloc> ret(left);
-	ret += right;
-	return ret;
-}
-
-
-#ifdef USTRING_CPP0X
-//! Appends two ustring16s.
-template <typename TAlloc>
-inline ustring16<TAlloc> && operator+(const ustring16<TAlloc>& left, ustring16<TAlloc> && right) {
-	//std::cout << "MOVE operator+(&, &&)" << std::endl;
-	right.insert(left, 0);
-	return std::move(right);
-}
-
-
-//! Appends two ustring16s.
-template <typename TAlloc>
-inline ustring16<TAlloc> && operator+(ustring16<TAlloc> && left, const ustring16<TAlloc>& right) {
-	//std::cout << "MOVE operator+(&&, &)" << std::endl;
-	left.append(right);
-	return std::move(left);
-}
-
-
-//! Appends two ustring16s.
-template <typename TAlloc>
-inline ustring16<TAlloc> && operator+(ustring16<TAlloc> && left, ustring16<TAlloc> && right) {
-	//std::cout << "MOVE operator+(&&, &&)" << std::endl;
-	if ((right.size_raw() <= left.capacity() - left.size_raw()) ||
-			(right.capacity() - right.size_raw() < left.size_raw())) {
-		left.append(right);
-		return std::move(left);
-	} else {
-		right.insert(left, 0);
-		return std::move(right);
-	}
-}
-
-
-//! Appends a ustring16 and a null-terminated unicode string.
-template <typename TAlloc, class B>
-inline ustring16<TAlloc> && operator+(ustring16<TAlloc> && left, const B* const right) {
-	//std::cout << "MOVE operator+(&&, B*)" << std::endl;
-	left.append(right);
-	return std::move(left);
-}
-
-
-//! Appends a ustring16 and a null-terminated unicode string.
-template <class B, typename TAlloc>
-inline ustring16<TAlloc> && operator+(const B* const left, ustring16<TAlloc> && right) {
-	//std::cout << "MOVE operator+(B*, &&)" << std::endl;
-	right.insert(left, 0);
-	return std::move(right);
-}
-
-
-//! Appends a ustring16 and an Irrlicht string.
-template <typename TAlloc, typename B, typename BAlloc>
-inline ustring16<TAlloc> && operator+(const string<B, BAlloc>& left, ustring16<TAlloc> && right) {
-	//std::cout << "MOVE operator+(&, &&)" << std::endl;
-	right.insert(left, 0);
-	return std::move(right);
-}
-
-
-//! Appends a ustring16 and an Irrlicht string.
-template <typename TAlloc, typename B, typename BAlloc>
-inline ustring16<TAlloc> && operator+(ustring16<TAlloc> && left, const string<B, BAlloc>& right) {
-	//std::cout << "MOVE operator+(&&, &)" << std::endl;
-	left.append(right);
-	return std::move(left);
-}
-
-
-//! Appends a ustring16 and a std::basic_string.
-template <typename TAlloc, typename B, typename A, typename BAlloc>
-inline ustring16<TAlloc> && operator+(const std::basic_string<B, A, BAlloc>& left, ustring16<TAlloc> && right) {
-	//std::cout << "MOVE operator+(&, &&)" << std::endl;
-	right.insert(core::ustring16<TAlloc>(left), 0);
-	return std::move(right);
-}
-
-
-//! Appends a ustring16 and a std::basic_string.
-template <typename TAlloc, typename B, typename A, typename BAlloc>
-inline ustring16<TAlloc> && operator+(ustring16<TAlloc> && left, const std::basic_string<B, A, BAlloc>& right) {
-	//std::cout << "MOVE operator+(&&, &)" << std::endl;
-	left.append(right);
-	return std::move(left);
-}
-#endif
-
-
-#ifndef USTRING_NO_STL
-//! Writes a ustring16 to an ostream.
-template <typename TAlloc>
-inline std::ostream& operator<<(std::ostream& out, const ustring16<TAlloc>& in) {
-	out << in.toUTF8_s().c_str();
-	return out;
-}
-
-//! Writes a ustring16 to a wostream.
-template <typename TAlloc>
-inline std::wostream& operator<<(std::wostream& out, const ustring16<TAlloc>& in) {
-	out << in.toWCHAR_s().c_str();
-	return out;
-}
-#endif
-
-
-#ifndef USTRING_NO_STL
-
-namespace unicode {
-
-//! Hashing algorithm for hashing a ustring.  Used for things like unordered_maps.
-//! Algorithm taken from std::hash<std::string>.
-class uhash {
-public:
-	size_t operator()(const core::ustring& s) const {
-		size_t ret = 2166136261U;
-		size_t index = 0;
-		size_t stride = 1 + s.size_raw() / 10;
-
-		core::ustring::const_iterator i = s.begin();
-		while (i != s.end()) {
-			// TODO: Don't force u32 on an x64 OS.  Make it agnostic.
-			ret = 16777619U * ret ^ (size_t)s[(u32)index];
-			index += stride;
-			i += stride;
-		}
-		return (ret);
-	}
-};
-
-} // end namespace unicode
-
-#endif
+typedef ustring16 ustring;
 
 } // end namespace core
 } // end namespace irr

--- a/gframe/irrUString.h
+++ b/gframe/irrUString.h
@@ -381,6 +381,11 @@ public:
 		size_raw_ = other.size_raw();
 	}
 
+	ustring16(const stringw& other)
+		: data_(nullptr), size_(0), size_raw_(0) {
+		assign(other.c_str(), static_cast<u32>(other.size()));
+	}
+
 	template <class T>
 	ustring16(const T& other)
 		: data_(nullptr), size_(0), size_raw_(0) {
@@ -407,6 +412,11 @@ public:
 		data_ = other.data();
 		size_raw_ = other.size_raw();
 		size_ = 0xffffffff;
+		return *this;
+	}
+
+	ustring16& operator=(const stringw& other) {
+		assign(other.c_str(), static_cast<u32>(other.size()));
 		return *this;
 	}
 


### PR DESCRIPTION
Base: #2602 

aa1e281674e07b6e54d05f027167b5bb3724c3c5
```cpp
std::wstring DataManager::GetNumString(int num, bool bracket) const;
```
Now `GetNumString` does not use global buffer.
The return value is a wide string.
Fix: Now the max number of cards in a pack is not limited by the size of `numStrings`.

8509aec134cbd584810808e16727dd0201b23a75
Rebuild class ustring16 from edopro version, which is modified by @edo9300 .

# edopro changes:
## remove allocator
Before:
```cpp
template <typename TAlloc = irrAllocator<uchar16_t> >
class ustring16
```
After:
```cpp
class ustring16
```

https://learn.microsoft.com/en-us/cpp/standard-library/allocators?view=msvc-170
If you are targeting C++11 and you need to write a new custom allocator, make it a minimal allocator if possible. Even if you have already implemented an old-style allocator, consider modifying it to be a minimal allocator in order to take advantage of the more efficient construct() method that will be provided for you automatically.

When creating a minimal allocator, do not implement any members except the ones shown in the example below:
1. a converting copy constructor (see example)
2. operator==
3. operator!=
4. allocate
5. deallocate

`class ustring16` is written before C++11, and it seems that its allocator `irrAllocator` is out-dated.
I agree that removing the allocator is a better choice.


## remove `class _ustring16_iterator_access`
Before:
```cpp
typedef typename ustring16<TAlloc>::_ustring16_iterator_access access;
```
After:
```cpp
typedef uchar32_t access;
```

## `class _ustring16_const_iterator` does not use `std::iterator`
Before:
```cpp
class _ustring16_const_iterator : public std::iterator <
	std::bidirectional_iterator_tag,	// iterator_category
	access,								// value_type
	ptrdiff_t,							// difference_type
	const access,						// pointer
	const access						// reference
>
```
After:
```cpp
class _ustring16_const_iterator
```

https://en.cppreference.com/w/cpp/iterator/iterator
```cpp
template<
    class Category,
    class T,
    class Distance = std::ptrdiff_t,
    class Pointer = T*,
    class Reference = T&
> struct iterator;
```
(deprecated in C++17) 

https://en.cppreference.com/w/cpp/iterator/iterator_traits
iterator_category
value_type
difference_type
pointer
reference


This template is just a helper, and we can explicitly define these traits.

## remove `class _ustring16_iterator`
Now it only has `const_iterator`.

# ygopro changes
## Remove `if constexpr`
It is a C++17 feature.
I am not sure if we are ready for C++17.

## Add constructor for `irr::core::wstring`
core::stringw in current version does not have `data()`.

----
8a8dc31b695a7671e68618a7d5b866580aef89a2
bcdaa5d73f25ed51651ccf3912415946a6eb9093
class CGUITTFont
add `drawUstring`
```cpp
void drawUstring(const core::ustring& text, const core::rect<s32>& position,
				video::SColor color, bool hcenter = false, bool vcenter = false,
				const core::rect<s32>* clip = 0);
```
Before:
Convert the string from core::stringw to core::ustring

After:
Use core::ustring directly.

343537ae85425a02e5642bef147885de6f339be5
update DrawShadowText
```cpp
template<typename T>
inline void DrawShadowText(irr::gui::CGUITTFont* font, const T& text, const core::rect<s32>& position, 
const core::rect<s32>& padding, video::SColor color = 0xffffffff, 
video::SColor shadowcolor = 0xff000000, bool hcenter = false, bool vcenter = false, const core::rect<s32>* clip = nullptr) 
```
Before:
wchar_t => converted to `core::stringw` => converted to `core::ustring`
a member function of `Game`

After:
wchar_t or `std::wstring` => converted to `core::ustring`
not a member function of `Game`

c457ae5e146ba38f47cfb271ee584c7dfafa031c
c97b29c4acbca3ef1362d244c25ee7c19ddb26da
fix Game::lpcstring 
fix DuelInfo::vic_string 
Now they are `std::wstring`.
Keeping a pointer to local variable is dangerous and unnecessary.

@mercury233 
@purerosefallen 
@Wind2009-Louse 
@edo9300


