### PR TITLE
fix warning -Wformat-truncation

### DIFF
--- a/gframe/myfilesystem.h
+++ b/gframe/myfilesystem.h
@@ -174,8 +174,12 @@ public:
 	static bool DeleteDir(const char* dir) {
 		bool success = true;
 		TraversalDir(dir, [dir, &success](const char *name, bool isdir) {
-			char full_path[256];
-			snprintf(full_path, sizeof full_path, "%s/%s", dir, name);
+			char full_path[1024];
+			int len = std::snprintf(full_path, sizeof full_path, "%s/%s", dir, name);
+			if (len < 0 || len >= (int)(sizeof full_path)) {
+				success = false;
+				return;
+			}
 			if (isdir)
 			{
 				if(!DeleteDir(full_path))
@@ -207,7 +211,9 @@ public:
 		while((dirp = readdir(dir)) != nullptr) {
 			file_unit funit;
 			char fname[1024];
-			std::snprintf(fname, sizeof fname, "%s/%s", path, dirp->d_name);
+			int len = std::snprintf(fname, sizeof fname, "%s/%s", path, dirp->d_name);
+			if (len < 0 || len >= (int)(sizeof fname))
+				continue;
 			stat(fname, &fileStat);
 			funit.filename = std::string(dirp->d_name);
 			funit.is_dir = S_ISDIR(fileStat.st_mode);


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Warning-Options.html
-Wformat-truncation
-Wformat-truncation=level

Warn about calls to formatted input/output functions such as snprintf and vsnprintf that might result in output truncation. 
When the exact number of bytes written by a format directive cannot be determined at compile-time it is estimated based on heuristics that depend on the level argument and on optimization. 
While enabling optimization will in most cases improve the accuracy of the warning, it may also result in false positives. 
Except as noted otherwise, the option uses the same logic -Wformat-overflow. 

snprintf 的返回值會顯示字串是否因為長度不足而被截斷
如果沒有檢查返回值就可能跳出這個警告
對於路徑而言，如果是被截斷的字串就應該停止行動

@mercury233 
@purerosefallen 
@Wind2009-Louse