### PR TITLE
Fix Client_field::AddCard

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -235,7 +235,7 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 			extra[controler].push_back(pcard);
 			pcard->sequence = (unsigned char)(extra[controler].size() - 1);
 		} else {
-			int p = extra[controler].size() - extra_p_count[controler] - 1;
+			int p = extra[controler].size() - extra_p_count[controler];
 			for(int i = extra[controler].size() - 1; i > p; --i) {
 				extra[controler][i]->sequence++;
 				extra[controler][i]->curPos += irr::core::vector3df(0, 0, 0.01f);


### PR DESCRIPTION
Fix bugs in https://github.com/Fluorohydride/ygopro/pull/2655
When you add cards to extra deck with face-up Pendulum cards in your extra deck, it will cause display error.

Test puzzle:
```lua
--[[message TEST]]
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(81997228,0,0,LOCATION_MZONE,5,POS_FACEUP_ATTACK)

Debug.AddCard(94192409,0,0,LOCATION_SZONE,4,POS_FACEDOWN)

Debug.AddCard(17382973,0,0,LOCATION_EXTRA,4,POS_FACEDOWN)
Debug.AddCard(43886072,0,0,LOCATION_EXTRA,4,POS_FACEDOWN)
Debug.AddCard(62312469,0,0,LOCATION_EXTRA,4,POS_FACEUP)
Debug.AddCard(52296675,0,0,LOCATION_EXTRA,4,POS_FACEUP)

Debug.ReloadFieldEnd()
```