### PR TITLE
client MSG_SELECT_SUM: cancellable & better display

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -1128,50 +1128,43 @@ void ClientField::FadeCard(ClientCard * pcard, int alpha, int frame) {
 	pcard->aniFrame = frame;
 }
 bool ClientField::ShowSelectSum(bool panelmode) {
-	if(panelmode) {
-		if(CheckSelectSum()) {
-			if(selectsum_cards.size() == 0 || selectable_cards.size() == 0) {
-				SetResponseSelectedCards();
-				ShowCancelOrFinishButton(0);
-				if(mainGame->wCardSelect->isVisible())
-					mainGame->HideElement(mainGame->wCardSelect, true);
-				else {
-					DuelClient::SendResponse();
-					return true;
-				}
-			} else {
-				select_ready = true;
-				mainGame->wCardSelect->setVisible(false);
-				wchar_t wbuf[256], *pwbuf = wbuf;
-				BufferIO::CopyWStrRef(dataManager.GetSysString(209), pwbuf, 256);
-				*pwbuf++ = L'\n';
-				BufferIO::CopyWStrRef(dataManager.GetSysString(210), pwbuf, 256);
-				mainGame->stQMessage->setText(wbuf);
-				mainGame->PopupElement(mainGame->wQuery);
-			}
-		} else {
-			select_ready = false;
-			mainGame->wCardSelect->setVisible(false);
-			mainGame->dField.ShowSelectCard();
-		}
+	select_ready = CheckSelectSum();
+	if(select_ready && (selectsum_cards.size() == 0 || selectable_cards.size() == 0)) {
+		SetResponseSelectedCards();
+		ShowCancelOrFinishButton(0);
+		if(mainGame->wCardSelect->isVisible())
+			mainGame->HideElement(mainGame->wCardSelect, true);
+		else 
+			DuelClient::SendResponse();
+		return true;
+	}
+
+	auto display_hint = select_hint ? dataManager.GetDesc(select_hint) : dataManager.GetSysString(560);
+
+	wchar_t cur_hint[20];
+	if (select_curval_l == select_curval_h) {
+		myswprintf(cur_hint, L"%d", select_curval_l);
 	} else {
-		if(CheckSelectSum()) {
-			if(selectsum_cards.size() == 0 || selectable_cards.size() == 0) {
-				SetResponseSelectedCards();
-				ShowCancelOrFinishButton(0);
-				DuelClient::SendResponse();
-				return true;
-			} else {
-				select_ready = true;
-				wchar_t wbuf[256], *pwbuf = wbuf;
-				BufferIO::CopyWStrRef(dataManager.GetSysString(209), pwbuf, 256);
-				*pwbuf++ = L'\n';
-				BufferIO::CopyWStrRef(dataManager.GetSysString(210), pwbuf, 256);
-				mainGame->stQMessage->setText(wbuf);
-				mainGame->PopupElement(mainGame->wQuery);
-			}
-		} else
-			select_ready = false;
+		myswprintf(cur_hint, L"%d-%d", select_curval_l, select_curval_h);
+	}
+
+	wchar_t target_hint[20];
+	if (select_mode == 0) { // sum equal
+		myswprintf(target_hint, L"%d", select_sumval);
+	} else { // sum greater
+		myswprintf(target_hint, L"%d+", select_sumval);
+	}
+
+	wchar_t textBuffer[256];
+	myswprintf(textBuffer, L"%ls(%ls/%ls)", display_hint, cur_hint, target_hint);
+
+	if(panelmode) {
+		mainGame->wCardSelect->setText(textBuffer);
+		mainGame->wCardSelect->setVisible(false);
+		mainGame->dField.ShowSelectCard();
+	} else {
+		mainGame->stHintMsg->setText(textBuffer);
+		mainGame->stHintMsg->setVisible(true);
 	}
 	if (select_ready) {
 		ShowCancelOrFinishButton(2);
@@ -1182,11 +1175,13 @@ bool ClientField::ShowSelectSum(bool panelmode) {
 }
 bool ClientField::CheckSelectSum() {
 	std::set<ClientCard*> selable;
-	for(auto sit = selectsum_all.begin(); sit != selectsum_all.end(); ++sit) {
-		(*sit)->is_selectable = false;
-		(*sit)->is_selected = false;
-		selable.insert(*sit);
+	for(auto sc : selectsum_all) {
+		sc->is_selectable = false;
+		sc->is_selected = false;
+		selable.insert(sc);
 	}
+	select_curval_l = 0;
+	select_curval_h = 0;
 	for(size_t i = 0; i < selected_cards.size(); ++i) {
 		if((int)i < must_select_count)
 			selected_cards[i]->is_selectable = false;
@@ -1194,22 +1189,32 @@ bool ClientField::CheckSelectSum() {
 			selected_cards[i]->is_selectable = true;
 		selected_cards[i]->is_selected = true;
 		selable.erase(selected_cards[i]);
+
+		int op1 = selected_cards[i]->opParam & 0xffff;
+		int op2 = selected_cards[i]->opParam >> 16;
+		int opmin = (op2 > 0 && op1 > op2) ? op2 : op1;
+		int opmax = op2 > op1 ? op2 : op1;
+		select_curval_l += opmin;
+		select_curval_h += opmax;
 	}
 	selectsum_cards.clear();
-	if (select_mode == 0) {
+	if (select_mode == 0) { // sum equal
 		bool ret = check_sel_sum_s(selable, 0, select_sumval);
 		selectable_cards.clear();
-		for(auto sit = selectsum_cards.begin(); sit != selectsum_cards.end(); ++sit) {
-			(*sit)->is_selectable = true;
-			selectable_cards.push_back(*sit);
+		for(auto sc : selected_cards) {
+			selectable_cards.push_back(sc);
+		}
+		for(auto sc : selectsum_cards) {
+			sc->is_selectable = true;
+			selectable_cards.push_back(sc);
 		}
 		return ret;
-	} else {
+	} else { // sum greater
 		int mm = -1, mx = -1, max = 0, sumc = 0;
 		bool ret = false;
-		for (auto sit = selected_cards.begin(); sit != selected_cards.end(); ++sit) {
-			int op1 = (*sit)->opParam & 0xffff;
-			int op2 = (*sit)->opParam >> 16;
+		for (auto sc : selected_cards) {
+			int op1 = sc->opParam & 0xffff;
+			int op2 = sc->opParam >> 16;
 			int opmin = (op2 > 0 && op1 > op2) ? op2 : op1;
 			int opmax = op2 > op1 ? op2 : op1;
 			if (mm == -1 || opmin < mm)
@@ -1223,9 +1228,9 @@ bool ClientField::CheckSelectSum() {
 			return true;
 		if (select_sumval <= max && select_sumval > max - mx)
 			ret = true;
-		for(auto sit = selable.begin(); sit != selable.end(); ++sit) {
-			int op1 = (*sit)->opParam & 0xffff;
-			int op2 = (*sit)->opParam >> 16;
+		for(auto sc : selable) {
+			int op1 = sc->opParam & 0xffff;
+			int op2 = sc->opParam >> 16;
 			int m = op1;
 			int sums = sumc;
 			sums += m;
@@ -1234,12 +1239,12 @@ bool ClientField::CheckSelectSum() {
 				ms = m;
 			if (sums >= select_sumval) {
 				if (sums - ms < select_sumval)
-					selectsum_cards.insert(*sit);
+					selectsum_cards.insert(sc);
 			} else {
 				std::set<ClientCard*> left(selable);
-				left.erase(*sit);
+				left.erase(sc);
 				if (check_min(left, left.begin(), select_sumval - sums, select_sumval - sums + ms - 1))
-					selectsum_cards.insert(*sit);
+					selectsum_cards.insert(sc);
 			}
 			if (op2 == 0)
 				continue;
@@ -1251,18 +1256,21 @@ bool ClientField::CheckSelectSum() {
 				ms = m;
 			if (sums >= select_sumval) {
 				if (sums - ms < select_sumval)
-					selectsum_cards.insert(*sit);
+					selectsum_cards.insert(sc);
 			} else {
 				std::set<ClientCard*> left(selable);
-				left.erase(*sit);
+				left.erase(sc);
 				if (check_min(left, left.begin(), select_sumval - sums, select_sumval - sums + ms - 1))
-					selectsum_cards.insert(*sit);
+					selectsum_cards.insert(sc);
 			}
 		}
 		selectable_cards.clear();
-		for(auto sit = selectsum_cards.begin(); sit != selectsum_cards.end(); ++sit) {
-			(*sit)->is_selectable = true;
-			selectable_cards.push_back(*sit);
+		for(auto sc : selected_cards) {
+			selectable_cards.push_back(sc);
+		}
+		for(auto sc : selectsum_cards) {
+			sc->is_selectable = true;
+			selectable_cards.push_back(sc);
 		}
 		return ret;
 	}

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -1201,11 +1201,11 @@ bool ClientField::CheckSelectSum() {
 	if (select_mode == 0) { // sum equal
 		bool ret = check_sel_sum_s(selable, 0, select_sumval);
 		selectable_cards.clear();
-		for(auto sc : selected_cards) {
-			selectable_cards.push_back(sc);
-		}
 		for(auto sc : selectsum_cards) {
 			sc->is_selectable = true;
+			selectable_cards.push_back(sc);
+		}
+		for(auto sc : selected_cards) {
 			selectable_cards.push_back(sc);
 		}
 		return ret;
@@ -1265,11 +1265,11 @@ bool ClientField::CheckSelectSum() {
 			}
 		}
 		selectable_cards.clear();
-		for(auto sc : selected_cards) {
-			selectable_cards.push_back(sc);
-		}
 		for(auto sc : selectsum_cards) {
 			sc->is_selectable = true;
+			selectable_cards.push_back(sc);
+		}
+		for(auto sc : selected_cards) {
 			selectable_cards.push_back(sc);
 		}
 		return ret;

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -57,9 +57,12 @@ public:
 	int select_min{ 0 };
 	int select_max{ 0 };
 	int must_select_count{ 0 };
+	int select_curval_l{ 0 };
+	int select_curval_h{ 0 };
 	int select_sumval{ 0 };
 	int select_mode{ 0 };
-	bool select_cancelable{ false };
+	int select_hint{0};
+	bool select_cancelable{false};
 	bool select_panalmode{ false };
 	bool select_ready{ false };
 	int announce_count{ 0 };

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2037,16 +2037,8 @@ int DuelClient::ClientAnalyze(unsigned char* msg, unsigned int len) {
 				mainGame->dField.select_panalmode = true;
 		}
 		std::sort(mainGame->dField.selectsum_all.begin(), mainGame->dField.selectsum_all.end(), ClientCard::client_card_sort);
-		if(select_hint)
-			myswprintf(textBuffer, L"%ls(%d)", dataManager.GetDesc(select_hint), mainGame->dField.select_sumval);
-		else myswprintf(textBuffer, L"%ls(%d)", dataManager.GetSysString(560), mainGame->dField.select_sumval);
+		mainGame->dField.select_hint = select_hint;
 		select_hint = 0;
-		if(mainGame->dField.select_panalmode) {
-			mainGame->wCardSelect->setText(textBuffer);
-		} else {
-			mainGame->stHintMsg->setText(textBuffer);
-			mainGame->stHintMsg->setVisible(true);
-		}
 		return mainGame->dField.ShowSelectSum(mainGame->dField.select_panalmode);
 	}
 	case MSG_SORT_CARD: {

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -742,7 +742,19 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				}
 				case MSG_SELECT_SUM: {
 					command_card = selectable_cards[id - BUTTON_CARD_0 + mainGame->scrCardList->getPos() / 10];
-					selected_cards.push_back(command_card);
+					if (command_card->is_selected) {
+						command_card->is_selected = false;
+						int i = 0;
+						while(selected_cards[i] != command_card) i++;
+						selected_cards.erase(selected_cards.begin() + i);
+						if(command_card->controler)
+							mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffd0d0d0);
+						else mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffffff);
+					} else {
+						command_card->is_selected = true;
+						mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffff00);
+						selected_cards.push_back(command_card);
+					}
 					ShowSelectSum(true);
 					break;
 				}
@@ -2595,11 +2607,14 @@ void ClientField::CancelOrFinish() {
 		break;
 	}
 	case MSG_SELECT_SUM: {
-		if(mainGame->wQuery->isVisible()) {
+		if (select_ready) {
 			SetResponseSelectedCards();
 			ShowCancelOrFinishButton(0);
-			mainGame->HideElement(mainGame->wQuery, true);
-			break;
+
+			if(mainGame->wCardSelect->isVisible())
+				mainGame->HideElement(mainGame->wCardSelect, true);
+			else
+				DuelClient::SendResponse();
 		}
 		break;
 	}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6c3f7a87-6a21-4a02-842c-d4c481bd6ef5)

It displays the value of current sum, and it can be cancelled, just like how Group.SelectSubGroup does.

The following lines of `strings.conf` are no longer needed and can be removed:

```
!system 209 当前所选的卡已满足选择条件
!system 210 是否要继续选择？
```