### PR TITLE
wcsncpy capped at N-1

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1249,10 +1249,10 @@ void Game::RefreshDeck(const wchar_t* deckpath, const std::function<void(const w
 	FileSystem::TraversalDir(deckpath, [additem](const wchar_t* name, bool isdir) {
 		if (!isdir && IsExtension(name, L".ydk")) {
 			size_t len = std::wcslen(name);
-			wchar_t deckname[256];
-			size_t count = std::min(len - 4, sizeof deckname / sizeof deckname[0]);
+			wchar_t deckname[256]{};
+			size_t count = std::min(len - 4, sizeof deckname / sizeof deckname[0] - 1);
 			std::wcsncpy(deckname, name, count);
-			deckname[(sizeof deckname / sizeof deckname[0]) - 1] = 0;
+			deckname[count] = 0;
 			additem(deckname);
 		}
 	});


### PR DESCRIPTION
The strncpy function copies not more than n characters (characters that follow a null character are not copied) from the array pointed to by s2 to the array pointed to by s1.
If the array pointed to by s2 is a string that is shorter than n characters, null characters are appended to the copy in the array pointed to by s1, until n characters in all have been written.

write N-1 char
write NULL at a[N-1]