### PR TITLE
 fix bounds checking in DeckManager::LoadLFListSingle 

### DIFF
--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -1,7 +1,7 @@
 #include "deck_manager.h"
+#include "game.h"
 #include "myfilesystem.h"
 #include "network.h"
-#include "game.h"
 
 namespace ygo {
 
@@ -269,13 +269,13 @@ FILE* DeckManager::OpenDeckFile(const wchar_t* file, const char* mode) {
 	FILE* fp = myfopen(file, mode);
 	return fp;
 }
-IReadFile* DeckManager::OpenDeckReader(const wchar_t* file) {
+irr::io::IReadFile* DeckManager::OpenDeckReader(const wchar_t* file) {
 #ifdef _WIN32
-	IReadFile* reader = DataManager::FileSystem->createAndOpenFile(file);
+	auto reader = DataManager::FileSystem->createAndOpenFile(file);
 #else
 	char file2[256];
 	BufferIO::EncodeUTF8(file, file2);
-	IReadFile* reader = DataManager::FileSystem->createAndOpenFile(file2);
+	auto = DataManager::FileSystem->createAndOpenFile(file2);
 #endif
 	return reader;
 }

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -18,19 +18,16 @@ void DeckManager::LoadLFListSingle(const char* path) {
 			if(linebuf[0] == '#')
 				continue;
 			if(linebuf[0] == '!') {
-				int sa = BufferIO::DecodeUTF8(&linebuf[1], strBuffer);
-				while(strBuffer[sa - 1] == L'\r' || strBuffer[sa - 1] == L'\n' )
-					sa--;
-				strBuffer[sa] = 0;
+				auto len = std::strcspn(linebuf, "\r\n");
+				linebuf[len] = 0;
+				BufferIO::DecodeUTF8(&linebuf[1], strBuffer);
 				LFList newlist;
+				newlist.listName = strBuffer;
+				newlist.hash = 0x7dfcee6a;
 				_lfList.push_back(newlist);
 				cur = _lfList.rbegin();
-				cur->listName = strBuffer;
-				cur->hash = 0x7dfcee6a;
 				continue;
 			}
-			if(linebuf[0] == 0)
-				continue;
 			int code = 0;
 			int count = -1;
 			if (sscanf(linebuf, "%d %d", &code, &count) != 2)

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -272,7 +272,7 @@ irr::io::IReadFile* DeckManager::OpenDeckReader(const wchar_t* file) {
 #else
 	char file2[256];
 	BufferIO::EncodeUTF8(file, file2);
-	auto = DataManager::FileSystem->createAndOpenFile(file2);
+	auto reader = DataManager::FileSystem->createAndOpenFile(file2);
 #endif
 	return reader;
 }

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -1,11 +1,16 @@
 #ifndef DECKMANAGER_H
 #define DECKMANAGER_H
 
-#include "config.h"
-#include "data_manager.h"
 #include <unordered_map>
 #include <vector>
 #include <sstream>
+#include "data_manager.h"
+
+namespace irr {
+	namespace gui {
+		class IGUIComboBox;
+	}
+}
 
 namespace ygo {
 	constexpr int DECK_MAX_SIZE = 60;
@@ -54,7 +59,7 @@ public:
 	void GetCategoryPath(wchar_t* ret, int index, const wchar_t* text);
 	void GetDeckFile(wchar_t* ret, irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
 	FILE* OpenDeckFile(const wchar_t* file, const char* mode);
-	IReadFile* OpenDeckReader(const wchar_t* file);
+	irr::io::IReadFile* OpenDeckReader(const wchar_t* file);
 	bool LoadCurrentDeck(const wchar_t* file, bool is_packlist = false);
 	bool LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck);
 	bool SaveDeck(Deck& deck, const wchar_t* file);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -4,13 +4,8 @@
 #include <unordered_map>
 #include <vector>
 #include <sstream>
+#include "config.h"
 #include "data_manager.h"
-
-namespace irr {
-	namespace gui {
-		class IGUIComboBox;
-	}
-}
 
 namespace ygo {
 	constexpr int DECK_MAX_SIZE = 60;

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -1,11 +1,11 @@
 #ifndef DECKMANAGER_H
 #define DECKMANAGER_H
 
+#include "config.h"
+#include "data_manager.h"
 #include <unordered_map>
 #include <vector>
 #include <sstream>
-#include "config.h"
-#include "data_manager.h"
 
 namespace ygo {
 	constexpr int DECK_MAX_SIZE = 60;


### PR DESCRIPTION
The last line in `lflist.conf`:
```
!
```
without newline char

sa: string length after conversion

sa=0, sa-1= -1
dereferencing strBuffer[sa - 1] is wrong


