### PR TITLE
热加载expansions

### DIFF
--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -13,11 +13,11 @@ namespace ygo {
 class DataManager {
 public:
 	DataManager();
-	bool ReadDB(sqlite3* pDB);
-	bool LoadDB(const wchar_t* wfile);
-	bool LoadStrings(const char* file);
-	bool LoadStrings(IReadFile* reader);
-	void ReadStringConfLine(const char* linebuf);
+	bool ReadDB(sqlite3* pDB, bool expansion = false);
+	bool LoadDB(const wchar_t* wfile, bool expansion = false);
+	bool LoadStrings(const char* file, bool expansion = false);
+	bool LoadStrings(IReadFile* reader, bool expansion = false);
+	void ReadStringConfLine(const char* linebuf, bool expansion = false);
 	bool Error(sqlite3* pDB, sqlite3_stmt* pStmt = nullptr);
 
 	code_pointer GetCodePointer(unsigned int code) const;
@@ -44,6 +44,10 @@ public:
 	std::wstring FormatSetName(const uint16_t setcode[]) const;
 	std::wstring FormatLinkMarker(unsigned int link_marker) const;
 
+	std::vector<int> _expansionDatas;
+	std::vector<int> _expansionStrings;
+	std::unordered_map<unsigned int, CardDataC> _datas;
+	std::unordered_map<unsigned int, CardString> _strings;
 	std::unordered_map<unsigned int, std::wstring> _counterStrings;
 	std::unordered_map<unsigned int, std::wstring> _victoryStrings;
 	std::unordered_map<unsigned int, std::wstring> _setnameStrings;
@@ -58,8 +62,6 @@ public:
 	static IFileSystem* FileSystem;
 
 private:
-	std::unordered_map<unsigned int, CardDataC> _datas;
-	std::unordered_map<unsigned int, CardString> _strings;
 	std::unordered_map<unsigned int, std::vector<uint16_t>> extra_setcode;
 };
 

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1143,18 +1143,44 @@ std::wstring Game::SetStaticText(irr::gui::IGUIStaticText* pControl, u32 cWidth,
 	ret.assign(strBuffer);
 	return ret;
 }
+void Game::ReLoadExpansions() {
+	for (size_t i = 0; i < dataManager._expansionDatas.size(); ++i) {
+		int code = dataManager._expansionDatas[i];
+		dataManager._strings.erase(code);
+		dataManager._datas.erase(code);
+	}
+	dataManager._expansionDatas.clear();
+	for (size_t i = 0; i < dataManager._expansionStrings.size(); ++i) {
+		int value = dataManager._expansionStrings[i];
+		dataManager._counterStrings.erase(value);
+		dataManager._victoryStrings.erase(value);
+		dataManager._setnameStrings.erase(value);
+		dataManager._sysStrings.erase(value);
+	}
+	dataManager._expansionStrings.clear();
+	dataManager.LoadStrings("./expansions/strings.conf", true);
+	deckManager._lfList.clear();
+	deckManager.LoadLFList();
+	cbHostLFlist->clear();
+	cbLFlist->clear();
+	for(unsigned int i = 0; i < deckManager._lfList.size(); ++i)
+		cbHostLFlist->addItem(deckManager._lfList[i].listName.c_str());
+	for(unsigned int i = 0; i < deckManager._lfList.size(); ++i)
+		cbLFlist->addItem(deckManager._lfList[i].listName.c_str(), deckManager._lfList[i].hash);
+	LoadExpansions();
+}
 void Game::LoadExpansions() {
 	FileSystem::TraversalDir(L"./expansions", [](const wchar_t* name, bool isdir) {
 		wchar_t fpath[1024];
 		myswprintf(fpath, L"./expansions/%ls", name);
 		if (!isdir && IsExtension(name, L".cdb")) {
-			dataManager.LoadDB(fpath);
+			dataManager.LoadDB(fpath, true);
 			return;
 		}
 		if (!isdir && IsExtension(name, L".conf")) {
 			char upath[1024];
 			BufferIO::EncodeUTF8(fpath, upath);
-			dataManager.LoadStrings(upath);
+			dataManager.LoadStrings(upath, true);
 			return;
 		}
 		if (!isdir && (IsExtension(name, L".zip") || IsExtension(name, L".ypk"))) {
@@ -1179,7 +1205,7 @@ void Game::LoadExpansions() {
 			BufferIO::DecodeUTF8(uname, fname);
 #endif
 			if (IsExtension(fname, L".cdb")) {
-				dataManager.LoadDB(fname);
+				dataManager.LoadDB(fname, true);
 				continue;
 			}
 			if (IsExtension(fname, L".conf")) {
@@ -1188,7 +1214,7 @@ void Game::LoadExpansions() {
 #else
 				IReadFile* reader = DataManager::FileSystem->createAndOpenFile(uname);
 #endif
-				dataManager.LoadStrings(reader);
+				dataManager.LoadStrings(reader, true);
 				continue;
 			}
 			if (!mywcsncasecmp(fname, L"pack/", 5) && IsExtension(fname, L".ydk")) {

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -110,6 +110,7 @@ bool Game::Initialize() {
 	}
 	LoadExpansions();
 	ChkLastTime();
+	ChkReload = false;
 	env = device->getGUIEnvironment();
 	numFont = irr::gui::CGUITTFont::createTTFont(env, gameConf.numfont, 16);
 	if(!numFont) {

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -109,7 +109,6 @@ bool Game::Initialize() {
 		return false;
 	}
 	LoadExpansions();
-	LastExpansionsTime = GetLastWriteTime(L"./expansions");
 	env = device->getGUIEnvironment();
 	numFont = irr::gui::CGUITTFont::createTTFont(env, gameConf.numfont, 16);
 	if(!numFont) {
@@ -1144,41 +1143,31 @@ std::wstring Game::SetStaticText(irr::gui::IGUIStaticText* pControl, u32 cWidth,
 	ret.assign(strBuffer);
 	return ret;
 }
-int Game::GetLastWriteTime(wchar_t* dirPath) {
-	struct _stat64i32 st = { 0 };
-	if (_wstat(dirPath, &st) != -1)
-		return (int)(st.st_mtime);
-	return 0;
-}
 void Game::ReLoadExpansions() {
-	int time = GetLastWriteTime(L"./expansions");
-	if (LastExpansionsTime != time) {
-		for (size_t i = 0; i < dataManager._expansionDatas.size(); ++i) {
-			int code = dataManager._expansionDatas[i];
-			dataManager._strings.erase(code);
-			dataManager._datas.erase(code);
-		}
-		dataManager._expansionDatas.clear();
-		for (size_t i = 0; i < dataManager._expansionStrings.size(); ++i) {
-			int value = dataManager._expansionStrings[i];
-			dataManager._counterStrings.erase(value);
-			dataManager._victoryStrings.erase(value);
-			dataManager._setnameStrings.erase(value);
-			dataManager._sysStrings.erase(value);
-		}
-		dataManager._expansionStrings.clear();
-		dataManager.LoadStrings("./expansions/strings.conf", true);
-		deckManager._lfList.clear();
-		deckManager.LoadLFList();
-		cbHostLFlist->clear();
-		cbLFlist->clear();
-		for (unsigned int i = 0; i < deckManager._lfList.size(); ++i)
-			cbHostLFlist->addItem(deckManager._lfList[i].listName.c_str());
-		for (unsigned int i = 0; i < deckManager._lfList.size(); ++i)
-			cbLFlist->addItem(deckManager._lfList[i].listName.c_str(), deckManager._lfList[i].hash);
-		LoadExpansions();
-		LastExpansionsTime = time;
+	for (size_t i = 0; i < dataManager._expansionDatas.size(); ++i) {
+		int code = dataManager._expansionDatas[i];
+		dataManager._strings.erase(code);
+		dataManager._datas.erase(code);
 	}
+	dataManager._expansionDatas.clear();
+	for (size_t i = 0; i < dataManager._expansionStrings.size(); ++i) {
+		int value = dataManager._expansionStrings[i];
+		dataManager._counterStrings.erase(value);
+		dataManager._victoryStrings.erase(value);
+		dataManager._setnameStrings.erase(value);
+		dataManager._sysStrings.erase(value);
+	}
+	dataManager._expansionStrings.clear();
+	dataManager.LoadStrings("./expansions/strings.conf", true);
+	deckManager._lfList.clear();
+	deckManager.LoadLFList();
+	cbHostLFlist->clear();
+	cbLFlist->clear();
+	for(unsigned int i = 0; i < deckManager._lfList.size(); ++i)
+		cbHostLFlist->addItem(deckManager._lfList[i].listName.c_str());
+	for(unsigned int i = 0; i < deckManager._lfList.size(); ++i)
+		cbLFlist->addItem(deckManager._lfList[i].listName.c_str(), deckManager._lfList[i].hash);
+	LoadExpansions();
 }
 void Game::LoadExpansions() {
 	FileSystem::TraversalDir(L"./expansions", [](const wchar_t* name, bool isdir) {

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -109,7 +109,7 @@ bool Game::Initialize() {
 		return false;
 	}
 	LoadExpansions();
-	ChkLastTime(false);
+	ChkLastTime();
 	env = device->getGUIEnvironment();
 	numFont = irr::gui::CGUITTFont::createTTFont(env, gameConf.numfont, 16);
 	if(!numFont) {
@@ -1150,20 +1150,19 @@ int Game::GetLastWriteTime(wchar_t* dirPath) {
 		return (int)(st.st_mtime);
 	return 0;
 }
-void Game::ChkLastTime(bool chk) {
+void Game::ChkLastTime() {
 	int time = GetLastWriteTime(L"./expansions");
 	if (LastExpansionsTime < time) {
 		LastExpansionsTime = time;
 		ChkReload = true;
-		if (chk) return;
 	}
 	FileSystem::TraversalDir(L"./expansions", [](const wchar_t* name, bool isdir) {
 		if (!isdir && wcsrchr(name, '.') && (!mywcsncasecmp(wcsrchr(name, '.'), L".cdb", 4) || !mywcsncasecmp(wcsrchr(name, '.'), L".zip", 4) || !mywcsncasecmp(wcsrchr(name, '.'), L".ypk", 4) || !mywcsncasecmp(wcsrchr(name, '.'), L".conf", 5))) {
 			wchar_t fpath[1024];
 			myswprintf(fpath, L"./expansions/%ls", name);
 			int time = mainGame->GetLastWriteTime(fpath);
-			if (mainGame->LastExpansionsTime < time) {
-				mainGame->LastExpansionsTime = time;
+			if (mainGame->LastExpansionsFileTime < time) {
+				mainGame->LastExpansionsFileTime = time;
 				mainGame->ChkReload = true;
 			}
 		}

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -139,6 +139,9 @@ struct FadingUnit {
 };
 
 class Game {
+private:
+	int LastExpansionsTime;
+	bool ChkReload;
 
 public:
 	bool Initialize();
@@ -185,7 +188,9 @@ public:
 	void CloseGameButtons();
 	void CloseGameWindow();
 	void CloseDuelWindow();
+	void ChkLastTime(bool chk = true);
 
+	int GetLastWriteTime(wchar_t* dirPath);
 	int LocalPlayer(int player) const;
 	int OppositePlayer(int player);
 	int ChatLocalPlayer(int player);

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -139,6 +139,8 @@ struct FadingUnit {
 };
 
 class Game {
+private:
+	int LastExpansionsTime;
 
 public:
 	bool Initialize();
@@ -186,6 +188,7 @@ public:
 	void CloseGameWindow();
 	void CloseDuelWindow();
 
+	int GetLastWriteTime(wchar_t* dirPath);
 	int LocalPlayer(int player) const;
 	int OppositePlayer(int player);
 	int ChatLocalPlayer(int player);

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -139,8 +139,6 @@ struct FadingUnit {
 };
 
 class Game {
-private:
-	int LastExpansionsTime;
 
 public:
 	bool Initialize();
@@ -188,7 +186,6 @@ public:
 	void CloseGameWindow();
 	void CloseDuelWindow();
 
-	int GetLastWriteTime(wchar_t* dirPath);
 	int LocalPlayer(int player) const;
 	int OppositePlayer(int player);
 	int ChatLocalPlayer(int player);

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -147,6 +147,7 @@ public:
 	void InitStaticText(irr::gui::IGUIStaticText* pControl, u32 cWidth, u32 cHeight, irr::gui::CGUITTFont* font, const wchar_t* text);
 	std::wstring SetStaticText(irr::gui::IGUIStaticText* pControl, u32 cWidth, irr::gui::CGUITTFont* font, const wchar_t* text, u32 pos = 0);
 	void LoadExpansions();
+	void ReLoadExpansions();
 	void RefreshCategoryDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck, bool selectlastused = true);
 	void RefreshDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
 	void RefreshDeck(const wchar_t* deckpath, const std::function<void(const wchar_t*)>& additem);

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -141,6 +141,7 @@ struct FadingUnit {
 class Game {
 private:
 	int LastExpansionsTime;
+	int LastExpansionsFileTime;
 	bool ChkReload;
 
 public:
@@ -188,7 +189,7 @@ public:
 	void CloseGameButtons();
 	void CloseGameWindow();
 	void CloseDuelWindow();
-	void ChkLastTime(bool chk = true);
+	void ChkLastTime();
 
 	int GetLastWriteTime(wchar_t* dirPath);
 	int LocalPlayer(int player) const;

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -54,6 +54,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_LAN_MODE: {
+				mainGame->Game::ReLoadExpansions();
 				mainGame->btnCreateHost->setEnabled(true);
 				mainGame->btnJoinHost->setEnabled(true);
 				mainGame->btnJoinCancel->setEnabled(true);
@@ -62,6 +63,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_JOIN_HOST: {
+				mainGame->Game::ReLoadExpansions();
 				bot_mode = false;
 				mainGame->TrimText(mainGame->ebJoinHost);
 				mainGame->TrimText(mainGame->ebJoinPort);
@@ -120,6 +122,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_CREATE_HOST: {
+				mainGame->Game::ReLoadExpansions();
 				mainGame->btnHostConfirm->setEnabled(true);
 				mainGame->btnHostCancel->setEnabled(true);
 				mainGame->HideElement(mainGame->wLanWindow);
@@ -217,6 +220,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_REPLAY_MODE: {
+				mainGame->Game::ReLoadExpansions();
 				mainGame->HideElement(mainGame->wMainMenu);
 				mainGame->ShowElement(mainGame->wReplay);
 				mainGame->ebRepStartTurn->setText(L"1");
@@ -225,6 +229,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_SINGLE_MODE: {
+				mainGame->Game::ReLoadExpansions();
 				mainGame->HideElement(mainGame->wMainMenu);
 				mainGame->ShowElement(mainGame->wSinglePlay);
 				mainGame->RefreshSingleplay();
@@ -426,6 +431,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_DECK_EDIT: {
+				mainGame->Game::ReLoadExpansions();
 				mainGame->RefreshCategoryDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
 				if(open_file && deckManager.LoadCurrentDeck(open_file_name)) {
 #ifdef _WIN32


### PR DESCRIPTION
在ygopro使用过程中，如果在expansions文件夹中添加新的cdb等操作后，需要重启客户端才能更新，所以做了此功能，使得在cdb添改、新增ypk补丁后不需要重启游戏，直接重新进入卡组编辑等界面即可直接加载新的cdb
ypk、zip此类文件在游戏运行时貌似不能删除、覆盖之类的操作，对此我暂不了解是否存在好的解决方式