### PR TITLE
rename `myfopen` to `mywfopen`

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -56,7 +56,7 @@ inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
 	return std::swprintf(buf, N, fmt, args...);
 }
 
-inline FILE* myfopen(const wchar_t* filename, const char* mode) {
+inline FILE* mywfopen(const wchar_t* filename, const char* mode) {
 	FILE* fp{};
 #ifdef _WIN32
 	wchar_t wmode[20]{};

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -432,9 +432,7 @@ unsigned char* DataManager::ReadScriptFromIrrFS(const char* script_name, int* sl
 	return scriptBuffer;
 }
 unsigned char* DataManager::ReadScriptFromFile(const char* script_name, int* slen) {
-	wchar_t fname[256]{};
-	BufferIO::DecodeUTF8(script_name, fname);
-	FILE* fp = myfopen(fname, "rb");
+	FILE* fp = fopen(script_name, "rb");
 	if (!fp)
 		return nullptr;
 	size_t len = std::fread(scriptBuffer, 1, sizeof scriptBuffer, fp);

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -432,7 +432,7 @@ unsigned char* DataManager::ReadScriptFromIrrFS(const char* script_name, int* sl
 	return scriptBuffer;
 }
 unsigned char* DataManager::ReadScriptFromFile(const char* script_name, int* slen) {
-	FILE* fp = fopen(script_name, "rb");
+	FILE* fp = std::fopen(script_name, "rb");
 	if (!fp)
 		return nullptr;
 	size_t len = std::fread(scriptBuffer, 1, sizeof scriptBuffer, fp);

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -263,7 +263,7 @@ void DeckManager::GetDeckFile(wchar_t* ret, irr::gui::IGUIComboBox* cbCategory, 
 	}
 }
 FILE* DeckManager::OpenDeckFile(const wchar_t* file, const char* mode) {
-	FILE* fp = myfopen(file, mode);
+	FILE* fp = mywfopen(file, mode);
 	return fp;
 }
 irr::io::IReadFile* DeckManager::OpenDeckReader(const wchar_t* file) {

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -581,7 +581,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				const wchar_t* name = mainGame->lstSinglePlayList->getListItem(sel);
 				wchar_t fname[256];
 				myswprintf(fname, L"./single/%ls", name);
-				FILE* fp = myfopen(fname, "rb");
+				FILE* fp = mywfopen(fname, "rb");
 				if(!fp) {
 					mainGame->stSinglePlayInfo->setText(L"");
 					break;

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -94,7 +94,7 @@ void Replay::SaveReplay(const wchar_t* name) {
 		return;
 	wchar_t fname[256];
 	myswprintf(fname, L"./replay/%ls.yrp", name);
-	FILE* rfp = myfopen(fname, "wb");
+	FILE* rfp = mywfopen(fname, "wb");
 	if(!rfp)
 		return;
 	fwrite(&pheader, sizeof pheader, 1, rfp);
@@ -102,11 +102,11 @@ void Replay::SaveReplay(const wchar_t* name) {
 	fclose(rfp);
 }
 bool Replay::OpenReplay(const wchar_t* name) {
-	FILE* rfp = myfopen(name, "rb");
+	FILE* rfp = mywfopen(name, "rb");
 	if(!rfp) {
 		wchar_t fname[256];
 		myswprintf(fname, L"./replay/%ls", name);
-		rfp = myfopen(fname, "rb");
+		rfp = mywfopen(fname, "rb");
 	}
 	if(!rfp)
 		return false;
@@ -143,7 +143,7 @@ bool Replay::OpenReplay(const wchar_t* name) {
 bool Replay::CheckReplay(const wchar_t* name) {
 	wchar_t fname[256];
 	myswprintf(fname, L"./replay/%ls", name);
-	FILE* rfp = myfopen(fname, "rb");
+	FILE* rfp = mywfopen(fname, "rb");
 	if(!rfp)
 		return false;
 	ReplayHeader rheader;


### PR DESCRIPTION
It is a wrap of [`_wfopen`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen).

-----

`DataManager::ReadScriptFromFile` is using `char` as param so there is no need to do the conversion to `wchar_t`.