### PR TITLE
DataManager: add DefaultScriptReader

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -394,8 +394,12 @@ unsigned char* DataManager::ScriptReaderEx(const char* script_name, int* slen) {
 	// default script name: ./script/c%d.lua
 	if (std::strncmp(script_name, "./script", 8) != 0)
 		return DefaultScriptReader(script_name, slen);
+	char expansions_path[1024]{};
+	std::snprintf(expansions_path, sizeof expansions_path, "./expansions/%s", script_name + 2);
 	if(mainGame->gameConf.prefer_expansion_script) {
 		if (ScriptReader(script_name, slen))
+			return scriptBuffer;
+		else if (DefaultScriptReader(expansions_path, slen))
 			return scriptBuffer;
 		else if (DefaultScriptReader(script_name, slen))
 			return scriptBuffer;
@@ -404,10 +408,10 @@ unsigned char* DataManager::ScriptReaderEx(const char* script_name, int* slen) {
 			return scriptBuffer;
 		else if (ScriptReader(script_name, slen))
 			return scriptBuffer;
+		else if (DefaultScriptReader(expansions_path, slen))
+			return scriptBuffer;
 	}
-	char expansions_path[1024]{};
-	std::snprintf(expansions_path, sizeof expansions_path, "./expansions/%s", script_name + 2);
-	return DefaultScriptReader(expansions_path, slen);
+	return nullptr;
 }
 unsigned char* DataManager::ScriptReader(const char* script_name, int* slen) {
 #ifdef _WIN32

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -392,19 +392,22 @@ uint32 DataManager::CardReader(uint32 code, card_data* pData) {
 }
 unsigned char* DataManager::ScriptReaderEx(const char* script_name, int* slen) {
 	// default script name: ./script/c%d.lua
-	char first[256]{};
-	char second[256]{};
+	if (std::strncmp(script_name, "./script", 8) != 0)
+		return DefaultScriptReader(script_name, slen);
 	if(mainGame->gameConf.prefer_expansion_script) {
-		snprintf(first, sizeof first, "expansions/%s", script_name + 2);
-		snprintf(second, sizeof second, "%s", script_name + 2);
+		if (ScriptReader(script_name, slen))
+			return scriptBuffer;
+		else if (DefaultScriptReader(script_name, slen))
+			return scriptBuffer;
 	} else {
-		snprintf(first, sizeof first, "%s", script_name + 2);
-		snprintf(second, sizeof second, "expansions/%s", script_name + 2);
+		if (DefaultScriptReader(script_name, slen))
+			return scriptBuffer;
+		else if (ScriptReader(script_name, slen))
+			return scriptBuffer;
 	}
-	if(ScriptReader(first, slen))
-		return scriptBuffer;
-	else
-		return ScriptReader(second, slen);
+	char expansions_path[1024]{};
+	std::snprintf(expansions_path, sizeof expansions_path, "./expansions/%s", script_name + 2);
+	return DefaultScriptReader(expansions_path, slen);
 }
 unsigned char* DataManager::ScriptReader(const char* script_name, int* slen) {
 #ifdef _WIN32
@@ -424,6 +427,19 @@ unsigned char* DataManager::ScriptReader(const char* script_name, int* slen) {
 	reader->read(scriptBuffer, size);
 	reader->drop();
 	*slen = (int)size;
+	return scriptBuffer;
+}
+unsigned char* DataManager::DefaultScriptReader(const char* script_name, int* slen) {
+	wchar_t fname[256]{};
+	BufferIO::DecodeUTF8(script_name, fname);
+	FILE* fp = myfopen(fname, "rb");
+	if (!fp)
+		return nullptr;
+	size_t len = std::fread(scriptBuffer, 1, sizeof scriptBuffer, fp);
+	std::fclose(fp);
+	if (len >= sizeof scriptBuffer)
+		return nullptr;
+	*slen = (int)len;
 	return scriptBuffer;
 }
 

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -54,7 +54,12 @@ public:
 	static const wchar_t* unknown_string;
 	static uint32 CardReader(uint32, card_data*);
 	static unsigned char* ScriptReaderEx(const char* script_name, int* slen);
+	
+	//read by IFileSystem
 	static unsigned char* ScriptReader(const char* script_name, int* slen);
+	//read by fread
+	static unsigned char* DefaultScriptReader(const char* script_name, int* slen);
+	
 	static IFileSystem* FileSystem;
 
 private:


### PR DESCRIPTION
## single mode will read the wrong script
In `single`
1234.lua

In `expansions/abc.zip`
single/1234.lua

choose 1234.lua in listbox
The single mode will read the file in `expansions/abc.zip`.
如果存在以上檔名
在單人模式選擇1234.lua
將會讀取`expansions/abc.zip`內部的檔案
而不是實體目錄`./single`的檔案

## `gameConf.prefer_expansion_script` does not work
In `expansions/abc.zip`
script/constant.lua

set `gameConf.prefer_expansion_script` to 0
It will still read the file in `expansions/abc.zip`.
即使`gameConf.prefer_expansion_script`設為0
仍然會優先讀取`expansions/abc.zip`內部的constant.lua


Reason:
https://github.com/Fluorohydride/ygopro/blob/298b43a8078404769ef784c8ab39115662cb6c4e/gframe/game.cpp#L1162

In dataManager.FileSystem, `./script/constant.lua` refers to the file in zip.
ScriptReader uses dataManager.FileSystem to read the script, so it will always read the file in zip.

如果使用dataManager.FileSystem讀取
constant.lua會被加入`./script`取代原本的檔案
ScriptReader使用dataManager.FileSystem
因此不管選項是on/off都會讀到zip內部的constant.lua


## nested directive
In `expansions/abc.zip`
expansions/script/constant.lua

set `gameConf.prefer_expansion_script` to 1
It will read the file in `expansions/abc.zip`.
如果`gameConf.prefer_expansion_script`設為1
ScriptReader將會讀取zip內部的`expansions/script/constant.lua`



## solution
DefaultScriptReader
It will read the script by C function `fread`, and it will not read from zip file.
使用fread，只讀取實體目錄而不包含zip

Single mode script
It will search from `./single`
只在`./single`搜尋

Card script
It will search from the following path
dataManager.FileSystem (including files in zip)
`./script`
`./expansions/script`
從以上路徑搜尋

@mercury233
@purerosefallen
@Wind2009-Louse
@fallenstardust




