### PR TITLE
set MAX_COMP_SIZE to UINT16_MAX + 1

### DIFF
--- a/gframe/network.h
+++ b/gframe/network.h
@@ -14,7 +14,7 @@
 
 namespace ygo {
 	constexpr int SIZE_NETWORK_BUFFER = 0x20000;
-	constexpr int MAX_DATA_SIZE = SIZE_NETWORK_BUFFER - 3;
+	constexpr int MAX_DATA_SIZE = UINT16_MAX - 1;
 	constexpr int MAINC_MAX = 250;	// the limit of card_state
 	constexpr int SIDEC_MAX = MAINC_MAX;
 

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -13,8 +13,8 @@ namespace ygo {
 #define REPLAY_UNIFORM		0x10
 
 // max size
-#define MAX_REPLAY_SIZE	0x20000
-#define MAX_COMP_SIZE	0x2000
+constexpr int MAX_REPLAY_SIZE = 0x20000;
+constexpr int MAX_COMP_SIZE = UINT16_MAX + 1;
 
 struct ReplayHeader {
 	unsigned int id{};


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro/blob/d7cf1187df24d0ebfac6527cd4052d78af7bd095/gframe/duelclient.cpp#L755

The max size of packet data is `UINT16_MAX - 1`.
The current size of `Replay::comp_data` is too small, and it may suffer from buffer overflow.

封包資料的最大長度是`UINT16_MAX - 1`
增加`Replay::comp_data`大小以避免buffer overflow

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust 
