### PR TITLE
 remove additional texts for cards in deck 

### DIFF
--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -220,27 +220,29 @@ bool ClientCard::client_card_sort(ClientCard* c1, ClientCard* c2) {
 		return cp1 < cp2;
 	if(c1->location != c2->location)
 		return c1->location < c2->location;
-	if (c1->location & LOCATION_OVERLAY) {
+	if (c1->location == LOCATION_OVERLAY) {
 		if (c1->overlayTarget != c2->overlayTarget)
 			return c1->overlayTarget->sequence < c2->overlayTarget->sequence;
 		else
 			return c1->sequence < c2->sequence;
 	}
-	else {
-		if(c1->location & (LOCATION_DECK | LOCATION_GRAVE | LOCATION_REMOVED | LOCATION_EXTRA)) {
-			auto it1 = std::find_if(mainGame->dField.chains.rbegin(), mainGame->dField.chains.rend(), [c1](const ChainInfo& ch) {
-				return c1 == ch.chain_card || ch.target.find(c1) != ch.target.end();
-				});
-			auto it2 = std::find_if(mainGame->dField.chains.rbegin(), mainGame->dField.chains.rend(), [c2](const ChainInfo& ch) {
-				return c2 == ch.chain_card || ch.target.find(c2) != ch.target.end();
-				});
-			if(it1 != mainGame->dField.chains.rend() || it2 != mainGame->dField.chains.rend()) {
-				return it1 < it2;
-			}
-			return c1->sequence > c2->sequence;
+	else if (c1->location == LOCATION_DECK) {
+		return c1->sequence > c2->sequence;
+	}
+	else if (c1->location & (LOCATION_GRAVE | LOCATION_REMOVED | LOCATION_EXTRA)) {
+		auto it1 = std::find_if(mainGame->dField.chains.rbegin(), mainGame->dField.chains.rend(), [c1](const ChainInfo& ch) {
+			return c1 == ch.chain_card || ch.target.find(c1) != ch.target.end();
+		});
+		auto it2 = std::find_if(mainGame->dField.chains.rbegin(), mainGame->dField.chains.rend(), [c2](const ChainInfo& ch) {
+			return c2 == ch.chain_card || ch.target.find(c2) != ch.target.end();
+		});
+		if (it1 != mainGame->dField.chains.rend() || it2 != mainGame->dField.chains.rend()) {
+			return it1 < it2;
 		}
-		else
-			return c1->sequence < c2->sequence;
+		return c1->sequence > c2->sequence;
+	}
+	else {
+		return c1->sequence < c2->sequence;
 	}
 }
 }

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -204,6 +204,7 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 		pcard->is_reversed = false;
 		pcard->ClearData();
 		pcard->ClearTarget();
+		SetShowMark(pcard, false);
 		break;
 	}
 	case LOCATION_HAND: {

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -127,7 +127,7 @@ void ClientField::Initial(int player, int deckc, int extrac) {
 		deck[player].push_back(pcard);
 		pcard->owner = player;
 		pcard->controler = player;
-		pcard->location = 0x1;
+		pcard->location = LOCATION_DECK;
 		pcard->sequence = i;
 		pcard->position = POS_FACEDOWN_DEFENSE;
 		GetCardLocation(pcard, &pcard->curPos, &pcard->curRot, true);
@@ -137,7 +137,7 @@ void ClientField::Initial(int player, int deckc, int extrac) {
 		extra[player].push_back(pcard);
 		pcard->owner = player;
 		pcard->controler = player;
-		pcard->location = 0x40;
+		pcard->location = LOCATION_EXTRA;
 		pcard->sequence = i;
 		pcard->position = POS_FACEDOWN_DEFENSE;
 		GetCardLocation(pcard, &pcard->curPos, &pcard->curRot, true);

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -202,6 +202,8 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 			pcard->sequence = 0;
 		}
 		pcard->is_reversed = false;
+		pcard->ClearData();
+		pcard->ClearTarget();
 		break;
 	}
 	case LOCATION_HAND: {

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -2407,19 +2407,19 @@ void ClientField::ShowCancelOrFinishButton(int buttonOp) {
 void ClientField::SetShowMark(ClientCard* pcard, bool enable) {
 	if(pcard->equipTarget)
 		pcard->equipTarget->is_showequip = enable;
-	for(auto cit = pcard->equipped.begin(); cit != pcard->equipped.end(); ++cit)
-		(*cit)->is_showequip = enable;
-	for(auto cit = pcard->cardTarget.begin(); cit != pcard->cardTarget.end(); ++cit)
-		(*cit)->is_showtarget = enable;
-	for(auto cit = pcard->ownerTarget.begin(); cit != pcard->ownerTarget.end(); ++cit)
-		(*cit)->is_showtarget = enable;
-	for(auto chit = chains.begin(); chit != chains.end(); ++chit) {
-		if(pcard == chit->chain_card) {
-			for(auto tgit = chit->target.begin(); tgit != chit->target.end(); ++tgit)
-				(*tgit)->is_showchaintarget = enable;
+	for (auto& card : pcard->equipped)
+		card->is_showequip = enable;
+	for (auto& card : pcard->cardTarget)
+		card->is_showtarget = enable;
+	for (auto& card : pcard->ownerTarget)
+		card->is_showtarget = enable;
+	for (auto& ch : chains) {
+		if (pcard == ch.chain_card) {
+			for (auto& tg : ch.target)
+				tg->is_showchaintarget = enable;
 		}
-		if(chit->target.find(pcard) != chit->target.end())
-			chit->chain_card->is_showchaintarget = enable;
+		if (ch.target.find(pcard) != ch.target.end())
+			ch.chain_card->is_showchaintarget = enable;
 	}
 }
 void ClientField::ShowCardInfoInList(ClientCard* pcard, irr::gui::IGUIElement* element, irr::gui::IGUIElement* parent) {

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -2428,26 +2428,28 @@ void ClientField::ShowCardInfoInList(ClientCard* pcard, irr::gui::IGUIElement* e
 	if(pcard->code) {
 		str.append(dataManager.GetName(pcard->code));
 	}
-	if(pcard->overlayTarget) {
-		myswprintf(formatBuffer, dataManager.GetSysString(225), dataManager.GetName(pcard->overlayTarget->code), pcard->overlayTarget->sequence + 1);
-		str.append(L"\n").append(formatBuffer);
-	}
-	if((pcard->status & STATUS_PROC_COMPLETE)
-		&& (pcard->type & (TYPE_RITUAL | TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK | TYPE_SPSUMMON)))
-		str.append(L"\n").append(dataManager.GetSysString(224));
-	for(auto iter = pcard->desc_hints.begin(); iter != pcard->desc_hints.end(); ++iter) {
-		myswprintf(formatBuffer, L"\n*%ls", dataManager.GetDesc(iter->first));
-		str.append(formatBuffer);
-	}
-	for(size_t i = 0; i < chains.size(); ++i) {
-		auto chit = chains[i];
-		if(pcard == chit.chain_card) {
-			myswprintf(formatBuffer, dataManager.GetSysString(216), i + 1);
+	if (pcard->location != LOCATION_DECK) {
+		if (pcard->overlayTarget) {
+			myswprintf(formatBuffer, dataManager.GetSysString(225), dataManager.GetName(pcard->overlayTarget->code), pcard->overlayTarget->sequence + 1);
 			str.append(L"\n").append(formatBuffer);
 		}
-		if(chit.target.find(pcard) != chit.target.end()) {
-			myswprintf(formatBuffer, dataManager.GetSysString(217), i + 1, dataManager.GetName(chit.chain_card->code));
-			str.append(L"\n").append(formatBuffer);
+		if ((pcard->status & STATUS_PROC_COMPLETE)
+			&& (pcard->type & (TYPE_RITUAL | TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK | TYPE_SPSUMMON)))
+			str.append(L"\n").append(dataManager.GetSysString(224));
+		for (auto iter = pcard->desc_hints.begin(); iter != pcard->desc_hints.end(); ++iter) {
+			myswprintf(formatBuffer, L"\n*%ls", dataManager.GetDesc(iter->first));
+			str.append(formatBuffer);
+		}
+		for (size_t i = 0; i < chains.size(); ++i) {
+			const auto& chit = chains[i];
+			if (pcard == chit.chain_card) {
+				myswprintf(formatBuffer, dataManager.GetSysString(216), i + 1);
+				str.append(L"\n").append(formatBuffer);
+			}
+			if (chit.target.find(pcard) != chit.target.end()) {
+				myswprintf(formatBuffer, dataManager.GetSysString(217), i + 1, dataManager.GetName(chit.chain_card->code));
+				str.append(L"\n").append(formatBuffer);
+			}
 		}
 	}
 	if(str.length() > 0) {


### PR DESCRIPTION
![bandicam_2025-01-22_20-43-35-410](https://github.com/user-attachments/assets/e919a876-0d9b-4f07-9894-896714a52328)
![bandicam_2025-01-22_20-43-38-688](https://github.com/user-attachments/assets/2ecd6b81-886c-4859-b8ba-fe8c6c39edeb)

https://github.com/Fluorohydride/ygopro-core/pull/564
Now the deck sequence sent with MSG_SELECT_CARD is not the real sequence.
The client does not know any information (except code) of cards in deck.

For cards in deck:
- ClientCard::client_card_sort should not change the order
- ClientField::ShowCardInfoInList should not show additional text
- card target mark, chain target should be removed

----
現在MSG_SELECT_CARD 傳送的序號並非真實序號
客戶端不知道除了code以外的任何信息

牌組的卡應該改成：
- ClientCard::client_card_sort 不再改變順序
- ClientField::ShowCardInfoInList 不再顯示額外的文字
- 卡片對象、連鎖對象的圖案移除

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust
