### PR TITLE
use <cwchar> function

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -43,12 +43,6 @@
 #define mystrncasecmp strncasecmp
 #endif
 
-#include <wchar.h>
-template<size_t N, typename... TR>
-inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
-	return swprintf(buf, N, fmt, args...);
-}
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>
@@ -57,6 +51,11 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 #include "bufferio.h"
 #include "../ocgcore/ocgapi.h"
 #include "../ocgcore/common.h"
+
+template<size_t N, typename... TR>
+inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
+	return std::swprintf(buf, N, fmt, args...);
+}
 
 inline FILE* myfopen(const wchar_t* filename, const char* mode) {
 	FILE* fp{};

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -505,7 +505,7 @@ bool DataManager::deck_sort_def(code_pointer p1, code_pointer p2) {
 bool DataManager::deck_sort_name(code_pointer p1, code_pointer p2) {
 	const wchar_t* name1 = dataManager.GetName(p1->first);
 	const wchar_t* name2 = dataManager.GetName(p2->first);
-	int res = wcscmp(name1, name2);
+	int res = std::wcscmp(name1, name2);
 	if (res != 0)
 		return res < 0;
 	return p1->first < p2->first;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -178,7 +178,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					break;
 				int sel = -1;
 				for(size_t i = 0; i < mainGame->cbDBDecks->getItemCount(); ++i) {
-					if(!wcscmp(dname, mainGame->cbDBDecks->getItem(i))) {
+					if(!std::wcscmp(dname, mainGame->cbDBDecks->getItem(i))) {
 						sel = i;
 						break;
 					}
@@ -1524,7 +1524,7 @@ void DeckBuilder::FilterCards() {
 	SortList();
 }
 void DeckBuilder::InstantSearch() {
-	if(mainGame->gameConf.auto_search_limit >= 0 && ((int)wcslen(mainGame->ebCardName->getText()) >= mainGame->gameConf.auto_search_limit))
+	if(mainGame->gameConf.auto_search_limit >= 0 && ((int)std::wcslen(mainGame->ebCardName->getText()) >= mainGame->gameConf.auto_search_limit))
 		StartFilter();
 }
 void DeckBuilder::ClearSearch() {
@@ -1565,7 +1565,7 @@ void DeckBuilder::SortList() {
 	auto left = results.begin();
 	const wchar_t* pstr = mainGame->ebCardName->getText();
 	for(auto it = results.begin(); it != results.end(); ++it) {
-		if(wcscmp(pstr, dataManager.GetName((*it)->first)) == 0) {
+		if(std::wcscmp(pstr, dataManager.GetName((*it)->first)) == 0) {
 			std::iter_swap(left, it);
 			++left;
 		}

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -141,10 +141,10 @@ void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 				BufferIO::CopyCharArray(mainGame->ebServerPass->getText(), cscg.pass);
 				cscg.info.rule = mainGame->cbRule->getSelected();
 				cscg.info.mode = mainGame->cbMatchMode->getSelected();
-				cscg.info.start_hand = wcstol(mainGame->ebStartHand->getText(),nullptr,10);
-				cscg.info.start_lp = wcstol(mainGame->ebStartLP->getText(),nullptr,10);
-				cscg.info.draw_count = wcstol(mainGame->ebDrawCount->getText(),nullptr,10);
-				cscg.info.time_limit = wcstol(mainGame->ebTimeLimit->getText(),nullptr,10);
+				cscg.info.start_hand = std::wcstol(mainGame->ebStartHand->getText(),nullptr,10);
+				cscg.info.start_lp = std::wcstol(mainGame->ebStartLP->getText(),nullptr,10);
+				cscg.info.draw_count = std::wcstol(mainGame->ebDrawCount->getText(),nullptr,10);
+				cscg.info.time_limit = std::wcstol(mainGame->ebTimeLimit->getText(),nullptr,10);
 				cscg.info.lflist = mainGame->cbHostLFlist->getItemData(mainGame->cbHostLFlist->getSelected());
 				cscg.info.duel_rule = mainGame->cbDuelRule->getSelected() + 1;
 				cscg.info.no_check_deck = mainGame->chkNoCheckDeck->isChecked();
@@ -732,7 +732,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		
 		tm* localedtime = localtime(&starttime);
 		wchar_t timetext[40];
-		wcsftime(timetext, 40, L"%Y-%m-%d %H-%M-%S", localedtime);
+		std::wcsftime(timetext, 40, L"%Y-%m-%d %H-%M-%S", localedtime);
 		mainGame->ebRSName->setText(timetext);
 		if(!mainGame->chkAutoSaveReplay->isChecked()) {
 			mainGame->wReplaySave->setText(dataManager.GetSysString(1340));

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -1572,7 +1572,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 							myswprintf(formatBuffer, L"%ls", dataManager.GetName(mcard->code));
 							str.append(formatBuffer);
 							if(mcard->type & TYPE_MONSTER) {
-								if(mcard->alias && wcscmp(dataManager.GetName(mcard->code), dataManager.GetName(mcard->alias))) {
+								if(mcard->alias && std::wcscmp(dataManager.GetName(mcard->code), dataManager.GetName(mcard->alias))) {
 									myswprintf(formatBuffer, L"\n(%ls)", dataManager.GetName(mcard->alias));
 									str.append(formatBuffer);
 								}
@@ -1594,7 +1594,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 									str.append(formatBuffer);
 								}
 							} else {
-								if(mcard->alias && wcscmp(dataManager.GetName(mcard->code), dataManager.GetName(mcard->alias))) {
+								if(mcard->alias && std::wcscmp(dataManager.GetName(mcard->code), dataManager.GetName(mcard->alias))) {
 									myswprintf(formatBuffer, L"\n(%ls)", dataManager.GetName(mcard->alias));
 									str.append(formatBuffer);
 								}

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1113,7 +1113,7 @@ std::wstring Game::SetStaticText(irr::gui::IGUIStaticText* pControl, u32 cWidth,
 	wchar_t strBuffer[4096];
 	std::wstring ret;
 
-	for(size_t i = 0; text[i] != 0 && i < wcslen(text); ++i) {
+	for(size_t i = 0; text[i] != 0 && i < std::wcslen(text); ++i) {
 		wchar_t c = text[i];
 		u32 w = font->getCharDimension(c).Width + font->getKerningWidth(c, prev);
 		prev = c;
@@ -1212,7 +1212,7 @@ void Game::RefreshCategoryDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGU
 	cbCategory->setSelected(2);
 	if(selectlastused) {
 		for(size_t i = 0; i < cbCategory->getItemCount(); ++i) {
-			if(!wcscmp(cbCategory->getItem(i), gameConf.lastcategory)) {
+			if(!std::wcscmp(cbCategory->getItem(i), gameConf.lastcategory)) {
 				cbCategory->setSelected(i);
 				break;
 			}
@@ -1221,7 +1221,7 @@ void Game::RefreshCategoryDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGU
 	RefreshDeck(cbCategory, cbDeck);
 	if(selectlastused) {
 		for(size_t i = 0; i < cbDeck->getItemCount(); ++i) {
-			if(!wcscmp(cbDeck->getItem(i), gameConf.lastdeck)) {
+			if(!std::wcscmp(cbDeck->getItem(i), gameConf.lastdeck)) {
 				cbDeck->setSelected(i);
 				break;
 			}

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) {
 		&& (!mystrncasecmp(pstrext, ".ydk", 4) || !mystrncasecmp(pstrext, ".yrp", 4))) {
 		wchar_t exepath[MAX_PATH];
 		GetModuleFileNameW(nullptr, exepath, MAX_PATH);
-		wchar_t* p = wcsrchr(exepath, '\\');
+		wchar_t* p = std::wcsrchr(exepath, '\\');
 		*p = '\0';
 		SetCurrentDirectoryW(exepath);
 	}
@@ -82,42 +82,42 @@ int main(int argc, char* argv[]) {
 			ygo::dataManager.LoadDB(&wargv[i][2]);
 			continue;
 		}
-		if(!wcscmp(wargv[i], L"-e")) { // extra database
+		if(!std::wcscmp(wargv[i], L"-e")) { // extra database
 			++i;
 			if(i < wargc) {
 				ygo::dataManager.LoadDB(wargv[i]);
 			}
 			continue;
-		} else if(!wcscmp(wargv[i], L"-n")) { // nickName
+		} else if(!std::wcscmp(wargv[i], L"-n")) { // nickName
 			++i;
 			if(i < wargc)
 				ygo::mainGame->ebNickName->setText(wargv[i]);
 			continue;
-		} else if(!wcscmp(wargv[i], L"-h")) { // Host address
+		} else if(!std::wcscmp(wargv[i], L"-h")) { // Host address
 			++i;
 			if(i < wargc)
 				ygo::mainGame->ebJoinHost->setText(wargv[i]);
 			continue;
-		} else if(!wcscmp(wargv[i], L"-p")) { // host Port
+		} else if(!std::wcscmp(wargv[i], L"-p")) { // host Port
 			++i;
 			if(i < wargc)
 				ygo::mainGame->ebJoinPort->setText(wargv[i]);
 			continue;
-		} else if(!wcscmp(wargv[i], L"-w")) { // host passWord
+		} else if(!std::wcscmp(wargv[i], L"-w")) { // host passWord
 			++i;
 			if(i < wargc)
 				ygo::mainGame->ebJoinPass->setText(wargv[i]);
 			continue;
-		} else if(!wcscmp(wargv[i], L"-k")) { // Keep on return
+		} else if(!std::wcscmp(wargv[i], L"-k")) { // Keep on return
 			exit_on_return = false;
 			keep_on_return = true;
-		} else if(!wcscmp(wargv[i], L"--deck-category")) {
+		} else if(!std::wcscmp(wargv[i], L"--deck-category")) {
 			++i;
 			if(i < wargc) {
 				deckCategorySpecified = true;
 				BufferIO::CopyWideString(wargv[i], ygo::mainGame->gameConf.lastcategory);
 			}
-		} else if(!wcscmp(wargv[i], L"-d")) { // Deck
+		} else if(!std::wcscmp(wargv[i], L"-d")) { // Deck
 			++i;
 			if(!deckCategorySpecified)
 				ygo::mainGame->gameConf.lastcategory[0] = 0;
@@ -141,17 +141,17 @@ int main(int argc, char* argv[]) {
 				ClickButton(ygo::mainGame->btnDeckEdit);
 				break;
 			}
-		} else if(!wcscmp(wargv[i], L"-c")) { // Create host
+		} else if(!std::wcscmp(wargv[i], L"-c")) { // Create host
 			exit_on_return = !keep_on_return;
 			ygo::mainGame->HideElement(ygo::mainGame->wMainMenu);
 			ClickButton(ygo::mainGame->btnHostConfirm);
 			break;
-		} else if(!wcscmp(wargv[i], L"-j")) { // Join host
+		} else if(!std::wcscmp(wargv[i], L"-j")) { // Join host
 			exit_on_return = !keep_on_return;
 			ygo::mainGame->HideElement(ygo::mainGame->wMainMenu);
 			ClickButton(ygo::mainGame->btnJoinHost);
 			break;
-		} else if(!wcscmp(wargv[i], L"-r")) { // Replay
+		} else if(!std::wcscmp(wargv[i], L"-r")) { // Replay
 			exit_on_return = !keep_on_return;
 			++i;
 			if(i < wargc) {
@@ -162,7 +162,7 @@ int main(int argc, char* argv[]) {
 			if(open_file)
 				ClickButton(ygo::mainGame->btnLoadReplay);
 			break;
-		} else if(!wcscmp(wargv[i], L"-s")) { // Single
+		} else if(!std::wcscmp(wargv[i], L"-s")) { // Single
 			exit_on_return = !keep_on_return;
 			++i;
 			if(i < wargc) {
@@ -173,8 +173,8 @@ int main(int argc, char* argv[]) {
 			if(open_file)
 				ClickButton(ygo::mainGame->btnLoadSinglePlay);
 			break;
-		} else if(wargc == 2 && wcslen(wargv[1]) >= 4) {
-			wchar_t* pstrext = wargv[1] + wcslen(wargv[1]) - 4;
+		} else if(wargc == 2 && std::wcslen(wargv[1]) >= 4) {
+			wchar_t* pstrext = wargv[1] + std::wcslen(wargv[1]) - 4;
 			if(!mywcsncasecmp(pstrext, L".ydk", 4)) {
 				open_file = true;
 				BufferIO::CopyWideString(wargv[i], open_file_name);

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -98,7 +98,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 						evutil_freeaddrinfo(answer);
 					}
 				}
-				unsigned int remote_port = wcstol(portstr, nullptr, 10);
+				unsigned int remote_port = std::wcstol(portstr, nullptr, 10);
 				BufferIO::CopyWideString(pstr, mainGame->gameConf.lasthost);
 				BufferIO::CopyWideString(portstr, mainGame->gameConf.lastport);
 				if(DuelClient::StartClient(remote_addr, remote_port, false)) {
@@ -257,7 +257,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				mainGame->dField.Clear();
 				mainGame->HideElement(mainGame->wReplay);
 				mainGame->device->setEventReceiver(&mainGame->dField);
-				unsigned int start_turn = wcstol(mainGame->ebRepStartTurn->getText(), nullptr, 10);
+				unsigned int start_turn = std::wcstol(mainGame->ebRepStartTurn->getText(), nullptr, 10);
 				if(start_turn == 1)
 					start_turn = 0;
 				ReplayMode::StartReplay(start_turn);
@@ -435,14 +435,14 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				mainGame->RefreshCategoryDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
 				if(open_file && deckManager.LoadCurrentDeck(open_file_name)) {
 #ifdef _WIN32
-					wchar_t *dash = wcsrchr(open_file_name, L'\\');
+					wchar_t *dash = std::wcsrchr(open_file_name, L'\\');
 #else
-					wchar_t *dash = wcsrchr(open_file_name, L'/');
+					wchar_t *dash = std::wcsrchr(open_file_name, L'/');
 #endif
-					wchar_t *dot = wcsrchr(open_file_name, L'.');
+					wchar_t *dot = std::wcsrchr(open_file_name, L'.');
 					if(dash && dot && !mywcsncasecmp(dot, L".ydk", 4)) { // full path
 						wchar_t deck_name[256];
-						wcsncpy(deck_name, dash + 1, dot - dash - 1);
+						std::wcsncpy(deck_name, dash + 1, dot - dash - 1);
 						deck_name[dot - dash - 1] = L'\0';
 						mainGame->ebDeckname->setText(deck_name);
 						mainGame->cbDBCategory->setSelected(-1);
@@ -452,9 +452,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 						mainGame->cbDBDecks->setEnabled(false);
 					} else if(dash) { // has category
 						wchar_t deck_name[256];
-						wcsncpy(deck_name, dash + 1, 256);
+						std::wcsncpy(deck_name, dash + 1, 256);
 						for(size_t i = 0; i < mainGame->cbDBDecks->getItemCount(); ++i) {
-							if(!wcscmp(mainGame->cbDBDecks->getItem(i), deck_name)) {
+							if(!std::wcscmp(mainGame->cbDBDecks->getItem(i), deck_name)) {
 								BufferIO::CopyWideString(deck_name, mainGame->gameConf.lastdeck);
 								mainGame->cbDBDecks->setSelected(i);
 								break;
@@ -462,7 +462,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 						}
 					} else { // only deck name
 						for(size_t i = 0; i < mainGame->cbDBDecks->getItemCount(); ++i) {
-							if(!wcscmp(mainGame->cbDBDecks->getItem(i), open_file_name)) {
+							if(!std::wcscmp(mainGame->cbDBDecks->getItem(i), open_file_name)) {
 								BufferIO::CopyWideString(open_file_name, mainGame->gameConf.lastdeck);
 								mainGame->cbDBDecks->setSelected(i);
 								break;
@@ -502,7 +502,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				if(prev_operation == BUTTON_RENAME_REPLAY) {
 					wchar_t newname[256];
 					BufferIO::CopyWideString(mainGame->ebRSName->getText(), newname);
-					if(mywcsncasecmp(newname + wcslen(newname) - 4, L".yrp", 4)) {
+					if(mywcsncasecmp(newname + std::wcslen(newname) - 4, L".yrp", 4)) {
 						myswprintf(newname, L"%ls.yrp", mainGame->ebRSName->getText());
 					}
 					if(Replay::RenameReplay(mainGame->lstReplayList->getListItem(prev_sel), newname)) {
@@ -557,7 +557,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				else
 					curtime = ReplayMode::cur_replay.pheader.seed;
 				tm* st = localtime(&curtime);
-				wcsftime(infobuf, 256, L"%Y/%m/%d %H:%M:%S\n", st);
+				std::wcsftime(infobuf, 256, L"%Y/%m/%d %H:%M:%S\n", st);
 				repinfo.append(infobuf);
 				wchar_t namebuf[4][20]{};
 				ReplayMode::cur_replay.ReadName(namebuf[0]);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -46,7 +46,7 @@ void SingleDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater)
 		wchar_t jpass[20];
 		BufferIO::NullTerminate(pkt->pass);
 		BufferIO::CopyCharArray(pkt->pass, jpass);
-		if(wcscmp(jpass, pass)) {
+		if(std::wcscmp(jpass, pass)) {
 			STOC_ErrorMsg scem;
 			scem.msg = ERRMSG_JOINERROR;
 			scem.code = 1;

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -138,7 +138,7 @@ int SingleMode::SinglePlayThread() {
 	time_t nowtime = time(nullptr);
 	tm* localedtime = localtime(&nowtime);
 	wchar_t timetext[40];
-	wcsftime(timetext, 40, L"%Y-%m-%d %H-%M-%S", localedtime);
+	std::wcsftime(timetext, 40, L"%Y-%m-%d %H-%M-%S", localedtime);
 	mainGame->ebRSName->setText(timetext);
 	if(!mainGame->chkAutoSaveReplay->isChecked()) {
 		mainGame->wReplaySave->setText(dataManager.GetSysString(1340));

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -50,7 +50,7 @@ void TagDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 		wchar_t jpass[20];
 		BufferIO::NullTerminate(pkt->pass);
 		BufferIO::CopyCharArray(pkt->pass, jpass);
-		if(wcscmp(jpass, pass)) {
+		if(std::wcscmp(jpass, pass)) {
 			STOC_ErrorMsg scem;
 			scem.msg = ERRMSG_JOINERROR;
 			scem.code = 1;


### PR DESCRIPTION
https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=msvc-170
Beginning with the UCRT in Visual Studio 2015 and Windows 10, snprintf is no longer identical to _snprintf.
The snprintf behavior is now C99 standard conformant.

Now we can use <cwchar> functions.

@mercury233 
@purerosefallen 
@fallenstardust

@Wind2009-Louse
可否幫忙測試在其他平台編譯的情形
謝謝


