### PR TITLE
添加.clang-tidy文件

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,35 @@
+---
+Checks:          '-*,hicpp-use-nullptr'
+WarningsAsErrors: ''
+HeaderFileExtensions:
+  - ''
+  - h
+  - hh
+  - hpp
+  - hxx
+ImplementationFileExtensions:
+  - c
+  - cc
+  - cpp
+  - cxx
+HeaderFilterRegex: ''
+ExcludeHeaderFilterRegex: ''
+FormatStyle:     none
+User:            Administrator
+CheckOptions:
+  cert-dcl16-c.NewSuffixes: 'L;LL;LU;LLU'
+  cert-err33-c.AllowCastToVoid: 'true'
+  cert-err33-c.CheckedFunctions: '^::aligned_alloc;^::asctime_s;^::at_quick_exit;^::atexit;^::bsearch;^::bsearch_s;^::btowc;^::c16rtomb;^::c32rtomb;^::calloc;^::clock;^::cnd_broadcast;^::cnd_init;^::cnd_signal;^::cnd_timedwait;^::cnd_wait;^::ctime_s;^::fclose;^::fflush;^::fgetc;^::fgetpos;^::fgets;^::fgetwc;^::fopen;^::fopen_s;^::fprintf;^::fprintf_s;^::fputc;^::fputs;^::fputwc;^::fputws;^::fread;^::freopen;^::freopen_s;^::fscanf;^::fscanf_s;^::fseek;^::fsetpos;^::ftell;^::fwprintf;^::fwprintf_s;^::fwrite;^::fwscanf;^::fwscanf_s;^::getc;^::getchar;^::getenv;^::getenv_s;^::gets_s;^::getwc;^::getwchar;^::gmtime;^::gmtime_s;^::localtime;^::localtime_s;^::malloc;^::mbrtoc16;^::mbrtoc32;^::mbsrtowcs;^::mbsrtowcs_s;^::mbstowcs;^::mbstowcs_s;^::memchr;^::mktime;^::mtx_init;^::mtx_lock;^::mtx_timedlock;^::mtx_trylock;^::mtx_unlock;^::printf_s;^::putc;^::putwc;^::raise;^::realloc;^::remove;^::rename;^::scanf;^::scanf_s;^::setlocale;^::setvbuf;^::signal;^::snprintf;^::snprintf_s;^::sprintf;^::sprintf_s;^::sscanf;^::sscanf_s;^::strchr;^::strerror_s;^::strftime;^::strpbrk;^::strrchr;^::strstr;^::strtod;^::strtof;^::strtoimax;^::strtok;^::strtok_s;^::strtol;^::strtold;^::strtoll;^::strtoul;^::strtoull;^::strtoumax;^::strxfrm;^::swprintf;^::swprintf_s;^::swscanf;^::swscanf_s;^::thrd_create;^::thrd_detach;^::thrd_join;^::thrd_sleep;^::time;^::timespec_get;^::tmpfile;^::tmpfile_s;^::tmpnam;^::tmpnam_s;^::tss_create;^::tss_get;^::tss_set;^::ungetc;^::ungetwc;^::vfprintf;^::vfprintf_s;^::vfscanf;^::vfscanf_s;^::vfwprintf;^::vfwprintf_s;^::vfwscanf;^::vfwscanf_s;^::vprintf_s;^::vscanf;^::vscanf_s;^::vsnprintf;^::vsnprintf_s;^::vsprintf;^::vsprintf_s;^::vsscanf;^::vsscanf_s;^::vswprintf;^::vswprintf_s;^::vswscanf;^::vswscanf_s;^::vwprintf_s;^::vwscanf;^::vwscanf_s;^::wcrtomb;^::wcschr;^::wcsftime;^::wcspbrk;^::wcsrchr;^::wcsrtombs;^::wcsrtombs_s;^::wcsstr;^::wcstod;^::wcstof;^::wcstoimax;^::wcstok;^::wcstok_s;^::wcstol;^::wcstold;^::wcstoll;^::wcstombs;^::wcstombs_s;^::wcstoul;^::wcstoull;^::wcstoumax;^::wcsxfrm;^::wctob;^::wctrans;^::wctype;^::wmemchr;^::wprintf_s;^::wscanf;^::wscanf_s;'
+  cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField: 'false'
+  cert-str34-c.DiagnoseSignedUnsignedCharComparisons: 'false'
+  cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'true'
+  google-readability-braces-around-statements.ShortStatementLines: '1'
+  google-readability-function-size.StatementThreshold: '800'
+  google-readability-namespace-comments.ShortNamespaceLines: '10'
+  google-readability-namespace-comments.SpacesBeforeComments: '2'
+  llvm-else-after-return.WarnOnConditionVariables: 'false'
+  llvm-else-after-return.WarnOnUnfixable: 'false'
+  llvm-qualified-auto.AddConstToQualified: 'false'
+SystemHeaders:   false
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,hicpp-use-nullptr'
+Checks:          '-*,hicpp-use-nullptr,readability-qualified-auto,cppcoreguidelines-init-variables,readability-braces-around-statements'
 WarningsAsErrors: ''
 HeaderFileExtensions:
   - ''

--- a/gframe/CGUIImageButton.cpp
+++ b/gframe/CGUIImageButton.cpp
@@ -27,8 +27,9 @@ void Draw2DImageRotation(video::IVideoDriver* driver, video::ITexture* image, co
 	corner[2] = irr::core::vector2df(position.X, position.Y + sourceRect.getHeight() * scale.Y);
 	corner[3] = irr::core::vector2df(position.X + sourceRect.getWidth() * scale.X, position.Y + sourceRect.getHeight() * scale.Y);
 	if (rotation != 0.0f) {
-		for (int x = 0; x < 4; x++)
+		for (int x = 0; x < 4; x++) {
 			corner[x].rotateBy(rotation, irr::core::vector2df(rotationPoint.X, rotationPoint.Y));
+}
 	}
 	irr::core::vector2df uvCorner[4];
 	uvCorner[0] = irr::core::vector2df(sourceRect.UpperLeftCorner.X, sourceRect.UpperLeftCorner.Y);
@@ -54,9 +55,10 @@ void Draw2DImageRotation(video::IVideoDriver* driver, video::ITexture* image, co
 	material.Lighting = false;
 	material.ZWriteEnable = false;
 	material.TextureLayer[0].Texture = image;
-	if (useAlphaChannel)
+	if (useAlphaChannel) {
 		material.MaterialType = irr::video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-	else material.MaterialType = irr::video::EMT_SOLID;
+	} else { material.MaterialType = irr::video::EMT_SOLID;
+}
 	driver->setMaterial(material);
 	driver->drawIndexedTriangleList(&vertices[0], 4, &indices[0], 2);
 	driver->setTransform(irr::video::ETS_PROJECTION, oldProjMat);
@@ -93,9 +95,10 @@ void Draw2DImageQuad(video::IVideoDriver* driver, video::ITexture* image, core::
 	material.Lighting = false;
 	material.ZWriteEnable = false;
 	material.TextureLayer[0].Texture = image;
-	if (useAlphaChannel)
+	if (useAlphaChannel) {
 		material.MaterialType = irr::video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-	else material.MaterialType = irr::video::EMT_SOLID;
+	} else { material.MaterialType = irr::video::EMT_SOLID;
+}
 	driver->setMaterial(material);
 	driver->drawIndexedTriangleList(&vertices[0], 4, &indices[0], 2);
 	driver->setTransform(irr::video::ETS_PROJECTION, oldProjMat);
@@ -119,8 +122,9 @@ CGUIImageButton::CGUIImageButton(IGUIEnvironment* environment, IGUIElement* pare
 	setNotClipped(noclip);
 
 	// Initialize the sprites.
-	for (u32 i = 0; i < EGBS_COUNT; ++i)
+	for (u32 i = 0; i < EGBS_COUNT; ++i) {
 		ButtonSprites[i].Index = -1;
+}
 
 	// This element can be tabbed.
 	setTabStop(true);
@@ -134,17 +138,21 @@ CGUIImageButton::CGUIImageButton(IGUIEnvironment* environment, IGUIElement* pare
 //! destructor
 CGUIImageButton::~CGUIImageButton()
 {
-	if (OverrideFont)
+	if (OverrideFont) {
 		OverrideFont->drop();
+}
 
-	if (Image)
+	if (Image) {
 		Image->drop();
+}
 
-	if (PressedImage)
+	if (PressedImage) {
 		PressedImage->drop();
+}
 
-	if (SpriteBank)
+	if (SpriteBank) {
 		SpriteBank->drop();
+}
 }
 
 
@@ -172,11 +180,13 @@ void CGUIImageButton::setDrawBorder(bool border)
 
 void CGUIImageButton::setSpriteBank(IGUISpriteBank* sprites)
 {
-	if (sprites)
+	if (sprites) {
 		sprites->grab();
+}
 
-	if (SpriteBank)
+	if (SpriteBank) {
 		SpriteBank->drop();
+}
 
 	SpriteBank = sprites;
 }
@@ -200,8 +210,9 @@ void CGUIImageButton::setSprite(EGUI_BUTTON_STATE state, s32 index, video::SColo
 //! called if an event happened.
 bool CGUIImageButton::OnEvent(const SEvent& event)
 {
-	if (!isEnabled())
+	if (!isEnabled()) {
 		return IGUIElement::OnEvent(event);
+}
 
 	switch (event.EventType)
 	{
@@ -209,10 +220,11 @@ bool CGUIImageButton::OnEvent(const SEvent& event)
 		if (event.KeyInput.PressedDown &&
 			(event.KeyInput.Key == KEY_RETURN || event.KeyInput.Key == KEY_SPACE))
 		{
-			if (!IsPushButton)
+			if (!IsPushButton) {
 				setPressed(true);
-			else
+			} else {
 				setPressed(!Pressed);
+}
 
 			return true;
 		}
@@ -226,8 +238,9 @@ bool CGUIImageButton::OnEvent(const SEvent& event)
 				(event.KeyInput.Key == KEY_RETURN || event.KeyInput.Key == KEY_SPACE))
 			{
 
-				if (!IsPushButton)
+				if (!IsPushButton) {
 					setPressed(false);
+}
 
 				if (Parent)
 				{
@@ -246,8 +259,9 @@ bool CGUIImageButton::OnEvent(const SEvent& event)
 		{
 			if (event.GUIEvent.EventType == EGET_ELEMENT_FOCUS_LOST)
 			{
-				if (!IsPushButton)
+				if (!IsPushButton) {
 					setPressed(false);
+}
 			}
 		}
 		break;
@@ -261,8 +275,9 @@ bool CGUIImageButton::OnEvent(const SEvent& event)
 				return false;
 			}
 
-			if (!IsPushButton)
+			if (!IsPushButton) {
 				setPressed(true);
+}
 
 			Environment->setFocus(this);
 			return true;
@@ -274,14 +289,15 @@ bool CGUIImageButton::OnEvent(const SEvent& event)
 
 				if (!AbsoluteClippingRect.isPointInside(core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y)))
 				{
-					if (!IsPushButton)
+					if (!IsPushButton) {
 						setPressed(false);
+}
 					return true;
 				}
 
-				if (!IsPushButton)
+				if (!IsPushButton) {
 					setPressed(false);
-				else
+				} else
 				{
 					setPressed(!Pressed);
 				}
@@ -309,8 +325,9 @@ bool CGUIImageButton::OnEvent(const SEvent& event)
 
 
 void CGUIImageButton::draw() {
-	if (!IsVisible)
+	if (!IsVisible) {
 		return;
+}
 	IGUISkin* skin = Environment->getSkin();
 	video::IVideoDriver* driver = Environment->getVideoDriver();
 	core::position2di center = AbsoluteRect.getCenter();
@@ -322,32 +339,39 @@ void CGUIImageButton::draw() {
 		pos.Y += 1;
 		center.X += 1;
 		center.Y += 1;
-		if (DrawBorder)
+		if (DrawBorder) {
 			skin->draw3DButtonPanePressed(this, AbsoluteRect, &AbsoluteClippingRect);
+}
 	} else {
-		if (DrawBorder)
+		if (DrawBorder) {
 			skin->draw3DButtonPaneStandard(this, AbsoluteRect, &AbsoluteClippingRect);
+}
 	}
-	if(Image && isDrawImage)
+	if(Image && isDrawImage) {
 		irr::gui::Draw2DImageRotation(driver, Image, ImageRect, pos, center, imageRotation, imageScale);
+}
 	IGUIElement::draw();
 }
 void CGUIImageButton::setImage(video::ITexture* image)
 {
-	if(image)
+	if(image) {
 		image->grab();
-	if(Image)
+}
+	if(Image) {
 		Image->drop();
+}
 
 	Image = image;
 	if(image) {
 		ImageRect = core::rect<s32>(core::position2d<s32>(0, 0), image->getOriginalSize());
-		if(isFixedSize)
+		if(isFixedSize) {
 			imageScale = core::vector2df((irr::f32)imageSize.Width / image->getSize().Width, (irr::f32)imageSize.Height / image->getSize().Height);
+}
 	}
 
-	if(!PressedImage)
+	if(!PressedImage) {
 		setPressedImage(Image);
+}
 }
 
 //! Sets the image which should be displayed on the button when it is in its normal state.
@@ -374,46 +398,54 @@ void CGUIImageButton::setImageSize(core::dimension2di s) {
 //! sets another skin independent font. if this is set to zero, the button uses the font of the skin.
 void CGUIImageButton::setOverrideFont(IGUIFont* font)
 {
-	if (OverrideFont == font)
+	if (OverrideFont == font) {
 		return;
+}
 
-	if (OverrideFont)
+	if (OverrideFont) {
 		OverrideFont->drop();
+}
 
 	OverrideFont = font;
 
-	if (OverrideFont)
+	if (OverrideFont) {
 		OverrideFont->grab();
+}
 }
 
 IGUIFont* CGUIImageButton::getOverrideFont( void ) const
 {
 	IGUISkin* skin = Environment->getSkin();
-	if (!skin)
+	if (!skin) {
 		return nullptr;
+}
 	return skin->getFont();
 }
 
 IGUIFont* CGUIImageButton::getActiveFont() const
 {
 	IGUISkin* skin = Environment->getSkin();
-	if (!skin)
+	if (!skin) {
 		return nullptr;
+}
 	return skin->getFont();
 }
 
 //! Sets an image which should be displayed on the button when it is in pressed state.
 void CGUIImageButton::setPressedImage(video::ITexture* image)
 {
-	if (image)
+	if (image) {
 		image->grab();
+}
 
-	if (PressedImage)
+	if (PressedImage) {
 		PressedImage->drop();
+}
 
 	PressedImage = image;
-	if (image)
+	if (image) {
 		PressedImageRect = core::rect<s32>(core::position2d<s32>(0, 0), image->getOriginalSize());
+}
 }
 
 
@@ -488,8 +520,9 @@ void CGUIImageButton::serializeAttributes(io::IAttributes* out, io::SAttributeRe
 	IGUIButton::serializeAttributes(out, options);
 
 	out->addBool("PushButton", IsPushButton);
-	if (IsPushButton)
+	if (IsPushButton) {
 		out->addBool("Pressed", Pressed);
+}
 
 	out->addTexture("Image", Image);
 	out->addRect("ImageRect", ImageRect);
@@ -513,16 +546,18 @@ void CGUIImageButton::deserializeAttributes(io::IAttributes* in, io::SAttributeR
 	Pressed = IsPushButton ? in->getAttributeAsBool("Pressed") : false;
 
 	core::rect<s32> rec = in->getAttributeAsRect("ImageRect");
-	if (rec.isValid())
+	if (rec.isValid()) {
 		setImage(in->getAttributeAsTexture("Image"), rec);
-	else
+	} else {
 		setImage(in->getAttributeAsTexture("Image"));
+}
 
 	rec = in->getAttributeAsRect("PressedImageRect");
-	if (rec.isValid())
+	if (rec.isValid()) {
 		setPressedImage(in->getAttributeAsTexture("PressedImage"), rec);
-	else
+	} else {
 		setPressedImage(in->getAttributeAsTexture("PressedImage"));
+}
 
 	setDrawBorder(in->getAttributeAsBool("Border"));
 	setUseAlphaChannel(in->getAttributeAsBool("UseAlphaChannel"));

--- a/gframe/CGUIImageButton.cpp
+++ b/gframe/CGUIImageButton.cpp
@@ -102,7 +102,7 @@ void Draw2DImageQuad(video::IVideoDriver* driver, video::ITexture* image, core::
 	driver->setTransform(irr::video::ETS_VIEW, oldViewMat);
 }
 CGUIImageButton* CGUIImageButton::addImageButton(IGUIEnvironment *env, const core::rect<s32>& rectangle, IGUIElement* parent, s32 id) {
-	CGUIImageButton* button = new CGUIImageButton(env, parent ? parent : 0, id, rectangle);
+	CGUIImageButton* button = new CGUIImageButton(env, parent ? parent : nullptr, id, rectangle);
 	button->drop();
 	return button;
 }
@@ -110,7 +110,7 @@ CGUIImageButton* CGUIImageButton::addImageButton(IGUIEnvironment *env, const cor
 CGUIImageButton::CGUIImageButton(IGUIEnvironment* environment, IGUIElement* parent,
 	s32 id, core::rect<s32> rectangle, bool noclip)
 	: IGUIButton(environment, parent, id, rectangle),
-	SpriteBank(0), OverrideFont(0), Image(0), PressedImage(0),
+	SpriteBank(nullptr), OverrideFont(nullptr), Image(nullptr), PressedImage(nullptr),
 	IsPushButton(false), Pressed(false),
 	UseAlphaChannel(false), DrawBorder(true), ScaleImage(false) {
 #ifdef _DEBUG
@@ -234,7 +234,7 @@ bool CGUIImageButton::OnEvent(const SEvent& event)
 					SEvent newEvent;
 					newEvent.EventType = EET_GUI_EVENT;
 					newEvent.GUIEvent.Caller = this;
-					newEvent.GUIEvent.Element = 0;
+					newEvent.GUIEvent.Element = nullptr;
 					newEvent.GUIEvent.EventType = EGET_BUTTON_CLICKED;
 					Parent->OnEvent(newEvent);
 				}
@@ -292,7 +292,7 @@ bool CGUIImageButton::OnEvent(const SEvent& event)
 					SEvent newEvent;
 					newEvent.EventType = EET_GUI_EVENT;
 					newEvent.GUIEvent.Caller = this;
-					newEvent.GUIEvent.Element = 0;
+					newEvent.GUIEvent.Element = nullptr;
 					newEvent.GUIEvent.EventType = EGET_BUTTON_CLICKED;
 					Parent->OnEvent(newEvent);
 				}
@@ -483,7 +483,7 @@ bool CGUIImageButton::isDrawingBorder() const
 
 
 //! Writes attributes of the element.
-void CGUIImageButton::serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options = 0) const
+void CGUIImageButton::serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options = nullptr) const
 {
 	IGUIButton::serializeAttributes(out, options);
 
@@ -505,7 +505,7 @@ void CGUIImageButton::serializeAttributes(io::IAttributes* out, io::SAttributeRe
 
 
 //! Reads attributes of the element
-void CGUIImageButton::deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options = 0)
+void CGUIImageButton::deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options = nullptr)
 {
 	IGUIButton::deserializeAttributes(in, options);
 

--- a/gframe/CGUITTFont.cpp
+++ b/gframe/CGUITTFont.cpp
@@ -522,7 +522,7 @@ void CGUITTFont::drawUstring(const core::ustring& utext, const core::rect<s32>&p
 	core::map<u32, CGUITTGlyphPage*> Render_Map;
 
 	// Start parsing characters.
-	u32 n;
+	u32 n = 0;
 	uchar32_t previousChar = 0;
 	core::ustring::const_iterator iter(utext);
 	while (!iter.atEnd()) {

--- a/gframe/CGUITTFont.cpp
+++ b/gframe/CGUITTFont.cpp
@@ -84,8 +84,9 @@ video::IImage* SGUITTGlyph::createGlyphImage(const FT_Bitmap& bits, video::IVide
 			for (s32 x = 0; x < (s32)bits.width; ++x) {
 				// Monochrome bitmaps store 8 pixels per byte.  The left-most pixel is the bit 0x80.
 				// So, we go through the data each bit at a time.
-				if ((glyph_data[y * bits.pitch + (x / 8)] & (0x80 >> (x % 8))) != 0)
+				if ((glyph_data[y * bits.pitch + (x / 8)] & (0x80 >> (x % 8))) != 0) {
 					*row = 0xFFFF;
+}
 				++row;
 			}
 			image_data += image_pitch;
@@ -124,15 +125,17 @@ video::IImage* SGUITTGlyph::createGlyphImage(const FT_Bitmap& bits, video::IVide
 }
 
 void SGUITTGlyph::preload(u32 char_index, FT_Face face, video::IVideoDriver* driver, u32 font_size, const FT_Int32 loadFlags) {
-	if (isLoaded) return;
+	if (isLoaded) { return;
+}
 
 	// Set the size of the glyph.
 	FT_Set_Pixel_Sizes(face, 0, font_size);
 
 	// Attempt to load the glyph.
-	if (FT_Load_Glyph(face, char_index, loadFlags) != FT_Err_Ok)
+	if (FT_Load_Glyph(face, char_index, loadFlags) != FT_Err_Ok) {
 		// TODO: error message?
 		return;
+}
 
 	FT_GlyphSlot glyph = face->glyph;
 	FT_Bitmap bits = glyph->bitmap;
@@ -147,9 +150,10 @@ void SGUITTGlyph::preload(u32 char_index, FT_Face face, video::IVideoDriver* dri
 	// If we need to make a new page, do that now.
 	if (!page) {
 		page = parent->createGlyphPage(bits.pixel_mode);
-		if (!page)
+		if (!page) {
 			// TODO: add error message?
 			return;
+}
 	}
 
 	glyph_page = parent->getLastGlyphPageIndex();
@@ -186,8 +190,9 @@ void SGUITTGlyph::unload() {
 
 CGUITTFont* CGUITTFont::createTTFont(IGUIEnvironment *env, const io::path& filename, const u32 size, const bool antialias, const bool transparency) {
 	if (!c_libraryLoaded) {
-		if (FT_Init_FreeType(&c_library))
+		if (FT_Init_FreeType(&c_library)) {
 			return nullptr;
+}
 		c_libraryLoaded = true;
 	}
 
@@ -203,8 +208,9 @@ CGUITTFont* CGUITTFont::createTTFont(IGUIEnvironment *env, const io::path& filen
 
 CGUITTFont* CGUITTFont::createTTFont(IrrlichtDevice *device, const io::path& filename, const u32 size, const bool antialias, const bool transparency) {
 	if (!c_libraryLoaded) {
-		if (FT_Init_FreeType(&c_library))
+		if (FT_Init_FreeType(&c_library)) {
 			return nullptr;
+}
 		c_libraryLoaded = true;
 	}
 
@@ -242,8 +248,9 @@ CGUITTFont::CGUITTFont(IGUIEnvironment *env)
 		Driver = Environment->getVideoDriver();
 	}
 
-	if (Driver)
+	if (Driver) {
 		Driver->grab();
+}
 
 	setInvisibleCharacters(L" ");
 
@@ -253,9 +260,12 @@ CGUITTFont::CGUITTFont(IGUIEnvironment *env)
 
 bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antialias, const bool transparency) {
 	// Some sanity checks.
-	if (Environment == nullptr || Driver == nullptr) return false;
-	if (size == 0) return false;
-	if (filename.size() == 0) return false;
+	if (Environment == nullptr || Driver == nullptr) { return false;
+}
+	if (size == 0) { return false;
+}
+	if (filename.size() == 0) { return false;
+}
 
 	io::IFileSystem* filesystem = Environment->getFileSystem();
 	irr::ILogger* logger = (Device != nullptr ? Device->getLogger() : nullptr);
@@ -268,8 +278,9 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 	update_load_flags();
 
 	// Log.
-	if (logger)
+	if (logger) {
 		logger->log(L"CGUITTFont", core::stringw(core::stringw(L"Creating new font: ") + core::stringc(filename) + L" " + core::stringc(size) + L"pt " + (antialias ? L"+antialias " : L"-antialias ") + (transparency ? L"+transparency" : L"-transparency")).c_str(), irr::ELL_INFORMATION);
+}
 
 	// Grab the face.
 	SGUITTFace* face = nullptr;
@@ -282,7 +293,8 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 			// Read in the file data.
 			io::IReadFile* file = filesystem->createAndOpenFile(filename);
 			if (file == nullptr) {
-				if (logger) logger->log(L"CGUITTFont", L"Failed to open the file.", irr::ELL_INFORMATION);
+				if (logger) { logger->log(L"CGUITTFont", L"Failed to open the file.", irr::ELL_INFORMATION);
+}
 
 				c_faces.remove(filename);
 				delete face;
@@ -296,7 +308,8 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 
 			// Create the face.
 			if (FT_New_Memory_Face(c_library, face->face_buffer, face->face_buffer_size, 0, &face->face)) {
-				if (logger) logger->log(L"CGUITTFont", L"FT_New_Memory_Face failed.", irr::ELL_INFORMATION);
+				if (logger) { logger->log(L"CGUITTFont", L"FT_New_Memory_Face failed.", irr::ELL_INFORMATION);
+}
 
 				c_faces.remove(filename);
 				delete face;
@@ -304,7 +317,8 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 				return false;
 			}
 		} else {
-			if (logger) logger->log(L"CGUITTFont", L"FT_New_Face failed.", irr::ELL_INFORMATION);
+			if (logger) { logger->log(L"CGUITTFont", L"FT_New_Face failed.", irr::ELL_INFORMATION);
+}
 
 			c_faces.remove(filename);
 			delete face;
@@ -377,8 +391,9 @@ CGUITTFont::~CGUITTFont() {
 		SGUITTFace* f = n->getValue();
 
 		// Drop our face.  If this was the last face, the destructor will clean up.
-		if (f->drop())
+		if (f->drop()) {
 			c_faces.remove(filename);
+}
 
 		// If there are no more faces referenced by FreeType, clean up.
 		if (c_faces.size() == 0) {
@@ -388,18 +403,21 @@ CGUITTFont::~CGUITTFont() {
 	}
 
 	// Drop our driver now.
-	if (Driver)
+	if (Driver) {
 		Driver->drop();
+}
 }
 
 void CGUITTFont::reset_images() {
 	// Delete the glyphs.
-	for (u32 i = 0; i != Glyphs.size(); ++i)
+	for (u32 i = 0; i != Glyphs.size(); ++i) {
 		Glyphs[i].unload();
+}
 
 	// Unload the glyph pages from video memory.
-	for (u32 i = 0; i != Glyph_Pages.size(); ++i)
+	for (u32 i = 0; i != Glyph_Pages.size(); ++i) {
 		delete Glyph_Pages[i];
+}
 	Glyph_Pages.clear();
 
 	// Always update the internal FreeType loading flags after resetting.
@@ -408,19 +426,21 @@ void CGUITTFont::reset_images() {
 
 void CGUITTFont::update_glyph_pages() const {
 	for (u32 i = 0; i != Glyph_Pages.size(); ++i) {
-		if (Glyph_Pages[i]->dirty)
+		if (Glyph_Pages[i]->dirty) {
 			Glyph_Pages[i]->updateTexture();
+}
 	}
 }
 
 CGUITTGlyphPage* CGUITTFont::getLastGlyphPage() const {
 	CGUITTGlyphPage* page = nullptr;
-	if (Glyph_Pages.empty())
+	if (Glyph_Pages.empty()) {
 		return nullptr;
-	else {
+	} else {
 		page = Glyph_Pages[getLastGlyphPageIndex()];
-		if (page->available_slots == 0)
+		if (page->available_slots == 0) {
 			page = nullptr;
+}
 	}
 	return page;
 }
@@ -444,21 +464,25 @@ CGUITTGlyphPage* CGUITTFont::createGlyphPage(const u8& pixel_mode) {
 	// Determine our maximum texture size.
 	// If we keep getting 0, set it to 1024x1024, as that number is pretty safe.
 	core::dimension2du max_texture_size = max_page_texture_size;
-	if (max_texture_size.Width == 0 || max_texture_size.Height == 0)
+	if (max_texture_size.Width == 0 || max_texture_size.Height == 0) {
 		max_texture_size = Driver->getMaxTextureSize();
-	if (max_texture_size.Width == 0 || max_texture_size.Height == 0)
+}
+	if (max_texture_size.Width == 0 || max_texture_size.Height == 0) {
 		max_texture_size = core::dimension2du(1024, 1024);
+}
 
 	// We want to try to put at least 144 glyphs on a single texture.
 	core::dimension2du page_texture_size;
-	if (size <= 21) page_texture_size = core::dimension2du(256, 256);
-	else if (size <= 42) page_texture_size = core::dimension2du(512, 512);
-	else if (size <= 84) page_texture_size = core::dimension2du(1024, 1024);
-	else if (size <= 168) page_texture_size = core::dimension2du(2048, 2048);
-	else page_texture_size = core::dimension2du(4096, 4096);
+	if (size <= 21) { page_texture_size = core::dimension2du(256, 256);
+	} else if (size <= 42) { page_texture_size = core::dimension2du(512, 512);
+	} else if (size <= 84) { page_texture_size = core::dimension2du(1024, 1024);
+	} else if (size <= 168) { page_texture_size = core::dimension2du(2048, 2048);
+	} else { page_texture_size = core::dimension2du(4096, 4096);
+}
 
-	if (page_texture_size.Width > max_texture_size.Width || page_texture_size.Height > max_texture_size.Height)
+	if (page_texture_size.Width > max_texture_size.Width || page_texture_size.Height > max_texture_size.Height) {
 		page_texture_size = max_texture_size;
+}
 
 	page->texture_size = page_texture_size;
 	page->pixel_mode = pixel_mode;
@@ -488,14 +512,16 @@ void CGUITTFont::setFontHinting(const bool enable, const bool enable_auto_hintin
 }
 
 void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position, video::SColor color, bool hcenter, bool vcenter, const core::rect<s32>* clip) {
-	if (!Driver)
+	if (!Driver) {
 		return;
+}
 	drawUstring(text, position, color, hcenter, vcenter, clip);
 }
 
 void CGUITTFont::drawUstring(const core::ustring& utext, const core::rect<s32>&position, video::SColor color, bool hcenter, bool vcenter, const core::rect<s32>*clip) {
-	if (!Driver)
+	if (!Driver) {
 		return;
+}
 
 	// Clear the glyph pages of their render information.
 	for (u32 i = 0; i < Glyph_Pages.size(); ++i) {
@@ -511,11 +537,13 @@ void CGUITTFont::drawUstring(const core::ustring& utext, const core::rect<s32>&p
 	if (hcenter || vcenter) {
 		textDimension = getDimension(utext);
 
-		if (hcenter)
+		if (hcenter) {
 			offset.X = ((position.getWidth() - textDimension.Width) >> 1) + offset.X;
+}
 
-		if (vcenter)
+		if (vcenter) {
 			offset.Y = ((position.getHeight() - textDimension.Height) >> 1) + offset.Y;
+}
 	}
 
 	// Set up our render map.
@@ -531,8 +559,9 @@ void CGUITTFont::drawUstring(const core::ustring& utext, const core::rect<s32>&p
 		bool lineBreak = false;
 		if (currentChar == L'\r') { // Mac or Windows breaks
 			lineBreak = true;
-			if (*(iter + 1) == L'\n')	// Windows line breaks.
+			if (*(iter + 1) == L'\n') {	// Windows line breaks.
 				currentChar = *(++iter);
+}
 		} else if (currentChar == L'\n') { // Unix breaks
 			lineBreak = true;
 		}
@@ -540,8 +569,9 @@ void CGUITTFont::drawUstring(const core::ustring& utext, const core::rect<s32>&p
 			previousChar = 0;
 			offset.Y += supposed_line_height; //font_metrics.ascender / 64;
 			offset.X = position.UpperLeftCorner.X;
-			if (hcenter)
+			if (hcenter) {
 				offset.X += (position.getWidth() - textDimension.Width) >> 1;
+}
 			++iter;
 			continue;
 		}
@@ -577,11 +607,13 @@ void CGUITTFont::drawUstring(const core::ustring& utext, const core::rect<s32>&p
 	while (!j.atEnd()) {
 		core::map<u32, CGUITTGlyphPage*>::Node* n = j.getNode();
 		j++;
-		if (n == nullptr) continue;
+		if (n == nullptr) { continue;
+}
 
 		CGUITTGlyphPage* page = n->getValue();
 
-		if (!use_transparency) color.color |= 0xff000000;
+		if (!use_transparency) { color.color |= 0xff000000;
+}
 		Driver->draw2DImageBatch(page->texture, page->render_positions, page->render_source_rects, clip, color, true);
 	}
 }
@@ -622,16 +654,18 @@ core::dimension2d<u32> CGUITTFont::getDimension(const core::ustring& text) const
 		if (lineBreak) {
 			previousChar = 0;
 			text_dimension.Height += line.Height;
-			if (text_dimension.Width < line.Width)
+			if (text_dimension.Width < line.Width) {
 				text_dimension.Width = line.Width;
+}
 			line.Width = 0;
 			line.Height = supposed_line_height;
 			continue;
 		}
 		line.Width += getWidthFromCharacter(p);
 	}
-	if (text_dimension.Width < line.Width)
+	if (text_dimension.Width < line.Width) {
 		text_dimension.Width = line.Width;
+}
 
 	return text_dimension;
 }
@@ -650,9 +684,10 @@ inline u32 CGUITTFont::getWidthFromCharacter(uchar32_t c) const {
 		int w = Glyphs[n - 1].advance.x / 64;
 		return w;
 	}
-	if (c >= 0x2000)
+	if (c >= 0x2000) {
 		return (font_metrics.ascender / 64);
-	else return (font_metrics.ascender / 64) / 2;
+	} else { return (font_metrics.ascender / 64) / 2;
+}
 }
 
 inline u32 CGUITTFont::getHeightFromCharacter(wchar_t c) const {
@@ -670,9 +705,10 @@ inline u32 CGUITTFont::getHeightFromCharacter(uchar32_t c) const {
 		s32 height = (font_metrics.ascender / 64) - Glyphs[n - 1].offset.Y + Glyphs[n - 1].source_rect.getHeight();
 		return height;
 	}
-	if (c >= 0x2000)
+	if (c >= 0x2000) {
 		return (font_metrics.ascender / 64);
-	else return (font_metrics.ascender / 64) / 2;
+	} else { return (font_metrics.ascender / 64) / 2;
+}
 }
 
 u32 CGUITTFont::getGlyphIndexByChar(wchar_t c) const {
@@ -684,17 +720,20 @@ u32 CGUITTFont::getGlyphIndexByChar(uchar32_t c) const {
 	u32 glyph = FT_Get_Char_Index(tt_face, c);
 
 	// Check for a valid glyph.  If it is invalid, attempt to use the replacement character.
-	if (glyph == 0)
+	if (glyph == 0) {
 		glyph = FT_Get_Char_Index(tt_face, core::unicode::UTF_REPLACEMENT_CHARACTER);
+}
 
 	// If our glyph is already loaded, don't bother doing any batch loading code.
-	if (glyph != 0 && Glyphs[glyph - 1].isLoaded)
+	if (glyph != 0 && Glyphs[glyph - 1].isLoaded) {
 		return glyph;
+}
 
 	// Determine our batch loading positions.
 	u32 half_size = (batch_load_size / 2);
 	u32 start_pos = 0;
-	if (c > half_size) start_pos = c - half_size;
+	if (c > half_size) { start_pos = c - half_size;
+}
 	u32 end_pos = start_pos + batch_load_size;
 
 	// Load all our characters.
@@ -735,8 +774,9 @@ s32 CGUITTFont::getCharacterFromPos(const core::ustring& text, s32 pixel_x) cons
 		core::vector2di k = getKerning(c, previousChar);
 		x += k.X;
 
-		if (x >= pixel_x)
+		if (x >= pixel_x) {
 			return character;
+}
 
 		previousChar = c;
 		++iter;
@@ -755,10 +795,12 @@ void CGUITTFont::setKerningHeight(s32 kerning) {
 }
 
 s32 CGUITTFont::getKerningWidth(const wchar_t* thisLetter, const wchar_t* previousLetter) const {
-	if (tt_face == nullptr)
+	if (tt_face == nullptr) {
 		return GlobalKerningWidth;
-	if (thisLetter == nullptr || previousLetter == nullptr)
+}
+	if (thisLetter == nullptr || previousLetter == nullptr) {
 		return 0;
+}
 
 	return getKerningWidth((uchar32_t) * thisLetter, (uchar32_t) * previousLetter);
 }
@@ -778,8 +820,9 @@ core::vector2di CGUITTFont::getKerning(const wchar_t thisLetter, const wchar_t p
 }
 
 core::vector2di CGUITTFont::getKerning(const uchar32_t thisLetter, const uchar32_t previousLetter) const {
-	if (tt_face == nullptr || thisLetter == 0 || previousLetter == 0)
+	if (tt_face == nullptr || thisLetter == 0 || previousLetter == 0) {
 		return core::vector2di();
+}
 
 	// Set the size of the face.
 	// This is because we cache faces and the face may have been set to a different size.
@@ -788,8 +831,9 @@ core::vector2di CGUITTFont::getKerning(const uchar32_t thisLetter, const uchar32
 	core::vector2di ret(GlobalKerningWidth, GlobalKerningHeight);
 
 	// If we don't have kerning, no point in continuing.
-	if (!FT_HAS_KERNING(tt_face))
+	if (!FT_HAS_KERNING(tt_face)) {
 		return ret;
+}
 
 	// Get the kerning information.
 	FT_Vector v;
@@ -817,8 +861,9 @@ video::IImage* CGUITTFont::createTextureFromChar(const uchar32_t& ch) {
 	const SGUITTGlyph& glyph = Glyphs[n - 1];
 	CGUITTGlyphPage* page = Glyph_Pages[glyph.glyph_page];
 
-	if (page->dirty)
+	if (page->dirty) {
 		page->updateTexture();
+}
 
 	video::ITexture* tex = page->texture;
 
@@ -839,10 +884,11 @@ video::IImage* CGUITTFont::createTextureFromChar(const uchar32_t& ch) {
 }
 
 video::ITexture* CGUITTFont::getPageTextureByIndex(const u32& page_index) const {
-	if (page_index < Glyph_Pages.size())
+	if (page_index < Glyph_Pages.size()) {
 		return Glyph_Pages[page_index]->texture;
-	else
+	} else {
 		return nullptr;
+}
 }
 
 void CGUITTFont::createSharedPlane() {
@@ -875,8 +921,9 @@ void CGUITTFont::createSharedPlane() {
 
 core::dimension2d<u32> CGUITTFont::getDimensionUntilEndOfLine(const wchar_t* p) const {
 	core::stringw s;
-	for (const wchar_t* temp = p; temp && *temp != '\0' && *temp != L'\r' && *temp != L'\n'; ++temp )
+	for (const wchar_t* temp = p; temp && *temp != '\0' && *temp != L'\r' && *temp != L'\n'; ++temp ) {
 		s.append(*temp);
+}
 
 	return getDimension(s.c_str());
 }
@@ -888,14 +935,17 @@ core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text
 
 	array<scene::ISceneNode*> container;
 
-	if (!Driver || !smgr) return container;
-	if (!parent)
+	if (!Driver || !smgr) { return container;
+}
+	if (!parent) {
 		parent = smgr->addEmptySceneNode(smgr->getRootSceneNode(), -1);
+}
 	// if you don't specify parent, then we add a empty node attached to the root node
 	// this is generally undesirable.
 
-	if (!shared_plane_ptr_) //this points to a static mesh that contains the plane
+	if (!shared_plane_ptr_) { //this points to a static mesh that contains the plane
 		createSharedPlane(); //if it's not initialized, we create one.
+}
 
 	dimension2d<s32> text_size(getDimension(text)); //convert from unsigned to signed.
 	vector3df start_point(0, 0, 0), offset;
@@ -931,8 +981,9 @@ core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text
 		bool line_break = false;
 		if (current_char == L'\r') { // Mac or Windows breaks
 			line_break = true;
-			if (*(text + 1) == L'\n') // Windows line breaks.
+			if (*(text + 1) == L'\n') { // Windows line breaks.
 				current_char = *(++text);
+}
 		} else if (current_char == L'\n') { // Unix breaks
 			line_break = true;
 		}
@@ -941,8 +992,9 @@ core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text
 			previous_char = 0;
 			offset.Y -= supposed_line_height; //tt_face->size->metrics.ascender / 64;
 			offset.X = start_point.X;
-			if (center)
+			if (center) {
 				offset.X += (text_size.Width - getDimensionUntilEndOfLine(text + 1).Width) >> 1;
+}
 			++text;
 		} else {
 			n = getGlyphIndexByChar(current_char);

--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -11,7 +11,7 @@ ClientCard::~ClientCard() {
 		equipTarget->equipped.erase(this);
 		equipTarget = nullptr;
 	}
-	for (auto& card : equipped) {
+	for (const auto& card : equipped) {
 		card->is_showequip = false;
 		card->equipTarget = nullptr;
 	}
@@ -175,11 +175,11 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 	}
 }
 void ClientCard::ClearTarget() {
-	for (auto& pcard : cardTarget) {
+	for (const auto& pcard : cardTarget) {
 		pcard->is_showtarget = false;
 		pcard->ownerTarget.erase(this);
 	}
-	for (auto& pcard : ownerTarget) {
+	for (const auto& pcard : ownerTarget) {
 		pcard->is_showtarget = false;
 		pcard->cardTarget.erase(this);
 	}

--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -21,8 +21,9 @@ ClientCard::~ClientCard() {
 			if (*it == this) {
 				it = overlayTarget->overlayed.erase(it);
 			}
-			else
+			else {
 				++it;
+}
 		}
 		overlayTarget = nullptr;
 	}
@@ -35,8 +36,9 @@ void ClientCard::SetCode(unsigned int x) {
 	if((location == LOCATION_HAND) && (code != x)) {
 		code = x;
 		mainGame->dField.MoveCard(this, 5);
-	} else
+	} else {
 		code = x;
+}
 }
 void ClientCard::UpdateInfo(unsigned char* buf) {
 	int flag = BufferIO::ReadInt32(buf);
@@ -46,26 +48,31 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 	}
 	if(flag & QUERY_CODE) {
 		int pdata = BufferIO::ReadInt32(buf);
-		if (!pdata)
+		if (!pdata) {
 			ClearData();
+}
 		if((location == LOCATION_HAND) && ((unsigned int)pdata != code)) {
 			code = pdata;
 			mainGame->dField.MoveCard(this, 5);
-		} else
+		} else {
 			code = pdata;
+}
 	}
 	if(flag & QUERY_POSITION) {
 		int pdata = (BufferIO::ReadInt32(buf) >> 24) & 0xff;
 		if((location & (LOCATION_EXTRA | LOCATION_REMOVED)) && (u8)pdata != position) {
 			position = pdata;
 			mainGame->dField.MoveCard(this, 1);
-		} else
+		} else {
 			position = pdata;
+}
 	}
-	if(flag & QUERY_ALIAS)
+	if(flag & QUERY_ALIAS) {
 		alias = BufferIO::ReadInt32(buf);
-	if(flag & QUERY_TYPE)
+}
+	if(flag & QUERY_TYPE) {
 		type = BufferIO::ReadInt32(buf);
+}
 	if(flag & QUERY_LEVEL) {
 		int pdata = BufferIO::ReadInt32(buf);
 		if(level != (unsigned int)pdata) {
@@ -80,17 +87,20 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 			myswprintf(lvstring, L"R%d", rank);
 		}
 	}
-	if(flag & QUERY_ATTRIBUTE)
+	if(flag & QUERY_ATTRIBUTE) {
 		attribute = BufferIO::ReadInt32(buf);
-	if(flag & QUERY_RACE)
+}
+	if(flag & QUERY_RACE) {
 		race = BufferIO::ReadInt32(buf);
+}
 	if(flag & QUERY_ATTACK) {
 		attack = BufferIO::ReadInt32(buf);
 		if(attack < 0) {
 			atkstring[0] = '?';
 			atkstring[1] = 0;
-		} else
+		} else {
 			myswprintf(atkstring, L"%d", attack);
+}
 	}
 	if(flag & QUERY_DEFENSE) {
 		defense = BufferIO::ReadInt32(buf);
@@ -100,17 +110,22 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 		} else if(defense < 0) {
 			defstring[0] = '?';
 			defstring[1] = 0;
-		} else
+		} else {
 			myswprintf(defstring, L"%d", defense);
+}
 	}
-	if(flag & QUERY_BASE_ATTACK)
+	if(flag & QUERY_BASE_ATTACK) {
 		base_attack = BufferIO::ReadInt32(buf);
-	if(flag & QUERY_BASE_DEFENSE)
+}
+	if(flag & QUERY_BASE_DEFENSE) {
 		base_defense = BufferIO::ReadInt32(buf);
-	if(flag & QUERY_REASON)
+}
+	if(flag & QUERY_REASON) {
 		reason = BufferIO::ReadInt32(buf);
-	if(flag & QUERY_REASON_CARD)
+}
+	if(flag & QUERY_REASON_CARD) {
 		buf += 4;
+}
 	if(flag & QUERY_EQUIP_CARD) {
 		int c = BufferIO::ReadUInt8(buf);
 		unsigned int l = BufferIO::ReadUInt8(buf);
@@ -150,10 +165,12 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 			counters[ctype] = ccount;
 		}
 	}
-	if(flag & QUERY_OWNER)
+	if(flag & QUERY_OWNER) {
 		owner = BufferIO::ReadInt32(buf);
-	if(flag & QUERY_STATUS)
+}
+	if(flag & QUERY_STATUS) {
 		status = BufferIO::ReadInt32(buf);
+}
 	if(flag & QUERY_LSCALE) {
 		lscale = BufferIO::ReadInt32(buf);
 		myswprintf(lscstring, L"%d", lscale);
@@ -212,19 +229,23 @@ void ClientCard::ClearData() {
 	counters.clear();
 }
 bool ClientCard::client_card_sort(ClientCard* c1, ClientCard* c2) {
-	if(c1->is_selected != c2->is_selected)
+	if(c1->is_selected != c2->is_selected) {
 		return c1->is_selected < c2->is_selected;
+}
 	int cp1 = c1->overlayTarget ? c1->overlayTarget->controler : c1->controler;
 	int cp2 = c2->overlayTarget ? c2->overlayTarget->controler : c2->controler;
-	if(cp1 != cp2)
+	if(cp1 != cp2) {
 		return cp1 < cp2;
-	if(c1->location != c2->location)
+}
+	if(c1->location != c2->location) {
 		return c1->location < c2->location;
+}
 	if (c1->location == LOCATION_OVERLAY) {
-		if (c1->overlayTarget != c2->overlayTarget)
+		if (c1->overlayTarget != c2->overlayTarget) {
 			return c1->overlayTarget->sequence < c2->overlayTarget->sequence;
-		else
+		} else {
 			return c1->sequence < c2->sequence;
+}
 	}
 	else if (c1->location == LOCATION_DECK) {
 		return c1->sequence > c2->sequence;

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -12,8 +12,8 @@ namespace ygo {
 
 ClientField::ClientField() {
 	for(int p = 0; p < 2; ++p) {
-		mzone[p].resize(7, 0);
-		szone[p].resize(8, 0);
+		mzone[p].resize(7, nullptr);
+		szone[p].resize(8, nullptr);
 	}
 	rnd.reset((uint_fast32_t)std::random_device()());
 }
@@ -100,11 +100,11 @@ void ClientField::Clear() {
 	reposable_cards.clear();
 	attackable_cards.clear();
 	disabled_field = 0;
-	panel = 0;
-	hovered_card = 0;
-	clicked_card = 0;
-	highlighting_card = 0;
-	menu_card = 0;
+	panel = nullptr;
+	hovered_card = nullptr;
+	clicked_card = nullptr;
+	highlighting_card = nullptr;
+	menu_card = nullptr;
 	hovered_controler = 0;
 	hovered_location = 0;
 	hovered_sequence = 0;
@@ -144,7 +144,7 @@ void ClientField::Initial(int player, int deckc, int extrac) {
 	}
 }
 ClientCard* ClientField::GetCard(int controler, int location, int sequence, int sub_seq) {
-	std::vector<ClientCard*>* lst = 0;
+	std::vector<ClientCard*>* lst = nullptr;
 	bool is_xyz = (location & LOCATION_OVERLAY) != 0;
 	location &= 0x7f;
 	switch(location) {
@@ -171,18 +171,18 @@ ClientCard* ClientField::GetCard(int controler, int location, int sequence, int 
 		break;
 	}
 	if(!lst)
-		return 0;
+		return nullptr;
 	if(is_xyz) {
 		if(sequence >= (int)lst->size())
-			return 0;
+			return nullptr;
 		ClientCard* scard = (*lst)[sequence];
 		if(scard && (int)scard->overlayed.size() > sub_seq)
 			return scard->overlayed[sub_seq];
 		else
-			return 0;
+			return nullptr;
 	} else {
 		if(sequence >= (int)lst->size())
-			return 0;
+			return nullptr;
 		return (*lst)[sequence];
 	}
 }
@@ -196,7 +196,7 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 			deck[controler].push_back(pcard);
 			pcard->sequence = (unsigned char)(deck[controler].size() - 1);
 		} else {
-			deck[controler].push_back(0);
+			deck[controler].push_back(nullptr);
 			for(int i = deck[controler].size() - 1; i > 0; --i) {
 				deck[controler][i] = deck[controler][i - 1];
 				deck[controler][i]->sequence++;
@@ -238,7 +238,7 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 			extra[controler].push_back(pcard);
 			pcard->sequence = (unsigned char)(extra[controler].size() - 1);
 		} else {
-			extra[controler].push_back(0);
+			extra[controler].push_back(nullptr);
 			int p = extra[controler].size() - extra_p_count[controler] - 1;
 			for(int i = extra[controler].size() - 1; i > p; --i) {
 				extra[controler][i] = extra[controler][i - 1];
@@ -256,7 +256,7 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 	}
 }
 ClientCard* ClientField::RemoveCard(int controler, int location, int sequence) {
-	ClientCard* pcard = 0;
+	ClientCard* pcard = nullptr;
 	switch (location) {
 	case LOCATION_DECK: {
 		pcard = deck[controler][sequence];
@@ -280,12 +280,12 @@ ClientCard* ClientField::RemoveCard(int controler, int location, int sequence) {
 	}
 	case LOCATION_MZONE: {
 		pcard = mzone[controler][sequence];
-		mzone[controler][sequence] = 0;
+		mzone[controler][sequence] = nullptr;
 		break;
 	}
 	case LOCATION_SZONE: {
 		pcard = szone[controler][sequence];
-		szone[controler][sequence] = 0;
+		szone[controler][sequence] = nullptr;
 		break;
 	}
 	case LOCATION_GRAVE: {
@@ -334,7 +334,7 @@ void ClientField::UpdateCard(int controler, int location, int sequence, unsigned
 		pcard->UpdateInfo(data);
 }
 void ClientField::UpdateFieldCard(int controler, int location, unsigned char* data) {
-	std::vector<ClientCard*>* lst = 0;
+	std::vector<ClientCard*>* lst = nullptr;
 	switch(location) {
 	case LOCATION_DECK:
 		lst = &deck[controler];

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -51,7 +51,7 @@ ClientField::~ClientField() {
 		}
 		extra[i].clear();
 	}
-	for (auto& card : overlay_cards) {
+	for (const auto& card : overlay_cards) {
 		delete card;
 	}
 	overlay_cards.clear();
@@ -1142,7 +1142,7 @@ bool ClientField::ShowSelectSum(bool panelmode) {
 		return true;
 	}
 
-	auto display_hint = select_hint ? dataManager.GetDesc(select_hint) : dataManager.GetSysString(560);
+	const auto *display_hint = select_hint ? dataManager.GetDesc(select_hint) : dataManager.GetSysString(560);
 
 	wchar_t cur_hint[20];
 	if (select_curval_l == select_curval_h) {
@@ -1178,7 +1178,7 @@ bool ClientField::ShowSelectSum(bool panelmode) {
 }
 bool ClientField::CheckSelectSum() {
 	std::set<ClientCard*> selable;
-	for(auto sc : selectsum_all) {
+	for(auto *sc : selectsum_all) {
 		sc->is_selectable = false;
 		sc->is_selected = false;
 		selable.insert(sc);
@@ -1204,18 +1204,18 @@ bool ClientField::CheckSelectSum() {
 	if (select_mode == 0) { // sum equal
 		bool ret = check_sel_sum_s(selable, 0, select_sumval);
 		selectable_cards.clear();
-		for(auto sc : selectsum_cards) {
+		for(auto *sc : selectsum_cards) {
 			sc->is_selectable = true;
 			selectable_cards.push_back(sc);
 		}
-		for(auto sc : selected_cards) {
+		for(auto *sc : selected_cards) {
 			selectable_cards.push_back(sc);
 		}
 		return ret;
 	} else { // sum greater
 		int mm = -1, mx = -1, max = 0, sumc = 0;
 		bool ret = false;
-		for (auto sc : selected_cards) {
+		for (auto *sc : selected_cards) {
 			int op1 = sc->opParam & 0xffff;
 			int op2 = sc->opParam >> 16;
 			int opmin = (op2 > 0 && op1 > op2) ? op2 : op1;
@@ -1231,7 +1231,7 @@ bool ClientField::CheckSelectSum() {
 			return true;
 		if (select_sumval <= max && select_sumval > max - mx)
 			ret = true;
-		for(auto sc : selable) {
+		for(auto *sc : selable) {
 			int op1 = sc->opParam & 0xffff;
 			int op2 = sc->opParam >> 16;
 			int m = op1;
@@ -1268,11 +1268,11 @@ bool ClientField::CheckSelectSum() {
 			}
 		}
 		selectable_cards.clear();
-		for(auto sc : selectsum_cards) {
+		for(auto *sc : selectsum_cards) {
 			sc->is_selectable = true;
 			selectable_cards.push_back(sc);
 		}
-		for(auto sc : selected_cards) {
+		for(auto *sc : selected_cards) {
 			selectable_cards.push_back(sc);
 		}
 		return ret;

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -121,7 +121,7 @@ void ClientField::Clear() {
 	tag_teammate_surrender = false;
 }
 void ClientField::Initial(int player, int deckc, int extrac) {
-	ClientCard* pcard;
+	ClientCard* pcard = nullptr;
 	for(int i = 0; i < deckc; ++i) {
 		pcard = new ClientCard;
 		deck[player].push_back(pcard);
@@ -360,7 +360,7 @@ void ClientField::UpdateFieldCard(int controler, int location, unsigned char* da
 	}
 	if(!lst)
 		return;
-	int len;
+	int len = 0;
 	for(auto cit = lst->begin(); cit != lst->end(); ++cit) {
 		len = BufferIO::ReadInt32(data);
 		if(len > LEN_HEADER)
@@ -438,8 +438,8 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 			rnd.shuffle_vector(selectable_cards);
 		}
 	}
-	int startpos;
-	int ct;
+	int startpos = 0;
+	int ct = 0;
 	if(selectable_cards.size() <= 5) {
 		startpos = 30 + 125 * (5 - selectable_cards.size()) / 2;
 		ct = selectable_cards.size();
@@ -530,8 +530,8 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 	mainGame->PopupElement(mainGame->wCardSelect);
 }
 void ClientField::ShowChainCard() {
-	int startpos;
-	int ct;
+	int startpos = 0;
+	int ct = 0;
 	if(selectable_cards.size() <= 5) {
 		startpos = 30 + 125 * (5 - selectable_cards.size()) / 2;
 		ct = selectable_cards.size();
@@ -584,8 +584,8 @@ void ClientField::ShowChainCard() {
 	mainGame->PopupElement(mainGame->wCardSelect);
 }
 void ClientField::ShowLocationCard() {
-	int startpos;
-	int ct;
+	int startpos = 0;
+	int ct = 0;
 	if(display_cards.size() <= 5) {
 		startpos = 30 + 125 * (5 - display_cards.size()) / 2;
 		ct = display_cards.size();

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -28,13 +28,15 @@ ClientField::~ClientField() {
 		}
 		hand[i].clear();
 		for (auto& card : mzone[i]) {
-			if (card)
+			if (card) {
 				delete card;
+}
 			card = nullptr;
 		}
 		for (auto& card : szone[i]) {
-			if (card)
+			if (card) {
 				delete card;
+}
 			card = nullptr;
 		}
 		for (auto& card : grave[i]) {
@@ -58,34 +60,42 @@ ClientField::~ClientField() {
 }
 void ClientField::Clear() {
 	for(int i = 0; i < 2; ++i) {
-		for(auto cit = deck[i].begin(); cit != deck[i].end(); ++cit)
+		for(auto cit = deck[i].begin(); cit != deck[i].end(); ++cit) {
 			delete *cit;
+}
 		deck[i].clear();
-		for(auto cit = hand[i].begin(); cit != hand[i].end(); ++cit)
+		for(auto cit = hand[i].begin(); cit != hand[i].end(); ++cit) {
 			delete *cit;
+}
 		hand[i].clear();
 		for(auto cit = mzone[i].begin(); cit != mzone[i].end(); ++cit) {
-			if(*cit)
+			if(*cit) {
 				delete *cit;
+}
 			*cit = 0;
 		}
 		for(auto cit = szone[i].begin(); cit != szone[i].end(); ++cit) {
-			if(*cit)
+			if(*cit) {
 				delete *cit;
+}
 			*cit = 0;
 		}
-		for(auto cit = grave[i].begin(); cit != grave[i].end(); ++cit)
+		for(auto cit = grave[i].begin(); cit != grave[i].end(); ++cit) {
 			delete *cit;
+}
 		grave[i].clear();
-		for(auto cit = remove[i].begin(); cit != remove[i].end(); ++cit)
+		for(auto cit = remove[i].begin(); cit != remove[i].end(); ++cit) {
 			delete *cit;
+}
 		remove[i].clear();
-		for(auto cit = extra[i].begin(); cit != extra[i].end(); ++cit)
+		for(auto cit = extra[i].begin(); cit != extra[i].end(); ++cit) {
 			delete *cit;
+}
 		extra[i].clear();
 	}
-	for(auto sit = overlay_cards.begin(); sit != overlay_cards.end(); ++sit)
+	for(auto sit = overlay_cards.begin(); sit != overlay_cards.end(); ++sit) {
 		delete *sit;
+}
 	overlay_cards.clear();
 	extra_p_count[0] = 0;
 	extra_p_count[1] = 0;
@@ -170,19 +180,23 @@ ClientCard* ClientField::GetCard(int controler, int location, int sequence, int 
 		lst = &extra[controler];
 		break;
 	}
-	if(!lst)
+	if(!lst) {
 		return nullptr;
+}
 	if(is_xyz) {
-		if(sequence >= (int)lst->size())
+		if(sequence >= (int)lst->size()) {
 			return nullptr;
+}
 		ClientCard* scard = (*lst)[sequence];
-		if(scard && (int)scard->overlayed.size() > sub_seq)
+		if(scard && (int)scard->overlayed.size() > sub_seq) {
 			return scard->overlayed[sub_seq];
-		else
+		} else {
 			return nullptr;
+}
 	} else {
-		if(sequence >= (int)lst->size())
+		if(sequence >= (int)lst->size()) {
 			return nullptr;
+}
 		return (*lst)[sequence];
 	}
 }
@@ -249,8 +263,9 @@ void ClientField::AddCard(ClientCard* pcard, int controler, int location, int se
 			extra[controler][p] = pcard;
 			pcard->sequence = p;
 		}
-		if (pcard->position & POS_FACEUP)
+		if (pcard->position & POS_FACEUP) {
 			extra_p_count[controler]++;
+}
 		break;
 	}
 	}
@@ -319,8 +334,9 @@ ClientCard* ClientField::RemoveCard(int controler, int location, int sequence) {
 			extra[controler][i]->mTransform.setTranslation(extra[controler][i]->curPos);
 		}
 		extra[controler].erase(extra[controler].end() - 1);
-		if (pcard->position & POS_FACEUP)
+		if (pcard->position & POS_FACEUP) {
 			extra_p_count[controler]--;
+}
 		break;
 	}
 	}
@@ -330,8 +346,9 @@ ClientCard* ClientField::RemoveCard(int controler, int location, int sequence) {
 void ClientField::UpdateCard(int controler, int location, int sequence, unsigned char* data) {
 	ClientCard* pcard = GetCard(controler, location, sequence);
 	int len = BufferIO::ReadInt32(data);
-	if (pcard && len > LEN_HEADER)
+	if (pcard && len > LEN_HEADER) {
 		pcard->UpdateInfo(data);
+}
 }
 void ClientField::UpdateFieldCard(int controler, int location, unsigned char* data) {
 	std::vector<ClientCard*>* lst = nullptr;
@@ -358,31 +375,40 @@ void ClientField::UpdateFieldCard(int controler, int location, unsigned char* da
 		lst = &extra[controler];
 		break;
 	}
-	if(!lst)
+	if(!lst) {
 		return;
+}
 	int len = 0;
 	for(auto cit = lst->begin(); cit != lst->end(); ++cit) {
 		len = BufferIO::ReadInt32(data);
-		if(len > LEN_HEADER)
+		if(len > LEN_HEADER) {
 			(*cit)->UpdateInfo(data);
+}
 		data += len - 4;
 	}
 }
 void ClientField::ClearCommandFlag() {
-	for(auto cit = activatable_cards.begin(); cit != activatable_cards.end(); ++cit)
+	for(auto cit = activatable_cards.begin(); cit != activatable_cards.end(); ++cit) {
 		(*cit)->cmdFlag = 0;
-	for(auto cit = summonable_cards.begin(); cit != summonable_cards.end(); ++cit)
+}
+	for(auto cit = summonable_cards.begin(); cit != summonable_cards.end(); ++cit) {
 		(*cit)->cmdFlag = 0;
-	for(auto cit = spsummonable_cards.begin(); cit != spsummonable_cards.end(); ++cit)
+}
+	for(auto cit = spsummonable_cards.begin(); cit != spsummonable_cards.end(); ++cit) {
 		(*cit)->cmdFlag = 0;
-	for(auto cit = msetable_cards.begin(); cit != msetable_cards.end(); ++cit)
+}
+	for(auto cit = msetable_cards.begin(); cit != msetable_cards.end(); ++cit) {
 		(*cit)->cmdFlag = 0;
-	for(auto cit = ssetable_cards.begin(); cit != ssetable_cards.end(); ++cit)
+}
+	for(auto cit = ssetable_cards.begin(); cit != ssetable_cards.end(); ++cit) {
 		(*cit)->cmdFlag = 0;
-	for(auto cit = reposable_cards.begin(); cit != reposable_cards.end(); ++cit)
+}
+	for(auto cit = reposable_cards.begin(); cit != reposable_cards.end(); ++cit) {
 		(*cit)->cmdFlag = 0;
-	for(auto cit = attackable_cards.begin(); cit != attackable_cards.end(); ++cit)
+}
+	for(auto cit = attackable_cards.begin(); cit != attackable_cards.end(); ++cit) {
 		(*cit)->cmdFlag = 0;
+}
 	conti_cards.clear();
 	deck_act = false;
 	extra_act = false;
@@ -450,55 +476,62 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 	for(int i = 0; i < ct; ++i) {
 		mainGame->stCardPos[i]->enableOverrideColor(false);
 		// image
-		if(selectable_cards[i]->code)
+		if(selectable_cards[i]->code) {
 			mainGame->imageLoading.insert(std::make_pair(mainGame->btnCardSelect[i], selectable_cards[i]->code));
-		else if(conti_selecting)
+		} else if(conti_selecting) {
 			mainGame->imageLoading.insert(std::make_pair(mainGame->btnCardSelect[i], selectable_cards[i]->chain_code));
-		else
+		} else {
 			mainGame->btnCardSelect[i]->setImage(imageManager.tCover[selectable_cards[i]->controler + 2]);
+}
 		mainGame->btnCardSelect[i]->setRelativePosition(rect<s32>(startpos + i * 125, 55, startpos + 120 + i * 125, 225));
 		mainGame->btnCardSelect[i]->setPressed(false);
 		mainGame->btnCardSelect[i]->setVisible(true);
 		if(mainGame->dInfo.curMsg != MSG_SORT_CARD) {
 			// text
 			wchar_t formatBuffer[2048];
-			if(conti_selecting)
+			if(conti_selecting) {
 				myswprintf(formatBuffer, L"%ls", DataManager::unknown_string);
-			else if(cant_check_grave && selectable_cards[i]->location == LOCATION_GRAVE)
+			} else if(cant_check_grave && selectable_cards[i]->location == LOCATION_GRAVE) {
 				myswprintf(formatBuffer, L"%ls", dataManager.FormatLocation(selectable_cards[i]->location, 0));
-			else if(selectable_cards[i]->location == LOCATION_OVERLAY)
+			} else if(selectable_cards[i]->location == LOCATION_OVERLAY) {
 				myswprintf(formatBuffer, L"%ls[%d](%d)", 
 					dataManager.FormatLocation(selectable_cards[i]->overlayTarget->location, selectable_cards[i]->overlayTarget->sequence),
 					selectable_cards[i]->overlayTarget->sequence + 1, selectable_cards[i]->sequence + 1);
-			else
+			} else {
 				myswprintf(formatBuffer, L"%ls[%d]", dataManager.FormatLocation(selectable_cards[i]->location, selectable_cards[i]->sequence),
 					selectable_cards[i]->sequence + 1);
+}
 			mainGame->stCardPos[i]->setText(formatBuffer);
 			// color
-			if (selectable_cards[i]->is_selected)
+			if (selectable_cards[i]->is_selected) {
 				mainGame->stCardPos[i]->setBackgroundColor(0xffffff00);
-			else {
-				if(conti_selecting)
+			} else {
+				if(conti_selecting) {
 					mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
-				else if(selectable_cards[i]->location == LOCATION_OVERLAY) {
-					if(selectable_cards[i]->owner != selectable_cards[i]->overlayTarget->controler)
+				} else if(selectable_cards[i]->location == LOCATION_OVERLAY) {
+					if(selectable_cards[i]->owner != selectable_cards[i]->overlayTarget->controler) {
 						mainGame->stCardPos[i]->setOverrideColor(0xff0000ff);
-					if(selectable_cards[i]->overlayTarget->controler)
+}
+					if(selectable_cards[i]->overlayTarget->controler) {
 						mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
-					else
+					} else {
 						mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
+}
 				} else if(selectable_cards[i]->location == LOCATION_DECK || selectable_cards[i]->location == LOCATION_EXTRA || selectable_cards[i]->location == LOCATION_REMOVED) {
-					if(selectable_cards[i]->position & POS_FACEDOWN)
+					if(selectable_cards[i]->position & POS_FACEDOWN) {
 						mainGame->stCardPos[i]->setOverrideColor(0xff0000ff);
-					if(selectable_cards[i]->controler)
+}
+					if(selectable_cards[i]->controler) {
 						mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
-					else
+					} else {
 						mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
+}
 				} else {
-					if(selectable_cards[i]->controler)
+					if(selectable_cards[i]->controler) {
 						mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
-					else
+					} else {
 						mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
+}
 				}
 			}
 		} else {
@@ -506,8 +539,9 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 				wchar_t formatBuffer[2048];
 				myswprintf(formatBuffer, L"%d", sort_list[i]);
 				mainGame->stCardPos[i]->setText(formatBuffer);
-			} else
+			} else {
 				mainGame->stCardPos[i]->setText(L"");
+}
 			mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 		}
 		mainGame->stCardPos[i]->setVisible(true);
@@ -540,10 +574,11 @@ void ClientField::ShowChainCard() {
 		ct = 5;
 	}
 	for(int i = 0; i < ct; ++i) {
-		if(selectable_cards[i]->code)
+		if(selectable_cards[i]->code) {
 			mainGame->imageLoading.insert(std::make_pair(mainGame->btnCardSelect[i], selectable_cards[i]->code));
-		else
+		} else {
 			mainGame->btnCardSelect[i]->setImage(imageManager.tCover[selectable_cards[i]->controler + 2]);
+}
 		mainGame->btnCardSelect[i]->setRelativePosition(rect<s32>(startpos + i * 125, 55, startpos + 120 + i * 125, 225));
 		mainGame->btnCardSelect[i]->setPressed(false);
 		mainGame->btnCardSelect[i]->setVisible(true);
@@ -552,15 +587,18 @@ void ClientField::ShowChainCard() {
 			selectable_cards[i]->sequence + 1);
 		mainGame->stCardPos[i]->setText(formatBuffer);
 		if(selectable_cards[i]->location == LOCATION_OVERLAY) {
-			if(selectable_cards[i]->owner != selectable_cards[i]->overlayTarget->controler)
+			if(selectable_cards[i]->owner != selectable_cards[i]->overlayTarget->controler) {
 				mainGame->stCardPos[i]->setOverrideColor(0xff0000ff);
-			if(selectable_cards[i]->overlayTarget->controler)
+}
+			if(selectable_cards[i]->overlayTarget->controler) {
 				mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
-			else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
+			} else { mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
+}
 		} else {
-			if(selectable_cards[i]->controler)
+			if(selectable_cards[i]->controler) {
 				mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
-			else mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
+			} else { mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
+}
 		}
 		mainGame->stCardPos[i]->setVisible(true);
 		mainGame->stCardPos[i]->setRelativePosition(rect<s32>(startpos + i * 125, 30, startpos + 120 + i * 125, 50));
@@ -578,9 +616,10 @@ void ClientField::ShowChainCard() {
 		mainGame->scrCardList->setMax((selectable_cards.size() - 5) * 10 + 9);
 		mainGame->scrCardList->setPos(0);
 	}
-	if(!chain_forced)
+	if(!chain_forced) {
 		mainGame->btnSelectOK->setVisible(true);
-	else mainGame->btnSelectOK->setVisible(false);
+	} else { mainGame->btnSelectOK->setVisible(false);
+}
 	mainGame->PopupElement(mainGame->wCardSelect);
 }
 void ClientField::ShowLocationCard() {
@@ -595,41 +634,48 @@ void ClientField::ShowLocationCard() {
 	}
 	for(int i = 0; i < ct; ++i) {
 		mainGame->stDisplayPos[i]->enableOverrideColor(false);
-		if(display_cards[i]->code)
+		if(display_cards[i]->code) {
 			mainGame->imageLoading.insert(std::make_pair(mainGame->btnCardDisplay[i], display_cards[i]->code));
-		else
+		} else {
 			mainGame->btnCardDisplay[i]->setImage(imageManager.tCover[display_cards[i]->controler + 2]);
+}
 		mainGame->btnCardDisplay[i]->setRelativePosition(rect<s32>(startpos + i * 125, 55, startpos + 120 + i * 125, 225));
 		mainGame->btnCardDisplay[i]->setPressed(false);
 		mainGame->btnCardDisplay[i]->setVisible(true);
 		wchar_t formatBuffer[2048];
-		if(display_cards[i]->location == LOCATION_OVERLAY)
+		if(display_cards[i]->location == LOCATION_OVERLAY) {
 			myswprintf(formatBuffer, L"%ls[%d](%d)", 
 				dataManager.FormatLocation(display_cards[i]->overlayTarget->location, display_cards[i]->overlayTarget->sequence),
 				display_cards[i]->overlayTarget->sequence + 1, display_cards[i]->sequence + 1);
-		else
+		} else {
 			myswprintf(formatBuffer, L"%ls[%d]", dataManager.FormatLocation(display_cards[i]->location, display_cards[i]->sequence),
 				display_cards[i]->sequence + 1);
+}
 		mainGame->stDisplayPos[i]->setText(formatBuffer);
 		if(display_cards[i]->location == LOCATION_OVERLAY) {
-			if(display_cards[i]->owner != display_cards[i]->overlayTarget->controler)
+			if(display_cards[i]->owner != display_cards[i]->overlayTarget->controler) {
 				mainGame->stDisplayPos[i]->setOverrideColor(0xff0000ff);
-			if(display_cards[i]->overlayTarget->controler)
+}
+			if(display_cards[i]->overlayTarget->controler) {
 				mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
-			else 
+			} else { 
 				mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
+}
 		} else if(display_cards[i]->location == LOCATION_EXTRA || display_cards[i]->location == LOCATION_REMOVED) {
-			if(display_cards[i]->position & POS_FACEDOWN)
+			if(display_cards[i]->position & POS_FACEDOWN) {
 				mainGame->stDisplayPos[i]->setOverrideColor(0xff0000ff);
-			if(display_cards[i]->controler)
+}
+			if(display_cards[i]->controler) {
 				mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
-			else
+			} else {
 				mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
+}
 		} else {
-			if(display_cards[i]->controler)
+			if(display_cards[i]->controler) {
 				mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
-			else 
+			} else { 
 				mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
+}
 		}
 		mainGame->stDisplayPos[i]->setVisible(true);
 		mainGame->stDisplayPos[i]->setRelativePosition(rect<s32>(startpos + i * 125, 30, startpos + 120 + i * 125, 50));
@@ -675,8 +721,9 @@ void ClientField::ShowSelectOption(int select_hint) {
 		mainGame->btnOptionp->setVisible(false);
 		mainGame->btnOptionn->setVisible(false);
 		mainGame->btnOptionOK->setVisible(false);
-		for(int i = 0; i < 5; i++)
+		for(int i = 0; i < 5; i++) {
 			mainGame->btnOption[i]->setVisible(i < count);
+}
 		recti pos = mainGame->wOptions->getRelativePosition();
 		int newheight = 30 + 40 * (scrollbar ? 5 : count);
 		int oldheight = pos.LowerRightCorner.Y - pos.UpperLeftCorner.Y;
@@ -690,16 +737,18 @@ void ClientField::ShowSelectOption(int select_hint) {
 		mainGame->btnOptionp->setVisible(false);
 		mainGame->btnOptionn->setVisible(count > 1);
 		mainGame->btnOptionOK->setVisible(true);
-		for(int i = 0; i < 5; i++)
+		for(int i = 0; i < 5; i++) {
 			mainGame->btnOption[i]->setVisible(false);
+}
 		recti pos = mainGame->wOptions->getRelativePosition();
 		pos.LowerRightCorner.Y = pos.UpperLeftCorner.Y + 140;
 		mainGame->wOptions->setRelativePosition(pos);
 	}
-	if(select_hint)
+	if(select_hint) {
 		myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
-	else
+	} else {
 		myswprintf(textBuffer, dataManager.GetSysString(555));
+}
 	mainGame->wOptions->setText(textBuffer);
 	mainGame->PopupElement(mainGame->wOptions);
 	mainGame->gMutex.unlock();
@@ -907,10 +956,11 @@ void ClientField::GetCardLocation(ClientCard* pcard, irr::core::vector3df* t, ir
 	case LOCATION_HAND: {
 		int count = hand[controler].size();
 		if (controler == 0) {
-			if (count <= 6)
+			if (count <= 6) {
 				t->X = (5.5f - 0.8f * count) / 2 + 1.55f + sequence * 0.8f;
-			else
+			} else {
 				t->X = 1.9f + sequence * 4.0f / (count - 1);
+}
 			if (pcard->is_hovered) {
 				t->Y = 3.84f;
 				t->Z = 0.656f + 0.001f * sequence;
@@ -928,10 +978,11 @@ void ClientField::GetCardLocation(ClientCard* pcard, irr::core::vector3df* t, ir
 				r->Z = 0;
 			}
 		} else {
-			if (count <= 6)
+			if (count <= 6) {
 				t->X = 6.25f - (5.5f - 0.8f * count) / 2 - sequence * 0.8f;
-			else
+			} else {
 				t->X = 5.9f - sequence * 4.0f / (count - 1);
+}
 			if (pcard->is_hovered) {
 				t->Y = -3.56f;
 				t->Z = 0.656f - 0.001f * sequence;
@@ -959,29 +1010,33 @@ void ClientField::GetCardLocation(ClientCard* pcard, irr::core::vector3df* t, ir
 			if (pcard->position & POS_DEFENSE) {
 				r->X = 0.0f;
 				r->Z = -3.1415926f / 2.0f;
-				if (pcard->position & POS_FACEDOWN)
+				if (pcard->position & POS_FACEDOWN) {
 					r->Y = 3.1415926f + 0.001f;
-				else r->Y = 0.0f;
+				} else { r->Y = 0.0f;
+}
 			} else {
 				r->X = 0.0f;
 				r->Z = 0.0f;
-				if (pcard->position & POS_FACEDOWN)
+				if (pcard->position & POS_FACEDOWN) {
 					r->Y = 3.1415926f;
-				else r->Y = 0.0f;
+				} else { r->Y = 0.0f;
+}
 			}
 		} else {
 			if (pcard->position & POS_DEFENSE) {
 				r->X = 0.0f;
 				r->Z = 3.1415926f / 2.0f;
-				if (pcard->position & POS_FACEDOWN)
+				if (pcard->position & POS_FACEDOWN) {
 					r->Y = 3.1415926f + 0.001f;
-				else r->Y = 0.0f;
+				} else { r->Y = 0.0f;
+}
 			} else {
 				r->X = 0.0f;
 				r->Z = 3.1415926f;
-				if (pcard->position & POS_FACEDOWN)
+				if (pcard->position & POS_FACEDOWN) {
 					r->Y = 3.1415926f;
-				else r->Y = 0.0f;
+				} else { r->Y = 0.0f;
+}
 			}
 		}
 		break;
@@ -993,15 +1048,17 @@ void ClientField::GetCardLocation(ClientCard* pcard, irr::core::vector3df* t, ir
 		if (controler == 0) {
 			r->X = 0.0f;
 			r->Z = 0.0f;
-			if (pcard->position & POS_FACEDOWN)
+			if (pcard->position & POS_FACEDOWN) {
 				r->Y = 3.1415926f;
-			else r->Y = 0.0f;
+			} else { r->Y = 0.0f;
+}
 		} else {
 			r->X = 0.0f;
 			r->Z = 3.1415926f;
-			if (pcard->position & POS_FACEDOWN)
+			if (pcard->position & POS_FACEDOWN) {
 				r->Y = 3.1415926f;
-			else r->Y = 0.0f;
+			} else { r->Y = 0.0f;
+}
 		}
 		break;
 	}
@@ -1053,15 +1110,17 @@ void ClientField::GetCardLocation(ClientCard* pcard, irr::core::vector3df* t, ir
 		t->Z = 0.01f + 0.01f * sequence;
 		if (controler == 0) {
 			r->X = 0.0f;
-			if(pcard->position & POS_FACEUP)
+			if(pcard->position & POS_FACEUP) {
 				r->Y = 0.0f;
-			else r->Y = 3.1415926f;
+			} else { r->Y = 3.1415926f;
+}
 			r->Z = 0.0f;
 		} else {
 			r->X = 0.0f;
-			if(pcard->position & POS_FACEUP)
+			if(pcard->position & POS_FACEUP) {
 				r->Y = 0.0f;
-			else r->Y = 3.1415926f;
+			} else { r->Y = 3.1415926f;
+}
 			r->Z = 3.1415926f;
 		}
 		break;
@@ -1101,27 +1160,36 @@ void ClientField::MoveCard(ClientCard * pcard, int frame) {
 	GetCardLocation(pcard, &trans, &rot);
 	pcard->dPos = (trans - pcard->curPos) / frame;
 	float diff = rot.X - pcard->curRot.X;
-	while (diff < 0) diff += 3.1415926f * 2;
-	while (diff > 3.1415926f * 2)
+	while (diff < 0) { diff += 3.1415926f * 2;
+}
+	while (diff > 3.1415926f * 2) {
 		diff -= 3.1415926f * 2;
-	if (diff < 3.1415926f)
+}
+	if (diff < 3.1415926f) {
 		pcard->dRot.X = diff / frame;
-	else
+	} else {
 		pcard->dRot.X = -(3.1415926f * 2 - diff) / frame;
+}
 	diff = rot.Y - pcard->curRot.Y;
-	while (diff < 0) diff += 3.1415926f * 2;
-	while (diff > 3.1415926f * 2) diff -= 3.1415926f * 2;
-	if (diff < 3.1415926f)
+	while (diff < 0) { diff += 3.1415926f * 2;
+}
+	while (diff > 3.1415926f * 2) { diff -= 3.1415926f * 2;
+}
+	if (diff < 3.1415926f) {
 		pcard->dRot.Y = diff / frame;
-	else
+	} else {
 		pcard->dRot.Y = -(3.1415926f * 2 - diff) / frame;
+}
 	diff = rot.Z - pcard->curRot.Z;
-	while (diff < 0) diff += 3.1415926f * 2;
-	while (diff > 3.1415926f * 2) diff -= 3.1415926f * 2;
-	if (diff < 3.1415926f)
+	while (diff < 0) { diff += 3.1415926f * 2;
+}
+	while (diff > 3.1415926f * 2) { diff -= 3.1415926f * 2;
+}
+	if (diff < 3.1415926f) {
 		pcard->dRot.Z = diff / frame;
-	else
+	} else {
 		pcard->dRot.Z = -(3.1415926f * 2 - diff) / frame;
+}
 	pcard->is_moving = true;
 	pcard->aniFrame = frame;
 }
@@ -1135,10 +1203,11 @@ bool ClientField::ShowSelectSum(bool panelmode) {
 	if(select_ready && (selectsum_cards.size() == 0 || selectable_cards.size() == 0)) {
 		SetResponseSelectedCards();
 		ShowCancelOrFinishButton(0);
-		if(mainGame->wCardSelect->isVisible())
+		if(mainGame->wCardSelect->isVisible()) {
 			mainGame->HideElement(mainGame->wCardSelect, true);
-		else 
+		} else { 
 			DuelClient::SendResponse();
+}
 		return true;
 	}
 
@@ -1186,10 +1255,11 @@ bool ClientField::CheckSelectSum() {
 	select_curval_l = 0;
 	select_curval_h = 0;
 	for(int i = 0; i < (int)selected_cards.size(); ++i) {
-		if(i < must_select_count)
+		if(i < must_select_count) {
 			selected_cards[i]->is_selectable = false;
-		else
+		} else {
 			selected_cards[i]->is_selectable = true;
+}
 		selected_cards[i]->is_selected = true;
 		selable.erase(selected_cards[i]);
 
@@ -1220,17 +1290,21 @@ bool ClientField::CheckSelectSum() {
 			int op2 = sc->opParam >> 16;
 			int opmin = (op2 > 0 && op1 > op2) ? op2 : op1;
 			int opmax = op2 > op1 ? op2 : op1;
-			if (mm == -1 || opmin < mm)
+			if (mm == -1 || opmin < mm) {
 				mm = opmin;
-			if (mx == -1 || opmax < mx)
+}
+			if (mx == -1 || opmax < mx) {
 				mx = opmax;
+}
 			sumc += opmin;
 			max += opmax;
 		}
-		if (select_sumval <= sumc)
+		if (select_sumval <= sumc) {
 			return true;
-		if (select_sumval <= max && select_sumval > max - mx)
+}
+		if (select_sumval <= max && select_sumval > max - mx) {
 			ret = true;
+}
 		for(auto *sc : selable) {
 			int op1 = sc->opParam & 0xffff;
 			int op2 = sc->opParam >> 16;
@@ -1238,33 +1312,40 @@ bool ClientField::CheckSelectSum() {
 			int sums = sumc;
 			sums += m;
 			int ms = mm;
-			if (ms == -1 || m < ms)
+			if (ms == -1 || m < ms) {
 				ms = m;
+}
 			if (sums >= select_sumval) {
-				if (sums - ms < select_sumval)
+				if (sums - ms < select_sumval) {
 					selectsum_cards.insert(sc);
+}
 			} else {
 				std::set<ClientCard*> left(selable);
 				left.erase(sc);
-				if (check_min(left, left.begin(), select_sumval - sums, select_sumval - sums + ms - 1))
+				if (check_min(left, left.begin(), select_sumval - sums, select_sumval - sums + ms - 1)) {
 					selectsum_cards.insert(sc);
+}
 			}
-			if (op2 == 0)
+			if (op2 == 0) {
 				continue;
+}
 			m = op2;
 			sums = sumc;
 			sums += m;
 			ms = mm;
-			if (ms == -1 || m < ms)
+			if (ms == -1 || m < ms) {
 				ms = m;
+}
 			if (sums >= select_sumval) {
-				if (sums - ms < select_sumval)
+				if (sums - ms < select_sumval) {
 					selectsum_cards.insert(sc);
+}
 			} else {
 				std::set<ClientCard*> left(selable);
 				left.erase(sc);
-				if (check_min(left, left.begin(), select_sumval - sums, select_sumval - sums + ms - 1))
+				if (check_min(left, left.begin(), select_sumval - sums, select_sumval - sums + ms - 1)) {
 					selectsum_cards.insert(sc);
+}
 			}
 		}
 		selectable_cards.clear();
@@ -1300,20 +1381,23 @@ bool ClientField::CheckSelectTribute() {
 	return ret;
 }
 bool ClientField::check_min(const std::set<ClientCard*>& left, std::set<ClientCard*>::const_iterator index, int min, int max) {
-	if (index == left.end())
+	if (index == left.end()) {
 		return false;
+}
 	int op1 = (*index)->opParam & 0xffff;
 	int op2 = (*index)->opParam >> 16;
 	int m = (op2 > 0 && op1 > op2) ? op2 : op1;
-	if (m >= min && m <= max)
+	if (m >= min && m <= max) {
 		return true;
+}
 	++index;
 	return (min > m && check_min(left, index, min - m, max - m))
 	        || check_min(left, index, min, max);
 }
 bool ClientField::check_sel_sum_s(const std::set<ClientCard*>& left, int index, int acc) {
-	if (acc < 0)
+	if (acc < 0) {
 		return false;
+}
 	if (index == (int)selected_cards.size()) {
 		if (acc == 0) {
 			int count = selected_cards.size() - must_select_count;
@@ -1327,15 +1411,17 @@ bool ClientField::check_sel_sum_s(const std::set<ClientCard*>& left, int index, 
 	int l2 = l >> 16;
 	bool res1 = false, res2 = false;
 	res1 = check_sel_sum_s(left, index + 1, acc - l1);
-	if (l2 > 0)
+	if (l2 > 0) {
 		res2 = check_sel_sum_s(left, index + 1, acc - l2);
+}
 	return res1 || res2;
 }
 void ClientField::check_sel_sum_t(const std::set<ClientCard*>& left, int acc) {
 	int count = selected_cards.size() + 1 - must_select_count;
 	for (auto sit = left.begin(); sit != left.end(); ++sit) {
-		if (selectsum_cards.find(*sit) != selectsum_cards.end())
+		if (selectsum_cards.find(*sit) != selectsum_cards.end()) {
 			continue;
+}
 		std::set<ClientCard*> testlist(left);
 		testlist.erase(*sit);
 		int l = (*sit)->opParam;
@@ -1348,23 +1434,27 @@ void ClientField::check_sel_sum_t(const std::set<ClientCard*>& left, int acc) {
 	}
 }
 bool ClientField::check_sum(std::set<ClientCard*>::const_iterator index, std::set<ClientCard*>::const_iterator end, int acc, int count) {
-	if (acc == 0)
+	if (acc == 0) {
 		return count >= select_min && count <= select_max;
-	if (acc < 0 || index == end)
+}
+	if (acc < 0 || index == end) {
 		return false;
+}
 	int l = (*index)->opParam;
 	int l1 = l & 0xffff;
 	int l2 = l >> 16;
-	if ((l1 == acc || (l2 > 0 && l2 == acc)) && (count + 1 >= select_min) && (count + 1 <= select_max))
+	if ((l1 == acc || (l2 > 0 && l2 == acc)) && (count + 1 >= select_min) && (count + 1 <= select_max)) {
 		return true;
+}
 	++index;
 	return (acc > l1 && check_sum(index, end, acc - l1, count + 1))
 	       || (l2 > 0 && acc > l2 && check_sum(index, end, acc - l2, count + 1))
 	       || check_sum(index, end, acc, count);
 }
 bool ClientField::check_sel_sum_trib_s(const std::set<ClientCard*>& left, int index, int acc) {
-	if(acc > select_max)
+	if(acc > select_max) {
 		return false;
+}
 	if(index == (int)selected_cards.size()) {
 		check_sel_sum_trib_t(left, acc);
 		return acc >= select_min && acc <= select_max;
@@ -1374,14 +1464,16 @@ bool ClientField::check_sel_sum_trib_s(const std::set<ClientCard*>& left, int in
 	int l2 = l >> 16;
 	bool res1 = false, res2 = false;
 	res1 = check_sel_sum_trib_s(left, index + 1, acc + l1);
-	if(l2 > 0)
+	if(l2 > 0) {
 		res2 = check_sel_sum_trib_s(left, index + 1, acc + l2);
+}
 	return res1 || res2;
 }
 void ClientField::check_sel_sum_trib_t(const std::set<ClientCard*>& left, int acc) {
 	for(auto sit = left.begin(); sit != left.end(); ++sit) {
-		if(selectsum_cards.find(*sit) != selectsum_cards.end())
+		if(selectsum_cards.find(*sit) != selectsum_cards.end()) {
 			continue;
+}
 		std::set<ClientCard*> testlist(left);
 		testlist.erase(*sit);
 		int l = (*sit)->opParam;
@@ -1394,15 +1486,18 @@ void ClientField::check_sel_sum_trib_t(const std::set<ClientCard*>& left, int ac
 	}
 }
 bool ClientField::check_sum_trib(std::set<ClientCard*>::const_iterator index, std::set<ClientCard*>::const_iterator end, int acc) {
-	if(acc >= select_min && acc <= select_max)
+	if(acc >= select_min && acc <= select_max) {
 		return true;
-	if(acc > select_max || index == end)
+}
+	if(acc > select_max || index == end) {
 		return false;
+}
 	int l = (*index)->opParam;
 	int l1 = l & 0xffff;
 	int l2 = l >> 16;
-	if((acc + l1 >= select_min && acc + l1 <= select_max) || (acc + l2 >= select_min && acc + l2 <= select_max))
+	if((acc + l1 >= select_min && acc + l1 <= select_max) || (acc + l2 >= select_min && acc + l2 <= select_max)) {
 		return true;
+}
 	++index;
 	return check_sum_trib(index, end, acc + l1)
 		|| check_sum_trib(index, end, acc + l2)
@@ -1535,10 +1630,12 @@ static bool is_declarable(const CardData& cd, const std::vector<unsigned int>& o
 		}
 		}
 	}
-	if(stack.size() != 1 || stack.top() == 0)
+	if(stack.size() != 1 || stack.top() == 0) {
 		return false;
-	if (cd.type & TYPE_TOKEN)
+}
+	if (cd.type & TYPE_TOKEN) {
 		return false;
+}
 	return !cd.alias || second_code.find(cd.code) != second_code.end();
 }
 void ClientField::UpdateDeclarableList() {
@@ -1562,8 +1659,9 @@ void ClientField::UpdateDeclarableList() {
 	for(auto cit = dataManager.strings_begin(); cit != dataManager.strings_end(); ++cit) {
 		if(cit->second.name.find(pname) != std::wstring::npos) {
 			auto cp = dataManager.GetCodePointer(cit->first);
-			if (cp == dataManager.datas_end())
+			if (cp == dataManager.datas_end()) {
 				continue;
+}
 			//datas.alias can be double card names or alias
 			if(is_declarable(cp->second, declare_opcodes)) {
 				if(pname == cit->second.name || trycode == cit->first) { //exact match or last used

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -16,17 +16,18 @@ DataManager::DataManager() : _datas(32768), _strings(32768) {
 bool DataManager::ReadDB(sqlite3* pDB) {
 	sqlite3_stmt* pStmt{};
 	const char* sql = "select * from datas,texts where datas.id=texts.id";
-	if (sqlite3_prepare_v2(pDB, sql, -1, &pStmt, nullptr) != SQLITE_OK)
+	if (sqlite3_prepare_v2(pDB, sql, -1, &pStmt, nullptr) != SQLITE_OK) {
 		return Error(pDB);
+}
 	wchar_t strBuffer[4096];
 	int step = 0;
 	do {
 		CardDataC cd;
 		CardString cs;
 		step = sqlite3_step(pStmt);
-		if (step == SQLITE_BUSY || step == SQLITE_ERROR || step == SQLITE_MISUSE)
+		if (step == SQLITE_BUSY || step == SQLITE_ERROR || step == SQLITE_MISUSE) {
 			return Error(pDB, pStmt);
-		else if (step == SQLITE_ROW) {
+		} else if (step == SQLITE_ROW) {
 			cd.code = sqlite3_column_int(pStmt, 0);
 			cd.ot = sqlite3_column_int(pStmt, 1);
 			cd.alias = sqlite3_column_int(pStmt, 2);
@@ -35,13 +36,16 @@ bool DataManager::ReadDB(sqlite3* pDB) {
 				auto it = extra_setcode.find(cd.code);
 				if (it != extra_setcode.end()) {
 					int len = it->second.size();
-					if (len > SIZE_SETCODE)
+					if (len > SIZE_SETCODE) {
 						len = SIZE_SETCODE;
-					if (len)
+}
+					if (len) {
 						std::memcpy(cd.setcode, it->second.data(), len * sizeof(uint16_t));
+}
 				}
-				else
+				else {
 					cd.set_setcode(setcode);
+}
 			}
 			cd.type = sqlite3_column_int(pStmt, 4);
 			cd.attack = sqlite3_column_int(pStmt, 5);
@@ -50,8 +54,9 @@ bool DataManager::ReadDB(sqlite3* pDB) {
 				cd.link_marker = cd.defense;
 				cd.defense = 0;
 			}
-			else
+			else {
 				cd.link_marker = 0;
+}
 			unsigned int level = sqlite3_column_int(pStmt, 7);
 			cd.level = level & 0xff;
 			cd.lscale = (level >> 24) & 0xff;
@@ -89,8 +94,9 @@ bool DataManager::LoadDB(const wchar_t* wfile) {
 #else
 	IReadFile* reader = FileSystem->createAndOpenFile(file);
 #endif
-	if(reader == nullptr)
+	if(reader == nullptr) {
 		return false;
+}
 	spmemvfs_db_t db;
 	spmembuffer_t* mem = (spmembuffer_t*)calloc(sizeof(spmembuffer_t), 1);
 	spmemvfs_env_init();
@@ -100,18 +106,20 @@ bool DataManager::LoadDB(const wchar_t* wfile) {
 	reader->drop();
 	(mem->data)[mem->total] = '\0';
 	bool ret{};
-	if (spmemvfs_open_db(&db, file, mem) != SQLITE_OK)
+	if (spmemvfs_open_db(&db, file, mem) != SQLITE_OK) {
 		ret = Error(db.handle);
-	else
+	} else {
 		ret = ReadDB(db.handle);
+}
 	spmemvfs_close_db(&db);
 	spmemvfs_env_fini();
 	return ret;
 }
 bool DataManager::LoadStrings(const char* file) {
 	FILE* fp = fopen(file, "r");
-	if(!fp)
+	if(!fp) {
 		return false;
+}
 	char linebuf[TEXT_LINE_SIZE]{};
 	while(fgets(linebuf, sizeof linebuf, fp)) {
 		ReadStringConfLine(linebuf);
@@ -123,8 +131,9 @@ bool DataManager::LoadStrings(irr::io::IReadFile* reader) {
 	char ch{};
 	std::string linebuf;
 	while (reader->read(&ch, 1)) {
-		if (ch == '\0')
+		if (ch == '\0') {
 			break;
+}
 		linebuf.push_back(ch);
 		if (ch == '\n' || linebuf.size() >= TEXT_LINE_SIZE - 1) {
 			ReadStringConfLine(linebuf.data());
@@ -135,32 +144,38 @@ bool DataManager::LoadStrings(irr::io::IReadFile* reader) {
 	return true;
 }
 void DataManager::ReadStringConfLine(const char* linebuf) {
-	if(linebuf[0] != '!')
+	if(linebuf[0] != '!') {
 		return;
+}
 	char strbuf[TEXT_LINE_SIZE]{};
 	int value{};
 	wchar_t strBuffer[4096]{};
-	if (sscanf(linebuf, "!%63s", strbuf) != 1)
+	if (sscanf(linebuf, "!%63s", strbuf) != 1) {
 		return;
+}
 	if(!std::strcmp(strbuf, "system")) {
-		if (sscanf(&linebuf[7], "%d %240[^\n]", &value, strbuf) != 2)
+		if (sscanf(&linebuf[7], "%d %240[^\n]", &value, strbuf) != 2) {
 			return;
+}
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_sysStrings[value] = strBuffer;
 	} else if(!std::strcmp(strbuf, "victory")) {
-		if (sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2)
+		if (sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2) {
 			return;
+}
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_victoryStrings[value] = strBuffer;
 	} else if(!std::strcmp(strbuf, "counter")) {
-		if (sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2)
+		if (sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2) {
 			return;
+}
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_counterStrings[value] = strBuffer;
 	} else if(!std::strcmp(strbuf, "setname")) {
 		//using tab for comment
-		if (sscanf(&linebuf[8], "%x %240[^\t\n]", &value, strbuf) != 2)
+		if (sscanf(&linebuf[8], "%x %240[^\t\n]", &value, strbuf) != 2) {
 			return;
+}
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
 		_setnameStrings[value] = strBuffer;
 	}
@@ -168,8 +183,9 @@ void DataManager::ReadStringConfLine(const char* linebuf) {
 bool DataManager::Error(sqlite3* pDB, sqlite3_stmt* pStmt) {
 	errmsg[0] = '\0';
 	std::strncat(errmsg, sqlite3_errmsg(pDB), sizeof errmsg - 1);
-	if(pStmt)
+	if(pStmt) {
 		sqlite3_finalize(pStmt);
+}
 	return false;
 }
 code_pointer DataManager::GetCodePointer(unsigned int code) const {
@@ -192,8 +208,9 @@ string_pointer DataManager::strings_end() const {
 }
 bool DataManager::GetData(unsigned int code, CardData* pData) const {
 	auto cdit = _datas.find(code);
-	if(cdit == _datas.end())
+	if(cdit == _datas.end()) {
 		return false;
+}
 	if (pData) {
 		*pData = cdit->second;
 	}
@@ -211,56 +228,68 @@ bool DataManager::GetString(unsigned int code, CardString* pStr) const {
 }
 const wchar_t* DataManager::GetName(unsigned int code) const {
 	auto csit = _strings.find(code);
-	if(csit == _strings.end())
+	if(csit == _strings.end()) {
 		return unknown_string;
-	if(!csit->second.name.empty())
+}
+	if(!csit->second.name.empty()) {
 		return csit->second.name.c_str();
+}
 	return unknown_string;
 }
 const wchar_t* DataManager::GetText(unsigned int code) const {
 	auto csit = _strings.find(code);
-	if(csit == _strings.end())
+	if(csit == _strings.end()) {
 		return unknown_string;
-	if(!csit->second.text.empty())
+}
+	if(!csit->second.text.empty()) {
 		return csit->second.text.c_str();
+}
 	return unknown_string;
 }
 const wchar_t* DataManager::GetDesc(unsigned int strCode) const {
-	if (strCode < (MIN_CARD_ID << 4))
+	if (strCode < (MIN_CARD_ID << 4)) {
 		return GetSysString(strCode);
+}
 	unsigned int code = (strCode >> 4) & 0x0fffffff;
 	unsigned int offset = strCode & 0xf;
 	auto csit = _strings.find(code);
-	if(csit == _strings.end())
+	if(csit == _strings.end()) {
 		return unknown_string;
-	if(!csit->second.desc[offset].empty())
+}
+	if(!csit->second.desc[offset].empty()) {
 		return csit->second.desc[offset].c_str();
+}
 	return unknown_string;
 }
 const wchar_t* DataManager::GetSysString(int code) const {
-	if (code < 0 || code > MAX_STRING_ID)
+	if (code < 0 || code > MAX_STRING_ID) {
 		return unknown_string;
+}
 	auto csit = _sysStrings.find(code);
-	if(csit == _sysStrings.end())
+	if(csit == _sysStrings.end()) {
 		return unknown_string;
+}
 	return csit->second.c_str();
 }
 const wchar_t* DataManager::GetVictoryString(int code) const {
 	auto csit = _victoryStrings.find(code);
-	if(csit == _victoryStrings.end())
+	if(csit == _victoryStrings.end()) {
 		return unknown_string;
+}
 	return csit->second.c_str();
 }
 const wchar_t* DataManager::GetCounterName(int code) const {
 	auto csit = _counterStrings.find(code);
-	if(csit == _counterStrings.end())
+	if(csit == _counterStrings.end()) {
 		return unknown_string;
+}
 	return csit->second.c_str();
 }
 const wchar_t* DataManager::GetSetName(int code) const {
 	auto csit = _setnameStrings.find(code);
-	if(csit == _setnameStrings.end())
+	if(csit == _setnameStrings.end()) {
 		return unknown_string;
+}
 	return csit->second.c_str();
 }
 std::vector<unsigned int> DataManager::GetSetCodes(std::wstring setname) const {
@@ -269,8 +298,9 @@ std::vector<unsigned int> DataManager::GetSetCodes(std::wstring setname) const {
 		auto xpos = csit->second.find_first_of(L'|');//setname|another setname or extra info
 		if(setname.size() < 2) {
 			if(csit->second.compare(0, xpos, setname) == 0
-				|| csit->second.compare(xpos + 1, csit->second.length(), setname) == 0)
+				|| csit->second.compare(xpos + 1, csit->second.length(), setname) == 0) {
 				matchingCodes.push_back(csit->first);
+}
 		} else {
 			if(csit->second.substr(0, xpos).find(setname) != std::wstring::npos
 				|| csit->second.substr(xpos + 1).find(setname) != std::wstring::npos) {
@@ -281,8 +311,9 @@ std::vector<unsigned int> DataManager::GetSetCodes(std::wstring setname) const {
 	return matchingCodes;
 }
 std::wstring DataManager::GetNumString(int num, bool bracket) const {
-	if(!bracket)
+	if(!bracket) {
 		return std::to_wstring(num);
+}
 	std::wstring numBuffer{ L"(" };
 	numBuffer.append(std::to_wstring(num));
 	numBuffer.push_back(L')');
@@ -290,12 +321,13 @@ std::wstring DataManager::GetNumString(int num, bool bracket) const {
 }
 const wchar_t* DataManager::FormatLocation(int location, int sequence) const {
 	if(location == LOCATION_SZONE) {
-		if(sequence < 5)
+		if(sequence < 5) {
 			return GetSysString(1003);
-		else if(sequence == 5)
+		} else if(sequence == 5) {
 			return GetSysString(1008);
-		else
+		} else {
 			return GetSysString(1009);
+}
 	}
 	int i = 1000;
 	int string_id = 0;
@@ -305,35 +337,40 @@ const wchar_t* DataManager::FormatLocation(int location, int sequence) const {
 			break;
 		}
 	}
-	if (string_id)
+	if (string_id) {
 		return GetSysString(string_id);
-	else
+	} else {
 		return unknown_string;
+}
 }
 std::wstring DataManager::FormatAttribute(unsigned int attribute) const {
 	std::wstring buffer;
 	for (int i = 0; i < ATTRIBUTES_COUNT; ++i) {
 		if (attribute & (0x1U << i)) {
-			if (!buffer.empty())
+			if (!buffer.empty()) {
 				buffer.push_back(L'|');
+}
 			buffer.append(GetSysString(1010 + i));
 		}
 	}
-	if (buffer.empty())
+	if (buffer.empty()) {
 		return std::wstring(unknown_string);
+}
 	return buffer;
 }
 std::wstring DataManager::FormatRace(unsigned int race) const {
 	std::wstring buffer;
 	for(int i = 0; i < RACES_COUNT; ++i) {
 		if(race & (0x1U << i)) {
-			if (!buffer.empty())
+			if (!buffer.empty()) {
 				buffer.push_back(L'|');
+}
 			buffer.append(GetSysString(1020 + i));
 		}
 	}
-	if (buffer.empty())
+	if (buffer.empty()) {
 		return std::wstring(unknown_string);
+}
 	return buffer;
 }
 std::wstring DataManager::FormatType(unsigned int type) const {
@@ -341,75 +378,96 @@ std::wstring DataManager::FormatType(unsigned int type) const {
 	int i = 1050;
 	for (unsigned filter = TYPE_MONSTER; filter <= TYPE_LINK; filter <<= 1, ++i) {
 		if (type & filter) {
-			if (!buffer.empty())
+			if (!buffer.empty()) {
 				buffer.push_back(L'|');
+}
 			buffer.append(GetSysString(i));
 		}
 	}
-	if (buffer.empty())
+	if (buffer.empty()) {
 		return std::wstring(unknown_string);
+}
 	return buffer;
 }
 std::wstring DataManager::FormatSetName(const uint16_t setcode[]) const {
 	std::wstring buffer;
 	for(int i = 0; i < 10; ++i) {
-		if (!setcode[i])
+		if (!setcode[i]) {
 			break;
+}
 		const wchar_t* setname = GetSetName(setcode[i]);
-		if (!buffer.empty())
+		if (!buffer.empty()) {
 			buffer.push_back(L'|');
+}
 		buffer.append(setname);
 	}
-	if (buffer.empty())
+	if (buffer.empty()) {
 		return std::wstring(unknown_string);
+}
 	return buffer;
 }
 std::wstring DataManager::FormatLinkMarker(unsigned int link_marker) const {
 	std::wstring buffer;
-	if (link_marker & LINK_MARKER_TOP_LEFT)
+	if (link_marker & LINK_MARKER_TOP_LEFT) {
 		buffer.append(L"[\u2196]");
-	if (link_marker & LINK_MARKER_TOP)
+}
+	if (link_marker & LINK_MARKER_TOP) {
 		buffer.append(L"[\u2191]");
-	if (link_marker & LINK_MARKER_TOP_RIGHT)
+}
+	if (link_marker & LINK_MARKER_TOP_RIGHT) {
 		buffer.append(L"[\u2197]");
-	if (link_marker & LINK_MARKER_LEFT)
+}
+	if (link_marker & LINK_MARKER_LEFT) {
 		buffer.append(L"[\u2190]");
-	if (link_marker & LINK_MARKER_RIGHT)
+}
+	if (link_marker & LINK_MARKER_RIGHT) {
 		buffer.append(L"[\u2192]");
-	if (link_marker & LINK_MARKER_BOTTOM_LEFT)
+}
+	if (link_marker & LINK_MARKER_BOTTOM_LEFT) {
 		buffer.append(L"[\u2199]");
-	if (link_marker & LINK_MARKER_BOTTOM)
+}
+	if (link_marker & LINK_MARKER_BOTTOM) {
 		buffer.append(L"[\u2193]");
-	if (link_marker & LINK_MARKER_BOTTOM_RIGHT)
+}
+	if (link_marker & LINK_MARKER_BOTTOM_RIGHT) {
 		buffer.append(L"[\u2198]");
+}
 	return buffer;
 }
 uint32_t DataManager::CardReader(uint32_t code, card_data* pData) {
-	if (!dataManager.GetData(code, pData))
+	if (!dataManager.GetData(code, pData)) {
 		pData->clear();
+}
 	return 0;
 }
 unsigned char* DataManager::ScriptReaderEx(const char* script_path, int* slen) {
 	// default script name: ./script/c%d.lua
-	if (std::strncmp(script_path, "./script", 8) != 0) // not a card script file
+	if (std::strncmp(script_path, "./script", 8) != 0) { // not a card script file
 		return ReadScriptFromFile(script_path, slen);
+}
 	const char* script_name = script_path + 2;
 	char expansions_path[1024]{};
 	std::snprintf(expansions_path, sizeof expansions_path, "./expansions/%s", script_name);
 	if (mainGame->gameConf.prefer_expansion_script) { // debug script with raw file in expansions
-		if (ReadScriptFromFile(expansions_path, slen))
+		if (ReadScriptFromFile(expansions_path, slen)) {
 			return scriptBuffer;
-		if (ReadScriptFromIrrFS(script_name, slen))
+}
+		if (ReadScriptFromIrrFS(script_name, slen)) {
 			return scriptBuffer;
-		if (ReadScriptFromFile(script_path, slen))
+}
+		if (ReadScriptFromFile(script_path, slen)) {
 			return scriptBuffer;
+}
 	} else {
-		if (ReadScriptFromIrrFS(script_name, slen))
+		if (ReadScriptFromIrrFS(script_name, slen)) {
 			return scriptBuffer;
-		if (ReadScriptFromFile(script_path, slen))
+}
+		if (ReadScriptFromFile(script_path, slen)) {
 			return scriptBuffer;
-		if (ReadScriptFromFile(expansions_path, slen))
+}
+		if (ReadScriptFromFile(expansions_path, slen)) {
 			return scriptBuffer;
+}
 	}
 
 	return nullptr;
@@ -422,12 +480,14 @@ unsigned char* DataManager::ReadScriptFromIrrFS(const char* script_name, int* sl
 #else
 	IReadFile* reader = FileSystem->createAndOpenFile(script_name);
 #endif
-	if (!reader)
+	if (!reader) {
 		return nullptr;
+}
 	int size = reader->read(scriptBuffer, sizeof scriptBuffer);
 	reader->drop();
-	if (size >= (int)sizeof scriptBuffer)
+	if (size >= (int)sizeof scriptBuffer) {
 		return nullptr;
+}
 	*slen = size;
 	return scriptBuffer;
 }
@@ -435,81 +495,102 @@ unsigned char* DataManager::ReadScriptFromFile(const char* script_name, int* sle
 	wchar_t fname[256]{};
 	BufferIO::DecodeUTF8(script_name, fname);
 	FILE* fp = myfopen(fname, "rb");
-	if (!fp)
+	if (!fp) {
 		return nullptr;
+}
 	size_t len = std::fread(scriptBuffer, 1, sizeof scriptBuffer, fp);
 	std::fclose(fp);
-	if (len >= sizeof scriptBuffer)
+	if (len >= sizeof scriptBuffer) {
 		return nullptr;
+}
 	*slen = (int)len;
 	return scriptBuffer;
 }
 bool DataManager::deck_sort_lv(code_pointer p1, code_pointer p2) {
-	if ((p1->second.type & 0x7) != (p2->second.type & 0x7))
+	if ((p1->second.type & 0x7) != (p2->second.type & 0x7)) {
 		return (p1->second.type & 0x7) < (p2->second.type & 0x7);
+}
 	if ((p1->second.type & 0x7) == 1) {
 		int type1 = (p1->second.type & 0x48020c0) ? (p1->second.type & 0x48020c1) : (p1->second.type & 0x31);
 		int type2 = (p2->second.type & 0x48020c0) ? (p2->second.type & 0x48020c1) : (p2->second.type & 0x31);
-		if (type1 != type2)
+		if (type1 != type2) {
 			return type1 < type2;
-		if (p1->second.level != p2->second.level)
+}
+		if (p1->second.level != p2->second.level) {
 			return p1->second.level > p2->second.level;
-		if (p1->second.attack != p2->second.attack)
+}
+		if (p1->second.attack != p2->second.attack) {
 			return p1->second.attack > p2->second.attack;
-		if (p1->second.defense != p2->second.defense)
+}
+		if (p1->second.defense != p2->second.defense) {
 			return p1->second.defense > p2->second.defense;
+}
 		return p1->first < p2->first;
 	}
-	if ((p1->second.type & 0xfffffff8) != (p2->second.type & 0xfffffff8))
+	if ((p1->second.type & 0xfffffff8) != (p2->second.type & 0xfffffff8)) {
 		return (p1->second.type & 0xfffffff8) < (p2->second.type & 0xfffffff8);
+}
 	return p1->first < p2->first;
 }
 bool DataManager::deck_sort_atk(code_pointer p1, code_pointer p2) {
-	if ((p1->second.type & 0x7) != (p2->second.type & 0x7))
+	if ((p1->second.type & 0x7) != (p2->second.type & 0x7)) {
 		return (p1->second.type & 0x7) < (p2->second.type & 0x7);
+}
 	if ((p1->second.type & 0x7) == 1) {
-		if (p1->second.attack != p2->second.attack)
+		if (p1->second.attack != p2->second.attack) {
 			return p1->second.attack > p2->second.attack;
-		if (p1->second.defense != p2->second.defense)
+}
+		if (p1->second.defense != p2->second.defense) {
 			return p1->second.defense > p2->second.defense;
-		if (p1->second.level != p2->second.level)
+}
+		if (p1->second.level != p2->second.level) {
 			return p1->second.level > p2->second.level;
+}
 		int type1 = (p1->second.type & 0x48020c0) ? (p1->second.type & 0x48020c1) : (p1->second.type & 0x31);
 		int type2 = (p2->second.type & 0x48020c0) ? (p2->second.type & 0x48020c1) : (p2->second.type & 0x31);
-		if (type1 != type2)
+		if (type1 != type2) {
 			return type1 < type2;
+}
 		return p1->first < p2->first;
 	}
-	if ((p1->second.type & 0xfffffff8) != (p2->second.type & 0xfffffff8))
+	if ((p1->second.type & 0xfffffff8) != (p2->second.type & 0xfffffff8)) {
 		return (p1->second.type & 0xfffffff8) < (p2->second.type & 0xfffffff8);
+}
 	return p1->first < p2->first;
 }
 bool DataManager::deck_sort_def(code_pointer p1, code_pointer p2) {
-	if ((p1->second.type & 0x7) != (p2->second.type & 0x7))
+	if ((p1->second.type & 0x7) != (p2->second.type & 0x7)) {
 		return (p1->second.type & 0x7) < (p2->second.type & 0x7);
+}
 	if ((p1->second.type & 0x7) == 1) {
-		if (p1->second.defense != p2->second.defense)
+		if (p1->second.defense != p2->second.defense) {
 			return p1->second.defense > p2->second.defense;
-		if (p1->second.attack != p2->second.attack)
+}
+		if (p1->second.attack != p2->second.attack) {
 			return p1->second.attack > p2->second.attack;
-		if (p1->second.level != p2->second.level)
+}
+		if (p1->second.level != p2->second.level) {
 			return p1->second.level > p2->second.level;
+}
 		int type1 = (p1->second.type & 0x48020c0) ? (p1->second.type & 0x48020c1) : (p1->second.type & 0x31);
 		int type2 = (p2->second.type & 0x48020c0) ? (p2->second.type & 0x48020c1) : (p2->second.type & 0x31);
-		if (type1 != type2)
+		if (type1 != type2) {
 			return type1 < type2;
+}
 		return p1->first < p2->first;
 	}
-	if ((p1->second.type & 0xfffffff8) != (p2->second.type & 0xfffffff8))
+	if ((p1->second.type & 0xfffffff8) != (p2->second.type & 0xfffffff8)) {
 		return (p1->second.type & 0xfffffff8) < (p2->second.type & 0xfffffff8);
+}
 	return p1->first < p2->first;
 }
 bool DataManager::deck_sort_name(code_pointer p1, code_pointer p2) {
 	const wchar_t* name1 = dataManager.GetName(p1->first);
 	const wchar_t* name2 = dataManager.GetName(p2->first);
 	int res = std::wcscmp(name1, name2);
-	if (res != 0)
+	if (res != 0) {
 		return res < 0;
+}
 	return p1->first < p2->first;
 }
 

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -16,7 +16,7 @@ DataManager::DataManager() : _datas(32768), _strings(32768) {
 bool DataManager::ReadDB(sqlite3* pDB) {
 	sqlite3_stmt* pStmt{};
 	const char* sql = "select * from datas,texts where datas.id=texts.id";
-	if (sqlite3_prepare_v2(pDB, sql, -1, &pStmt, 0) != SQLITE_OK)
+	if (sqlite3_prepare_v2(pDB, sql, -1, &pStmt, nullptr) != SQLITE_OK)
 		return Error(pDB);
 	wchar_t strBuffer[4096];
 	int step = 0;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -638,7 +638,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				}
 				mainGame->ClearCardInfo();
 				unsigned char deckbuf[1024];
-				auto pdeck = deckbuf;
+				auto *pdeck = deckbuf;
 				BufferIO::WriteInt32(pdeck, deckManager.current_deck.main.size() + deckManager.current_deck.extra.size());
 				BufferIO::WriteInt32(pdeck, deckManager.current_deck.side.size());
 				for(size_t i = 0; i < deckManager.current_deck.main.size(); ++i)

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -105,17 +105,21 @@ void DeckBuilder::Terminate() {
 	mainGame->scrPackCards->setVisible(false);
 	mainGame->scrPackCards->setPos(0);
 	int catesel = mainGame->cbDBCategory->getSelected();
-	if (catesel >= 0)
+	if (catesel >= 0) {
 		BufferIO::CopyWideString(mainGame->cbDBCategory->getItem(catesel), mainGame->gameConf.lastcategory);
+}
 	int decksel = mainGame->cbDBDecks->getSelected();
-	if (decksel >= 0)
+	if (decksel >= 0) {
 		BufferIO::CopyWideString(mainGame->cbDBDecks->getItem(decksel), mainGame->gameConf.lastdeck);
-	if(exit_on_return)
+}
+	if(exit_on_return) {
 		mainGame->device->closeDevice();
 }
+}
 bool DeckBuilder::OnEvent(const irr::SEvent& event) {
-	if(mainGame->dField.OnCommonEvent(event))
+	if(mainGame->dField.OnCommonEvent(event)) {
 		return false;
+}
 	switch(event.EventType) {
 	case irr::EET_GUI_EVENT: {
 		s32 id = event.GUIEvent.Caller->getID();
@@ -126,8 +130,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			(mainGame->wDeckManage->isVisible() && !(id >= WINDOW_DECK_MANAGE && id < COMBOBOX_LFLIST)))
 			&& event.GUIEvent.EventType != irr::gui::EGET_LISTBOX_CHANGED
 			&& event.GUIEvent.EventType != irr::gui::EGET_COMBO_BOX_CHANGED) {
-			if(mainGame->wDMQuery->isVisible())
+			if(mainGame->wDMQuery->isVisible()) {
 				mainGame->wDMQuery->getParent()->bringToFront(mainGame->wDMQuery);
+}
 			break;
 		}
 		switch(event.GUIEvent.EventType) {
@@ -161,8 +166,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_SAVE_DECK: {
 				int sel = mainGame->cbDBDecks->getSelected();
-				if(sel == -1)
+				if(sel == -1) {
 					break;
+}
 				wchar_t filepath[256];
 				deckManager.GetDeckFile(filepath, mainGame->cbDBCategory, mainGame->cbDBDecks);
 				if(deckManager.SaveDeck(deckManager.current_deck, filepath)) {
@@ -174,8 +180,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_SAVE_DECK_AS: {
 				const wchar_t* dname = mainGame->ebDeckname->getText();
-				if(*dname == 0)
+				if(*dname == 0) {
 					break;
+}
 				int sel = -1;
 				for(int i = 0; i < (int)mainGame->cbDBDecks->getItemCount(); ++i) {
 					if(!std::wcscmp(dname, mainGame->cbDBDecks->getItem(i))) {
@@ -183,9 +190,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 						break;
 					}
 				}
-				if(sel >= 0)
+				if(sel >= 0) {
 					mainGame->cbDBDecks->setSelected(sel);
-				else {
+				} else {
 					mainGame->cbDBDecks->addItem(dname);
 					mainGame->cbDBDecks->setSelected(mainGame->cbDBDecks->getItemCount() - 1);
 				}
@@ -212,8 +219,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_DELETE_DECK: {
 				int sel = mainGame->cbDBDecks->getSelected();
-				if(sel == -1)
+				if(sel == -1) {
 					break;
+}
 				mainGame->gMutex.lock();
 				wchar_t textBuffer[256];
 				myswprintf(textBuffer, L"%ls\n%ls", mainGame->cbDBDecks->getItem(sel), dataManager.GetSysString(1337));
@@ -242,8 +250,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_START_FILTER: {
 				StartFilter();
-				if(!mainGame->gameConf.separate_clear_button)
+				if(!mainGame->gameConf.separate_clear_button) {
 					ClearFilter();
+}
 				break;
 			}
 			case BUTTON_CLEAR_FILTER: {
@@ -253,9 +262,11 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			case BUTTON_CATEGORY_OK: {
 				filter_effect = 0;
 				long long filter = 0x1;
-				for(int i = 0; i < 32; ++i, filter <<= 1)
-					if(mainGame->chkCategory[i]->isChecked())
+				for(int i = 0; i < 32; ++i, filter <<= 1) {
+					if(mainGame->chkCategory[i]->isChecked()) {
 						filter_effect |= filter;
+}
+}
 				mainGame->btnEffectFilter->setPressed(filter_effect > 0);
 				mainGame->HideElement(mainGame->wCategories);
 				InstantSearch();
@@ -284,8 +295,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_RENAME_CATEGORY: {
-				if(mainGame->lstCategories->getSelected() < 4)
+				if(mainGame->lstCategories->getSelected() < 4) {
 					break;
+}
 				mainGame->gMutex.lock();
 				mainGame->stDMMessage->setText(dataManager.GetSysString(1469));
 				mainGame->ebDMName->setVisible(true);
@@ -341,11 +353,13 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				mainGame->cbDMCategory->setVisible(true);
 				mainGame->cbDMCategory->clear();
 				int catesel = mainGame->lstCategories->getSelected();
-				if(catesel != 2)
+				if(catesel != 2) {
 					mainGame->cbDMCategory->addItem(dataManager.GetSysString(1452));
+}
 				for(int i = 4; i < (int)mainGame->lstCategories->getItemCount(); i++) {
-					if(i != catesel)
+					if(i != catesel) {
 						mainGame->cbDMCategory->addItem(mainGame->lstCategories->getListItem(i));
+}
 				}
 				mainGame->PopupElement(mainGame->wDMQuery);
 				mainGame->gMutex.unlock();
@@ -358,11 +372,13 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				mainGame->cbDMCategory->setVisible(true);
 				mainGame->cbDMCategory->clear();
 				int catesel = mainGame->lstCategories->getSelected();
-				if(catesel != 2)
+				if(catesel != 2) {
 					mainGame->cbDMCategory->addItem(dataManager.GetSysString(1452));
+}
 				for(int i = 4; i < (int)mainGame->lstCategories->getItemCount(); i++) {
-					if(i != catesel)
+					if(i != catesel) {
 						mainGame->cbDMCategory->addItem(mainGame->lstCategories->getListItem(i));
+}
 				}
 				mainGame->PopupElement(mainGame->wDMQuery);
 				mainGame->gMutex.unlock();
@@ -641,12 +657,15 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				auto *pdeck = deckbuf;
 				BufferIO::WriteInt32(pdeck, deckManager.current_deck.main.size() + deckManager.current_deck.extra.size());
 				BufferIO::WriteInt32(pdeck, deckManager.current_deck.side.size());
-				for(size_t i = 0; i < deckManager.current_deck.main.size(); ++i)
+				for(size_t i = 0; i < deckManager.current_deck.main.size(); ++i) {
 					BufferIO::WriteInt32(pdeck, deckManager.current_deck.main[i]->first);
-				for(size_t i = 0; i < deckManager.current_deck.extra.size(); ++i)
+}
+				for(size_t i = 0; i < deckManager.current_deck.extra.size(); ++i) {
 					BufferIO::WriteInt32(pdeck, deckManager.current_deck.extra[i]->first);
-				for(size_t i = 0; i < deckManager.current_deck.side.size(); ++i)
+}
+				for(size_t i = 0; i < deckManager.current_deck.side.size(); ++i) {
 					BufferIO::WriteInt32(pdeck, deckManager.current_deck.side[i]->first);
+}
 				DuelClient::SendBufferToServer(CTOS_UPDATE_DECK, deckbuf, pdeck - deckbuf);
 				break;
 			}
@@ -679,8 +698,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_YES: {
 				mainGame->HideElement(mainGame->wQuery);
-				if(!mainGame->is_building || mainGame->is_siding)
+				if(!mainGame->is_building || mainGame->is_siding) {
 					break;
+}
 				if(prev_operation == BUTTON_CLEAR_DECK) {
 					deckManager.current_deck.main.clear();
 					deckManager.current_deck.extra.clear();
@@ -693,11 +713,13 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					if(deckManager.DeleteDeck(filepath)) {
 						mainGame->cbDBDecks->removeItem(sel);
 						int count = mainGame->cbDBDecks->getItemCount();
-						if(sel >= count)
+						if(sel >= count) {
 							sel = count - 1;
+}
 						mainGame->cbDBDecks->setSelected(sel);
-						if(sel != -1)
+						if(sel != -1) {
 							deckManager.LoadCurrentDeck(mainGame->cbDBCategory, mainGame->cbDBDecks);
+}
 						mainGame->stACMessage->setText(dataManager.GetSysString(1338));
 						mainGame->PopupElement(mainGame->wACMessage, 20);
 						prev_deck = sel;
@@ -736,22 +758,30 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_MARKERS_OK: {
 				filter_marks = 0;
-				if (mainGame->btnMark[0]->isPressed())
+				if (mainGame->btnMark[0]->isPressed()) {
 					filter_marks |= 0100;
-				if (mainGame->btnMark[1]->isPressed())
+}
+				if (mainGame->btnMark[1]->isPressed()) {
 					filter_marks |= 0200;
-				if (mainGame->btnMark[2]->isPressed())
+}
+				if (mainGame->btnMark[2]->isPressed()) {
 					filter_marks |= 0400;
-				if (mainGame->btnMark[3]->isPressed())
+}
+				if (mainGame->btnMark[3]->isPressed()) {
 					filter_marks |= 0010;
-				if (mainGame->btnMark[4]->isPressed())
+}
+				if (mainGame->btnMark[4]->isPressed()) {
 					filter_marks |= 0040;
-				if (mainGame->btnMark[5]->isPressed())
+}
+				if (mainGame->btnMark[5]->isPressed()) {
 					filter_marks |= 0001;
-				if (mainGame->btnMark[6]->isPressed())
+}
+				if (mainGame->btnMark[6]->isPressed()) {
 					filter_marks |= 0002;
-				if (mainGame->btnMark[7]->isPressed())
+}
+				if (mainGame->btnMark[7]->isPressed()) {
 					filter_marks |= 0004;
+}
 				mainGame->HideElement(mainGame->wLinkMarks);
 				mainGame->btnMarksFilter->setPressed(filter_marks > 0);
 				InstantSearch();
@@ -799,8 +829,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				if(catesel == 3) {
 					catesel = 2;
 					mainGame->cbDBCategory->setSelected(2);
-					if(prev_category == 2)
+					if(prev_category == 2) {
 						break;
+}
 				}
 				if(is_modified && !readonly && !mainGame->chkIgnoreDeckChanges->isChecked()) {
 					mainGame->gMutex.lock();
@@ -965,8 +996,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				if(catesel == 3) {
 					catesel = 2;
 					mainGame->lstCategories->setSelected(catesel);
-					if(prev_category == catesel)
+					if(prev_category == catesel) {
 						break;
+}
 				}
 				RefreshDeckList();
 				mainGame->lstDecks->setSelected(0);
@@ -981,8 +1013,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				}
 				int decksel = mainGame->lstDecks->getSelected();
 				mainGame->cbDBDecks->setSelected(decksel);
-				if(decksel == -1)
+				if(decksel == -1) {
 					break;
+}
 				wchar_t filepath[256];
 				wchar_t catepath[256];
 				deckManager.GetCategoryPath(catepath, mainGame->lstCategories->getSelected(), mainGame->lstCategories->getListItem(mainGame->lstCategories->getSelected()));
@@ -1003,23 +1036,29 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 		switch(event.MouseInput.Event) {
 		case irr::EMIE_LMOUSE_PRESSED_DOWN: {
 			irr::gui::IGUIElement* root = mainGame->env->getRootGUIElement();
-			if(root->getElementFromPoint(mouse_pos) != root)
+			if(root->getElementFromPoint(mouse_pos) != root) {
 				break;
-			if(havePopupWindow())
+}
+			if(havePopupWindow()) {
 				break;
-			if(hovered_pos == 0 || hovered_seq == -1)
+}
+			if(hovered_pos == 0 || hovered_seq == -1) {
 				break;
+}
 			click_pos = hovered_pos;
-			if(readonly)
+			if(readonly) {
 				break;
+}
 			dragx = event.MouseInput.X;
 			dragy = event.MouseInput.Y;
 			draging_pointer = dataManager.GetCodePointer(hovered_code);
-			if(draging_pointer == dataManager.datas_end())
+			if(draging_pointer == dataManager.datas_end()) {
 				break;
+}
 			if(hovered_pos == 4) {
-				if(!check_limit(draging_pointer))
+				if(!check_limit(draging_pointer)) {
 					break;
+}
 			}
 			is_starting_dragging = true;
 			break;
@@ -1031,25 +1070,28 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				ShowBigCard(mainGame->showingcode, 1);
 				break;
 			}
-			if(!is_draging)
+			if(!is_draging) {
 				break;
+}
 			soundManager.PlaySoundEffect(SOUND_CARD_DROP);
 			bool pushed = false;
-			if(hovered_pos == 1)
+			if(hovered_pos == 1) {
 				pushed = push_main(draging_pointer, hovered_seq);
-			else if(hovered_pos == 2)
+			} else if(hovered_pos == 2) {
 				pushed = push_extra(draging_pointer, hovered_seq + is_lastcard);
-			else if(hovered_pos == 3)
+			} else if(hovered_pos == 3) {
 				pushed = push_side(draging_pointer, hovered_seq + is_lastcard);
-			else if(hovered_pos == 4 && !mainGame->is_siding)
+			} else if(hovered_pos == 4 && !mainGame->is_siding) {
 				pushed = true;
+}
 			if(!pushed) {
-				if(click_pos == 1)
+				if(click_pos == 1) {
 					push_main(draging_pointer);
-				else if(click_pos == 2)
+				} else if(click_pos == 2) {
 					push_extra(draging_pointer);
-				else if(click_pos == 3)
+				} else if(click_pos == 3) {
 					push_side(draging_pointer);
+}
 			}
 			is_draging = false;
 			break;
@@ -1064,23 +1106,29 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 		}
 		case irr::EMIE_RMOUSE_LEFT_UP: {
 			if(mainGame->is_siding) {
-				if(is_draging)
+				if(is_draging) {
 					break;
-				if(hovered_pos == 0 || hovered_seq == -1)
+}
+				if(hovered_pos == 0 || hovered_seq == -1) {
 					break;
+}
 				auto pointer = dataManager.GetCodePointer(hovered_code);
-				if(pointer == dataManager.datas_end())
+				if(pointer == dataManager.datas_end()) {
 					break;
+}
 				soundManager.PlaySoundEffect(SOUND_CARD_DROP);
 				if(hovered_pos == 1) {
-					if(push_side(pointer))
+					if(push_side(pointer)) {
 						pop_main(hovered_seq);
+}
 				} else if(hovered_pos == 2) {
-					if(push_side(pointer))
+					if(push_side(pointer)) {
 						pop_extra(hovered_seq);
+}
 				} else {
-					if(push_extra(pointer) || push_main(pointer))
+					if(push_extra(pointer) || push_main(pointer)) {
 						pop_side(hovered_seq);
+}
 				}
 				break;
 			}
@@ -1088,13 +1136,16 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				CloseBigCard();
 				break;
 			}
-			if(havePopupWindow())
+			if(havePopupWindow()) {
 				break;
+}
 			if(!is_draging) {
-				if(hovered_pos == 0 || hovered_seq == -1)
+				if(hovered_pos == 0 || hovered_seq == -1) {
 					break;
-				if(readonly)
+}
+				if(readonly) {
 					break;
+}
 				soundManager.PlaySoundEffect(SOUND_CARD_DROP);
 				if(hovered_pos == 1) {
 					pop_main(hovered_seq);
@@ -1104,12 +1155,15 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					pop_side(hovered_seq);
 				} else {
 					auto pointer = dataManager.GetCodePointer(hovered_code);
-					if(pointer == dataManager.datas_end())
+					if(pointer == dataManager.datas_end()) {
 						break;
-					if(!check_limit(pointer))
+}
+					if(!check_limit(pointer)) {
 						break;
-					if(!push_extra(pointer) && !push_main(pointer))
+}
+					if(!push_extra(pointer) && !push_main(pointer)) {
 						push_side(pointer);
+}
 				}
 			} else {
 				soundManager.PlaySoundEffect(SOUND_CARD_PICK);
@@ -1118,8 +1172,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				} else if(click_pos == 2) {
 					push_side(draging_pointer);
 				} else if(click_pos == 3) {
-					if(!push_extra(draging_pointer))
+					if(!push_extra(draging_pointer)) {
 						push_main(draging_pointer);
+}
 				} else {
 					push_side(draging_pointer);
 				}
@@ -1128,34 +1183,45 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			break;
 		}
 		case irr::EMIE_MMOUSE_LEFT_UP: {
-			if (mainGame->is_siding)
+			if (mainGame->is_siding) {
 				break;
-			if (havePopupWindow())
+}
+			if (havePopupWindow()) {
 				break;
-			if (hovered_pos == 0 || hovered_seq == -1)
+}
+			if (hovered_pos == 0 || hovered_seq == -1) {
 				break;
-			if (readonly)
+}
+			if (readonly) {
 				break;
-			if (is_draging)
+}
+			if (is_draging) {
 				break;
+}
 			auto pointer = dataManager.GetCodePointer(hovered_code);
-			if (pointer == dataManager.datas_end())
+			if (pointer == dataManager.datas_end()) {
 				break;
-			if(!check_limit(pointer))
+}
+			if(!check_limit(pointer)) {
 				break;
+}
 			soundManager.PlaySoundEffect(SOUND_CARD_PICK);
 			if (hovered_pos == 1) {
-				if(!push_main(pointer))
+				if(!push_main(pointer)) {
 					push_side(pointer);
+}
 			} else if (hovered_pos == 2) {
-				if(!push_extra(pointer))
+				if(!push_extra(pointer)) {
 					push_side(pointer);
+}
 			} else if (hovered_pos == 3) {
-				if(!push_side(pointer) && !push_extra(pointer))
+				if(!push_side(pointer) && !push_extra(pointer)) {
 					push_main(pointer);
+}
 			} else {
-				if(!push_extra(pointer) && !push_main(pointer))
+				if(!push_extra(pointer) && !push_main(pointer)) {
 					push_side(pointer);
+}
 			}
 			break;
 		}
@@ -1163,12 +1229,13 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			if(is_starting_dragging) {
 				is_draging = true;
 				soundManager.PlaySoundEffect(SOUND_CARD_PICK);
-				if(hovered_pos == 1)
+				if(hovered_pos == 1) {
 					pop_main(hovered_seq);
-				else if(hovered_pos == 2)
+				} else if(hovered_pos == 2) {
 					pop_extra(hovered_seq);
-				else if(hovered_pos == 3)
+				} else if(hovered_pos == 3) {
 					pop_side(hovered_seq);
+}
 				is_starting_dragging = false;
 			}
 			mouse_pos.set(event.MouseInput.X, event.MouseInput.Y);
@@ -1182,18 +1249,23 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				ZoomBigCard(mouse_pos.X, mouse_pos.Y);
 				break;
 			}
-			if(!mainGame->scrFilter->isVisible())
+			if(!mainGame->scrFilter->isVisible()) {
 				break;
-			if(mainGame->env->hasFocus(mainGame->scrFilter))
+}
+			if(mainGame->env->hasFocus(mainGame->scrFilter)) {
 				break;
-			if(root->getElementFromPoint(mouse_pos) != root)
+}
+			if(root->getElementFromPoint(mouse_pos) != root) {
 				break;
+}
 			if(event.MouseInput.Wheel < 0) {
-				if(mainGame->scrFilter->getPos() < mainGame->scrFilter->getMax())
+				if(mainGame->scrFilter->getPos() < mainGame->scrFilter->getMax()) {
 					mainGame->scrFilter->setPos(mainGame->scrFilter->getPos() + 1);
+}
 			} else {
-				if(mainGame->scrFilter->getPos() > 0)
+				if(mainGame->scrFilter->getPos() > 0) {
 					mainGame->scrFilter->setPos(mainGame->scrFilter->getPos() - 1);
+}
 			}
 			GetHoveredCard();
 			break;
@@ -1214,8 +1286,9 @@ void DeckBuilder::GetHoveredCard() {
 	hovered_pos = 0;
 	hovered_code = 0;
 	irr::gui::IGUIElement* root = mainGame->env->getRootGUIElement();
-	if(root->getElementFromPoint(mouse_pos) != root)
+	if(root->getElementFromPoint(mouse_pos) != root) {
 		return;
+}
 	position2di pos = mainGame->ResizeReverse(mouse_pos.X, mouse_pos.Y);
 	int x = pos.X;
 	int y = pos.Y;
@@ -1226,19 +1299,23 @@ void DeckBuilder::GetHoveredCard() {
 				int mainsize = deckManager.current_deck.main.size();
 				int lx = 10;
 				int dy = 68;
-				if(mainsize > 10 * 7)
+				if(mainsize > 10 * 7) {
 					lx = 11;
-				if(mainsize > 11 * 7)
+}
+				if(mainsize > 11 * 7) {
 					lx = 12;
-				if(mainsize > 60)
+}
+				if(mainsize > 60) {
 					dy = 66;
+}
 				int px = 0;
 				int py = (y - 164) / dy;
 				hovered_pos = 1;
-				if(x >= 750)
+				if(x >= 750) {
 					px = lx - 1;
-				else
+				} else {
 					px = (x - 314) * (lx - 1) / (mainGame->scrPackCards->isVisible() ? 414.0f : 436.0f);
+}
 				hovered_seq = py * lx + px + mainGame->scrPackCards->getPos() * lx;
 				if(hovered_seq >= mainsize) {
 					hovered_seq = -1;
@@ -1250,12 +1327,14 @@ void DeckBuilder::GetHoveredCard() {
 		} else if(y >= 164 && y <= 435) {
 			int lx = 10, px = 0, py = (y - 164) / 68;
 			hovered_pos = 1;
-			if(deckManager.current_deck.main.size() > DECK_MIN_SIZE)
+			if(deckManager.current_deck.main.size() > DECK_MIN_SIZE) {
 				lx = (deckManager.current_deck.main.size() - 41) / 4 + 11;
-			if(x >= 750)
+}
+			if(x >= 750) {
 				px = lx - 1;
-			else
+			} else {
 				px = (x - 314) * (lx - 1) / 436;
+}
 			hovered_seq = py * lx + px;
 			if(hovered_seq >= (int)deckManager.current_deck.main.size()) {
 				hovered_seq = -1;
@@ -1266,36 +1345,42 @@ void DeckBuilder::GetHoveredCard() {
 		} else if(y >= 466 && y <= 530) {
 			int lx = deckManager.current_deck.extra.size();
 			hovered_pos = 2;
-			if(lx < 10)
+			if(lx < 10) {
 				lx = 10;
-			if(x >= 750)
+}
+			if(x >= 750) {
 				hovered_seq = lx - 1;
-			else
+			} else {
 				hovered_seq = (x - 314) * (lx - 1) / 436;
+}
 			if(hovered_seq >= (int)deckManager.current_deck.extra.size()) {
 				hovered_seq = -1;
 				hovered_code = 0;
 			} else {
 				hovered_code = deckManager.current_deck.extra[hovered_seq]->first;
-				if(x >= 772)
+				if(x >= 772) {
 					is_lastcard = 1;
+}
 			}
 		} else if (y >= 564 && y <= 628) {
 			int lx = deckManager.current_deck.side.size();
 			hovered_pos = 3;
-			if(lx < 10)
+			if(lx < 10) {
 				lx = 10;
-			if(x >= 750)
+}
+			if(x >= 750) {
 				hovered_seq = lx - 1;
-			else
+			} else {
 				hovered_seq = (x - 314) * (lx - 1) / 436;
+}
 			if(hovered_seq >= (int)deckManager.current_deck.side.size()) {
 				hovered_seq = -1;
 				hovered_code = 0;
 			} else {
 				hovered_code = deckManager.current_deck.side[hovered_seq]->first;
-				if(x >= 772)
+				if(x >= 772) {
 					is_lastcard = 1;
+}
 			}
 		}
 	} else if(x >= 810 && x <= 995 && y >= 165 && y <= 626) {
@@ -1314,10 +1399,12 @@ void DeckBuilder::GetHoveredCard() {
 		dragy = mouse_pos.Y;
 	}
 	if(!is_draging && pre_code != hovered_code) {
-		if(hovered_code)
+		if(hovered_code) {
 			mainGame->ShowCardInfo(hovered_code);
-		if(pre_code)
+}
+		if(pre_code) {
 			imageManager.RemoveTexture(pre_code);
+}
 	}
 }
 void DeckBuilder::StartFilter() {
@@ -1357,15 +1444,17 @@ void DeckBuilder::FilterCards() {
 		size_t element_start = 0;
 		for(;;) {
 			element_start = str.find_first_not_of(separator, element_start);
-			if(element_start == std::wstring::npos)
+			if(element_start == std::wstring::npos) {
 				break;
+}
 			element_t element;
 			if(str[element_start] == minussign) {
 				element.exclude = true;
 				element_start++;
 			}
-			if(element_start >= str.size())
+			if(element_start >= str.size()) {
 				break;
+}
 			if(str[element_start] == L'$') {
 				element.type = element_t::type_t::name;
 				element_start++;
@@ -1373,8 +1462,9 @@ void DeckBuilder::FilterCards() {
 				element.type = element_t::type_t::setcode;
 				element_start++;
 			}
-			if(element_start >= str.size())
+			if(element_start >= str.size()) {
 				break;
+}
 			wchar_t delimiter = separator;
 			if(str[element_start] == quotation) {
 				delimiter = quotation;
@@ -1384,12 +1474,14 @@ void DeckBuilder::FilterCards() {
 			if(element_end != std::wstring::npos) {
 				size_t length = element_end - element_start;
 				element.keyword = str.substr(element_start, length);
-			} else
+			} else {
 				element.keyword = str.substr(element_start);
+}
 			element.setcodes = dataManager.GetSetCodes(element.keyword);
 			query_elements.push_back(element);
-			if(element_end == std::wstring::npos)
+			if(element_end == std::wstring::npos) {
 				break;
+}
 			element_start = element_end + 1;
 		}
 	} else {
@@ -1411,79 +1503,100 @@ void DeckBuilder::FilterCards() {
 	for(code_pointer ptr = dataManager.datas_begin(); ptr != dataManager.datas_end(); ++ptr) {
 		const CardDataC& data = ptr->second;
 		auto strpointer = dataManager.GetStringPointer(ptr->first);
-		if (strpointer == dataManager.strings_end())
+		if (strpointer == dataManager.strings_end()) {
 			continue;
+}
 		const CardString& text = strpointer->second;
-		if(data.type & TYPE_TOKEN)
+		if(data.type & TYPE_TOKEN) {
 			continue;
+}
 		switch(filter_type) {
 		case 1: {
-			if(!(data.type & TYPE_MONSTER) || (data.type & filter_type2) != filter_type2)
+			if(!(data.type & TYPE_MONSTER) || (data.type & filter_type2) != filter_type2) {
 				continue;
-			if(filter_race && data.race != filter_race)
+}
+			if(filter_race && data.race != filter_race) {
 				continue;
-			if(filter_attrib && data.attribute != filter_attrib)
+}
+			if(filter_attrib && data.attribute != filter_attrib) {
 				continue;
+}
 			if(filter_atktype) {
 				if((filter_atktype == 1 && data.attack != filter_atk) || (filter_atktype == 2 && data.attack < filter_atk)
 				        || (filter_atktype == 3 && data.attack <= filter_atk) || (filter_atktype == 4 && (data.attack > filter_atk || data.attack < 0))
-				        || (filter_atktype == 5 && (data.attack >= filter_atk || data.attack < 0)) || (filter_atktype == 6 && data.attack != -2))
+				        || (filter_atktype == 5 && (data.attack >= filter_atk || data.attack < 0)) || (filter_atktype == 6 && data.attack != -2)) {
 					continue;
+}
 			}
 			if(filter_deftype) {
 				if((filter_deftype == 1 && data.defense != filter_def) || (filter_deftype == 2 && data.defense < filter_def)
 				        || (filter_deftype == 3 && data.defense <= filter_def) || (filter_deftype == 4 && (data.defense > filter_def || data.defense < 0))
 				        || (filter_deftype == 5 && (data.defense >= filter_def || data.defense < 0)) || (filter_deftype == 6 && data.defense != -2)
-				        || (data.type & TYPE_LINK))
+				        || (data.type & TYPE_LINK)) {
 					continue;
+}
 			}
 			if(filter_lvtype) {
 				if((filter_lvtype == 1 && data.level != filter_lv) || (filter_lvtype == 2 && data.level < filter_lv)
 				        || (filter_lvtype == 3 && data.level <= filter_lv) || (filter_lvtype == 4 && data.level > filter_lv)
-				        || (filter_lvtype == 5 && data.level >= filter_lv) || filter_lvtype == 6)
+				        || (filter_lvtype == 5 && data.level >= filter_lv) || filter_lvtype == 6) {
 					continue;
+}
 			}
 			if(filter_scltype) {
 				if((filter_scltype == 1 && data.lscale != filter_scl) || (filter_scltype == 2 && data.lscale < filter_scl)
 				        || (filter_scltype == 3 && data.lscale <= filter_scl) || (filter_scltype == 4 && (data.lscale > filter_scl))
 				        || (filter_scltype == 5 && (data.lscale >= filter_scl)) || filter_scltype == 6
-				        || !(data.type & TYPE_PENDULUM))
+				        || !(data.type & TYPE_PENDULUM)) {
 					continue;
+}
 			}
 			break;
 		}
 		case 2: {
-			if(!(data.type & TYPE_SPELL))
+			if(!(data.type & TYPE_SPELL)) {
 				continue;
-			if(filter_type2 && data.type != filter_type2)
+}
+			if(filter_type2 && data.type != filter_type2) {
 				continue;
+}
 			break;
 		}
 		case 3: {
-			if(!(data.type & TYPE_TRAP))
+			if(!(data.type & TYPE_TRAP)) {
 				continue;
-			if(filter_type2 && data.type != filter_type2)
+}
+			if(filter_type2 && data.type != filter_type2) {
 				continue;
+}
 			break;
 		}
 		}
-		if(filter_effect && !(data.category & filter_effect))
+		if(filter_effect && !(data.category & filter_effect)) {
 			continue;
-		if(filter_marks && (data.link_marker & filter_marks) != filter_marks)
+}
+		if(filter_marks && (data.link_marker & filter_marks) != filter_marks) {
 			continue;
+}
 		if(filter_lm) {
-			if(filter_lm <= 3 && (!filterList->count(ptr->first) || (*filterList).at(ptr->first) != filter_lm - 1))
+			if(filter_lm <= 3 && (!filterList->count(ptr->first) || (*filterList).at(ptr->first) != filter_lm - 1)) {
 				continue;
-			if(filter_lm == 4 && !(data.ot & AVAIL_OCG))
+}
+			if(filter_lm == 4 && !(data.ot & AVAIL_OCG)) {
 				continue;
-			if(filter_lm == 5 && !(data.ot & AVAIL_TCG))
+}
+			if(filter_lm == 5 && !(data.ot & AVAIL_TCG)) {
 				continue;
-			if(filter_lm == 6 && !(data.ot & AVAIL_SC))
+}
+			if(filter_lm == 6 && !(data.ot & AVAIL_SC)) {
 				continue;
-			if(filter_lm == 7 && !(data.ot & AVAIL_CUSTOM))
+}
+			if(filter_lm == 7 && !(data.ot & AVAIL_CUSTOM)) {
 				continue;
-			if(filter_lm == 8 && ((data.ot & AVAIL_OCGTCG) != AVAIL_OCGTCG))
+}
+			if(filter_lm == 8 && ((data.ot & AVAIL_OCGTCG) != AVAIL_OCGTCG)) {
 				continue;
+}
 		}
 		bool is_target = true;
 		for (auto elements_iterator = query_elements.begin(); elements_iterator != query_elements.end(); ++elements_iterator) {
@@ -1499,17 +1612,19 @@ void DeckBuilder::FilterCards() {
 					|| text.text.find(elements_iterator->keyword) != std::wstring::npos
 					|| data.is_setcodes(elements_iterator->setcodes);
 			}
-			if(elements_iterator->exclude)
+			if(elements_iterator->exclude) {
 				match = !match;
+}
 			if(!match) {
 				is_target = false;
 				break;
 			}
 		}
-		if(is_target)
+		if(is_target) {
 			results.push_back(ptr);
-		else
+		} else {
 			continue;
+}
 	}
 	myswprintf(result_string, L"%d", results.size());
 	if(results.size() > 7) {
@@ -1523,8 +1638,9 @@ void DeckBuilder::FilterCards() {
 	SortList();
 }
 void DeckBuilder::InstantSearch() {
-	if(mainGame->gameConf.auto_search_limit >= 0 && ((int)std::wcslen(mainGame->ebCardName->getText()) >= mainGame->gameConf.auto_search_limit))
+	if(mainGame->gameConf.auto_search_limit >= 0 && ((int)std::wcslen(mainGame->ebCardName->getText()) >= mainGame->gameConf.auto_search_limit)) {
 		StartFilter();
+}
 }
 void DeckBuilder::ClearSearch() {
 	mainGame->cbCardType->setSelected(0);
@@ -1552,11 +1668,13 @@ void DeckBuilder::ClearFilter() {
 	mainGame->ebStar->setText(L"");
 	mainGame->ebScale->setText(L"");
 	filter_effect = 0;
-	for(int i = 0; i < 32; ++i)
+	for(int i = 0; i < 32; ++i) {
 		mainGame->chkCategory[i]->setChecked(false);
+}
 	filter_marks = 0;
-	for(int i = 0; i < 8; i++)
+	for(int i = 0; i < 8; i++) {
 		mainGame->btnMark[i]->setPressed(false);
+}
 	mainGame->btnEffectFilter->setPressed(false);
 	mainGame->btnMarksFilter->setPressed(false);
 }
@@ -1678,10 +1796,12 @@ void DeckBuilder::ShowBigCard(int code, float zoom) {
 	mainGame->gMutex.unlock();
 }
 void DeckBuilder::ZoomBigCard(s32 centerx, s32 centery) {
-	if(bigcard_zoom >= 4)
+	if(bigcard_zoom >= 4) {
 		bigcard_zoom = 4;
-	if(bigcard_zoom <= 0.2f)
+}
+	if(bigcard_zoom <= 0.2f) {
 		bigcard_zoom = 0.2f;
+}
 	ITexture* img = imageManager.GetBigPicture(bigcard_code, bigcard_zoom);
 	mainGame->imgBigCard->setImage(img);
 	auto size = img->getSize();
@@ -1751,31 +1871,37 @@ bool DeckBuilder::CardNameContains(const wchar_t* haystack, const wchar_t* needl
 	return false;
 }
 bool DeckBuilder::push_main(code_pointer pointer, int seq) {
-	if(pointer->second.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK))
+	if(pointer->second.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK)) {
 		return false;
+}
 	auto& container = deckManager.current_deck.main;
 	int maxc = mainGame->is_siding ? DECK_MAX_SIZE + 5 : DECK_MAX_SIZE;
-	if((int)container.size() >= maxc)
+	if((int)container.size() >= maxc) {
 		return false;
-	if(seq >= 0 && seq < (int)container.size())
+}
+	if(seq >= 0 && seq < (int)container.size()) {
 		container.insert(container.begin() + seq, pointer);
-	else
+	} else {
 		container.push_back(pointer);
+}
 	is_modified = true;
 	GetHoveredCard();
 	return true;
 }
 bool DeckBuilder::push_extra(code_pointer pointer, int seq) {
-	if(!(pointer->second.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK)))
+	if(!(pointer->second.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK))) {
 		return false;
+}
 	auto& container = deckManager.current_deck.extra;
 	int maxc = mainGame->is_siding ? EXTRA_MAX_SIZE + 5 : EXTRA_MAX_SIZE;
-	if((int)container.size() >= maxc)
+	if((int)container.size() >= maxc) {
 		return false;
-	if(seq >= 0 && seq < (int)container.size())
+}
+	if(seq >= 0 && seq < (int)container.size()) {
 		container.insert(container.begin() + seq, pointer);
-	else
+	} else {
 		container.push_back(pointer);
+}
 	is_modified = true;
 	GetHoveredCard();
 	return true;
@@ -1783,12 +1909,14 @@ bool DeckBuilder::push_extra(code_pointer pointer, int seq) {
 bool DeckBuilder::push_side(code_pointer pointer, int seq) {
 	auto& container = deckManager.current_deck.side;
 	int maxc = mainGame->is_siding ? SIDE_MAX_SIZE + 5 : SIDE_MAX_SIZE;
-	if((int)container.size() >= maxc)
+	if((int)container.size() >= maxc) {
 		return false;
-	if(seq >= 0 && seq < (int)container.size())
+}
+	if(seq >= 0 && seq < (int)container.size()) {
 		container.insert(container.begin() + seq, pointer);
-	else
+	} else {
 		container.push_back(pointer);
+}
 	is_modified = true;
 	GetHoveredCard();
 	return true;
@@ -1815,19 +1943,23 @@ bool DeckBuilder::check_limit(code_pointer pointer) {
 	unsigned int limitcode = pointer->second.alias ? pointer->second.alias : pointer->first;
 	int limit = 3;
 	auto flit = filterList->find(limitcode);
-	if(flit != filterList->end())
+	if(flit != filterList->end()) {
 		limit = flit->second;
+}
 	for(auto it = deckManager.current_deck.main.begin(); it != deckManager.current_deck.main.end(); ++it) {
-		if((*it)->first == limitcode || (*it)->second.alias == limitcode)
+		if((*it)->first == limitcode || (*it)->second.alias == limitcode) {
 			limit--;
+}
 	}
 	for(auto it = deckManager.current_deck.extra.begin(); it != deckManager.current_deck.extra.end(); ++it) {
-		if((*it)->first == limitcode || (*it)->second.alias == limitcode)
+		if((*it)->first == limitcode || (*it)->second.alias == limitcode) {
 			limit--;
+}
 	}
 	for(auto it = deckManager.current_deck.side.begin(); it != deckManager.current_deck.side.end(); ++it) {
-		if((*it)->first == limitcode || (*it)->second.alias == limitcode)
+		if((*it)->first == limitcode || (*it)->second.alias == limitcode) {
 			limit--;
+}
 	}
 	return limit > 0;
 }

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -924,13 +924,13 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					break;
 				}
 				}
-				mainGame->env->setFocus(0);
+				mainGame->env->setFocus(nullptr);
 				InstantSearch();
 				break;
 			}
 			case COMBOBOX_SORTTYPE: {
 				SortList();
-				mainGame->env->setFocus(0);
+				mainGame->env->setFocus(nullptr);
 				break;
 			}
 			case COMBOBOX_SECONDTYPE: {
@@ -942,14 +942,14 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 						mainGame->ebDefense->setEnabled(true);
 					}
 				}
-				mainGame->env->setFocus(0);
+				mainGame->env->setFocus(nullptr);
 				InstantSearch();
 				break;
 			}
 			case COMBOBOX_ATTRIBUTE:
 			case COMBOBOX_RACE:
 			case COMBOBOX_LIMIT:
-				mainGame->env->setFocus(0);
+				mainGame->env->setFocus(nullptr);
 				InstantSearch();
 				break;
 			}

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1232,7 +1232,7 @@ void DeckBuilder::GetHoveredCard() {
 					lx = 12;
 				if(mainsize > 60)
 					dy = 66;
-				int px;
+				int px = 0;
 				int py = (y - 164) / dy;
 				hovered_pos = 1;
 				if(x >= 750)
@@ -1248,7 +1248,7 @@ void DeckBuilder::GetHoveredCard() {
 				}
 			}
 		} else if(y >= 164 && y <= 435) {
-			int lx = 10, px, py = (y - 164) / 68;
+			int lx = 10, px = 0, py = (y - 164) / 68;
 			hovered_pos = 1;
 			if(deckManager.current_deck.main.size() > DECK_MIN_SIZE)
 				lx = (deckManager.current_deck.main.size() - 41) / 4 + 11;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -87,7 +87,7 @@ unsigned int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 		return (DECKERROR_EXTRACOUNT << 28) | (unsigned)deck.extra.size();
 	if(deck.side.size() > SIDE_MAX_SIZE)
 		return (DECKERROR_SIDECOUNT << 28) | (unsigned)deck.side.size();
-	auto list = GetLFListContent(lfhash);
+	const auto *list = GetLFListContent(lfhash);
 	if (!list)
 		return 0;
 	const unsigned int rule_map[6] = { AVAIL_OCG, AVAIL_TCG, AVAIL_SC, AVAIL_CUSTOM, AVAIL_OCGTCG, 0 };
@@ -268,7 +268,7 @@ FILE* DeckManager::OpenDeckFile(const wchar_t* file, const char* mode) {
 }
 irr::io::IReadFile* DeckManager::OpenDeckReader(const wchar_t* file) {
 #ifdef _WIN32
-	auto reader = DataManager::FileSystem->createAndOpenFile(file);
+	auto *reader = DataManager::FileSystem->createAndOpenFile(file);
 #else
 	char file2[256];
 	BufferIO::EncodeUTF8(file, file2);

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -15,8 +15,9 @@ void DeckManager::LoadLFListSingle(const char* path) {
 	wchar_t strBuffer[256]{};
 	if(fp) {
 		while(fgets(linebuf, 256, fp)) {
-			if(linebuf[0] == '#')
+			if(linebuf[0] == '#') {
 				continue;
+}
 			if(linebuf[0] == '!') {
 				auto len = std::strcspn(linebuf, "\r\n");
 				linebuf[len] = 0;
@@ -30,14 +31,18 @@ void DeckManager::LoadLFListSingle(const char* path) {
 			}
 			int code = 0;
 			int count = -1;
-			if (sscanf(linebuf, "%d %d", &code, &count) != 2)
+			if (sscanf(linebuf, "%d %d", &code, &count) != 2) {
 				continue;
-			if (code <= 0 || code > MAX_CARD_ID)
+}
+			if (code <= 0 || code > MAX_CARD_ID) {
 				continue;
-			if (count < 0 || count > 2)
+}
+			if (count < 0 || count > 2) {
 				continue;
-			if (cur == _lfList.rend())
+}
+			if (cur == _lfList.rend()) {
 				continue;
+}
 			unsigned int hcode = code;
 			cur->content[code] = count;
 			cur->hash = cur->hash ^ ((hcode << 18) | (hcode >> 14)) ^ ((hcode << (27 + count)) | (hcode >> (5 - count)));
@@ -57,87 +62,109 @@ const wchar_t* DeckManager::GetLFListName(int lfhash) {
 	auto lit = std::find_if(_lfList.begin(), _lfList.end(), [lfhash](const ygo::LFList& list) {
 		return list.hash == lfhash;
 	});
-	if(lit != _lfList.end())
+	if(lit != _lfList.end()) {
 		return lit->listName.c_str();
+}
 	return dataManager.unknown_string;
 }
 const std::unordered_map<int, int>* DeckManager::GetLFListContent(int lfhash) {
 	auto lit = std::find_if(_lfList.begin(), _lfList.end(), [lfhash](const ygo::LFList& list) {
 		return list.hash == lfhash;
 	});
-	if(lit != _lfList.end())
+	if(lit != _lfList.end()) {
 		return &lit->content;
+}
 	return nullptr;
 }
 static unsigned int checkAvail(unsigned int ot, unsigned int avail) {
-	if((ot & avail) == avail)
+	if((ot & avail) == avail) {
 		return 0;
-	if((ot & AVAIL_OCG) && (avail != AVAIL_OCG))
+}
+	if((ot & AVAIL_OCG) && (avail != AVAIL_OCG)) {
 		return DECKERROR_OCGONLY;
-	if((ot & AVAIL_TCG) && (avail != AVAIL_TCG))
+}
+	if((ot & AVAIL_TCG) && (avail != AVAIL_TCG)) {
 		return DECKERROR_TCGONLY;
+}
 	return DECKERROR_NOTAVAIL;
 }
 unsigned int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 	std::unordered_map<int, int> ccount;
 	// rule
-	if(deck.main.size() < DECK_MIN_SIZE || deck.main.size() > DECK_MAX_SIZE)
+	if(deck.main.size() < DECK_MIN_SIZE || deck.main.size() > DECK_MAX_SIZE) {
 		return (DECKERROR_MAINCOUNT << 28) | (unsigned)deck.main.size();
-	if(deck.extra.size() > EXTRA_MAX_SIZE)
+}
+	if(deck.extra.size() > EXTRA_MAX_SIZE) {
 		return (DECKERROR_EXTRACOUNT << 28) | (unsigned)deck.extra.size();
-	if(deck.side.size() > SIDE_MAX_SIZE)
+}
+	if(deck.side.size() > SIDE_MAX_SIZE) {
 		return (DECKERROR_SIDECOUNT << 28) | (unsigned)deck.side.size();
+}
 	const auto *list = GetLFListContent(lfhash);
-	if (!list)
+	if (!list) {
 		return 0;
+}
 	const unsigned int rule_map[6] = { AVAIL_OCG, AVAIL_TCG, AVAIL_SC, AVAIL_CUSTOM, AVAIL_OCGTCG, 0 };
 	unsigned int avail = 0;
-	if (rule >= 0 && rule < (int)(sizeof rule_map / sizeof rule_map[0]))
+	if (rule >= 0 && rule < (int)(sizeof rule_map / sizeof rule_map[0])) {
 		avail = rule_map[rule];
+}
 	for (auto& cit : deck.main) {
 		auto gameruleDeckError = checkAvail(cit->second.ot, avail);
-		if(gameruleDeckError)
+		if(gameruleDeckError) {
 			return (gameruleDeckError << 28) | cit->first;
-		if (cit->second.type & (TYPES_EXTRA_DECK | TYPE_TOKEN))
+}
+		if (cit->second.type & (TYPES_EXTRA_DECK | TYPE_TOKEN)) {
 			return (DECKERROR_MAINCOUNT << 28);
+}
 		int code = cit->second.alias ? cit->second.alias : cit->first;
 		ccount[code]++;
 		int dc = ccount[code];
-		if(dc > 3)
+		if(dc > 3) {
 			return (DECKERROR_CARDCOUNT << 28) | cit->first;
+}
 		auto it = list->find(code);
-		if(it != list->end() && dc > it->second)
+		if(it != list->end() && dc > it->second) {
 			return (DECKERROR_LFLIST << 28) | cit->first;
+}
 	}
 	for (auto& cit : deck.extra) {
 		auto gameruleDeckError = checkAvail(cit->second.ot, avail);
-		if(gameruleDeckError)
+		if(gameruleDeckError) {
 			return (gameruleDeckError << 28) | cit->first;
-		if (!(cit->second.type & TYPES_EXTRA_DECK) || cit->second.type & TYPE_TOKEN)
+}
+		if (!(cit->second.type & TYPES_EXTRA_DECK) || cit->second.type & TYPE_TOKEN) {
 			return (DECKERROR_EXTRACOUNT << 28);
+}
 		int code = cit->second.alias ? cit->second.alias : cit->first;
 		ccount[code]++;
 		int dc = ccount[code];
-		if(dc > 3)
+		if(dc > 3) {
 			return (DECKERROR_CARDCOUNT << 28) | cit->first;
+}
 		auto it = list->find(code);
-		if(it != list->end() && dc > it->second)
+		if(it != list->end() && dc > it->second) {
 			return (DECKERROR_LFLIST << 28) | cit->first;
+}
 	}
 	for (auto& cit : deck.side) {
 		auto gameruleDeckError = checkAvail(cit->second.ot, avail);
-		if(gameruleDeckError)
+		if(gameruleDeckError) {
 			return (gameruleDeckError << 28) | cit->first;
-		if (cit->second.type & TYPE_TOKEN)
+}
+		if (cit->second.type & TYPE_TOKEN) {
 			return (DECKERROR_SIDECOUNT << 28);
+}
 		int code = cit->second.alias ? cit->second.alias : cit->first;
 		ccount[code]++;
 		int dc = ccount[code];
-		if(dc > 3)
+		if(dc > 3) {
 			return (DECKERROR_CARDCOUNT << 28) | cit->first;
+}
 		auto it = list->find(code);
-		if(it != list->end() && dc > it->second)
+		if(it != list->end() && dc > it->second) {
 			return (DECKERROR_LFLIST << 28) | cit->first;
+}
 	}
 	return 0;
 }
@@ -161,12 +188,14 @@ int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_p
 			continue;
 		}
 		if (cd.type & TYPES_EXTRA_DECK) {
-			if (deck.extra.size() < EXTRA_MAX_SIZE)
+			if (deck.extra.size() < EXTRA_MAX_SIZE) {
 				deck.extra.push_back(dataManager.GetCodePointer(code));
+}
 		}
 		else {
-			if (deck.main.size() < DECK_MAX_SIZE)
+			if (deck.main.size() < DECK_MAX_SIZE) {
 				deck.main.push_back(dataManager.GetCodePointer(code));
+}
 		}
 	}
 	for(int i = 0; i < sidec; ++i) {
@@ -179,8 +208,9 @@ int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_p
 			errorcode = code;
 			continue;
 		}
-		if(deck.side.size() < SIDE_MAX_SIZE)
+		if(deck.side.size() < SIDE_MAX_SIZE) {
 			deck.side.push_back(dataManager.GetCodePointer(code));
+}
 	}
 	return errorcode;
 }
@@ -194,39 +224,50 @@ int DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_pa
 			is_side = true;
 			continue;
 		}
-		if (linebuf[0] < '0' || linebuf[0] > '9')
+		if (linebuf[0] < '0' || linebuf[0] > '9') {
 			continue;
+}
 		code = std::stoi(linebuf);
 		cardlist[ct++] = code;
-		if (is_side)
+		if (is_side) {
 			++sidec;
-		else
+		} else {
 			++mainc;
+}
 	}
 	return LoadDeck(current_deck, cardlist, mainc, sidec, is_packlist);
 }
 bool DeckManager::LoadSide(Deck& deck, int* dbuf, int mainc, int sidec) {
 	std::unordered_map<int, int> pcount;
 	std::unordered_map<int, int> ncount;
-	for(size_t i = 0; i < deck.main.size(); ++i)
+	for(size_t i = 0; i < deck.main.size(); ++i) {
 		++pcount[deck.main[i]->first];
-	for(size_t i = 0; i < deck.extra.size(); ++i)
+}
+	for(size_t i = 0; i < deck.extra.size(); ++i) {
 		++pcount[deck.extra[i]->first];
-	for(size_t i = 0; i < deck.side.size(); ++i)
+}
+	for(size_t i = 0; i < deck.side.size(); ++i) {
 		++pcount[deck.side[i]->first];
+}
 	Deck ndeck;
 	LoadDeck(ndeck, dbuf, mainc, sidec);
-	if (ndeck.main.size() != deck.main.size() || ndeck.extra.size() != deck.extra.size() || ndeck.side.size() != deck.side.size())
+	if (ndeck.main.size() != deck.main.size() || ndeck.extra.size() != deck.extra.size() || ndeck.side.size() != deck.side.size()) {
 		return false;
-	for(size_t i = 0; i < ndeck.main.size(); ++i)
+}
+	for(size_t i = 0; i < ndeck.main.size(); ++i) {
 		++ncount[ndeck.main[i]->first];
-	for(size_t i = 0; i < ndeck.extra.size(); ++i)
+}
+	for(size_t i = 0; i < ndeck.extra.size(); ++i) {
 		++ncount[ndeck.extra[i]->first];
-	for(size_t i = 0; i < ndeck.side.size(); ++i)
+}
+	for(size_t i = 0; i < ndeck.side.size(); ++i) {
 		++ncount[ndeck.side[i]->first];
-	for (auto& cdit : ncount)
-		if (cdit.second != pcount[cdit.first])
+}
+	for (auto& cdit : ncount) {
+		if (cdit.second != pcount[cdit.first]) {
 			return false;
+}
+}
 	deck = ndeck;
 	return true;
 }
@@ -289,8 +330,9 @@ bool DeckManager::LoadCurrentDeck(const wchar_t* file, bool is_packlist) {
 		myswprintf(zipfile, L"%ls", file + 2);
 		reader = OpenDeckReader(zipfile);
 	}
-	if(!reader)
+	if(!reader) {
 		return false;
+}
 	std::memset(deckBuffer, 0, sizeof deckBuffer);
 	int size = reader->read(deckBuffer, sizeof deckBuffer);
 	reader->drop();
@@ -306,25 +348,31 @@ bool DeckManager::LoadCurrentDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::
 	GetDeckFile(filepath, cbCategory, cbDeck);
 	bool is_packlist = cbCategory->getSelected() == 0;
 	bool res = LoadCurrentDeck(filepath, is_packlist);
-	if (res && mainGame->is_building)
+	if (res && mainGame->is_building) {
 		mainGame->deckBuilder.RefreshPackListScroll();
+}
 	return res;
 }
 bool DeckManager::SaveDeck(Deck& deck, const wchar_t* file) {
-	if(!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck"))
+	if(!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck")) {
 		return false;
+}
 	FILE* fp = OpenDeckFile(file, "w");
-	if(!fp)
+	if(!fp) {
 		return false;
+}
 	fprintf(fp, "#created by ...\n#main\n");
-	for(size_t i = 0; i < deck.main.size(); ++i)
+	for(size_t i = 0; i < deck.main.size(); ++i) {
 		fprintf(fp, "%d\n", deck.main[i]->first);
+}
 	fprintf(fp, "#extra\n");
-	for(size_t i = 0; i < deck.extra.size(); ++i)
+	for(size_t i = 0; i < deck.extra.size(); ++i) {
 		fprintf(fp, "%d\n", deck.extra[i]->first);
+}
 	fprintf(fp, "!side\n");
-	for(size_t i = 0; i < deck.side.size(); ++i)
+	for(size_t i = 0; i < deck.side.size(); ++i) {
 		fprintf(fp, "%d\n", deck.side[i]->first);
+}
 	fclose(fp);
 	return true;
 }
@@ -340,19 +388,23 @@ bool DeckManager::DeleteDeck(const wchar_t* file) {
 #endif
 }
 bool DeckManager::CreateCategory(const wchar_t* name) {
-	if(!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck"))
+	if(!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck")) {
 		return false;
-	if(name[0] == 0)
+}
+	if(name[0] == 0) {
 		return false;
+}
 	wchar_t localname[256];
 	myswprintf(localname, L"./deck/%ls", name);
 	return FileSystem::MakeDir(localname);
 }
 bool DeckManager::RenameCategory(const wchar_t* oldname, const wchar_t* newname) {
-	if(!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck"))
+	if(!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck")) {
 		return false;
-	if(newname[0] == 0)
+}
+	if(newname[0] == 0) {
 		return false;
+}
 	wchar_t oldlocalname[256];
 	wchar_t newlocalname[256];
 	myswprintf(oldlocalname, L"./deck/%ls", oldname);
@@ -362,16 +414,19 @@ bool DeckManager::RenameCategory(const wchar_t* oldname, const wchar_t* newname)
 bool DeckManager::DeleteCategory(const wchar_t* name) {
 	wchar_t localname[256];
 	myswprintf(localname, L"./deck/%ls", name);
-	if(!FileSystem::IsDirExists(localname))
+	if(!FileSystem::IsDirExists(localname)) {
 		return false;
+}
 	return FileSystem::DeleteDir(localname);
 }
 bool DeckManager::SaveDeckBuffer(const int deckbuf[], const wchar_t* name) {
-	if (!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck"))
+	if (!FileSystem::IsDirExists(L"./deck") && !FileSystem::MakeDir(L"./deck")) {
 		return false;
+}
 	FILE* fp = OpenDeckFile(name, "w");
-	if (!fp)
+	if (!fp) {
 		return false;
+}
 	int it = 0;
 	const int mainc = deckbuf[it];
 	++it;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -143,7 +143,7 @@ unsigned int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 }
 int DeckManager::LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_packlist) {
 	deck.clear();
-	int code;
+	int code = 0;
 	int errorcode = 0;
 	CardData cd;
 	for(int i = 0; i < mainc; ++i) {

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -186,7 +186,7 @@ void Game::DrawBackGround() {
 	if (dField.hovered_location != 0 && dField.hovered_location != 2 && dField.hovered_location != POSITION_HINT
 		&& !(dInfo.duel_rule < 4 && dField.hovered_location == LOCATION_MZONE && dField.hovered_sequence > 4)
 		&& !(dInfo.duel_rule >= 4 && dField.hovered_location == LOCATION_SZONE && dField.hovered_sequence > 5)) {
-		S3DVertex *vertex = 0;
+		S3DVertex *vertex = nullptr;
 		if (dField.hovered_location == LOCATION_DECK)
 			vertex = matManager.vFieldDeck[dField.hovered_controler];
 		else if (dField.hovered_location == LOCATION_MZONE) {
@@ -532,8 +532,8 @@ void Game::DrawMisc() {
 		driver->draw2DRectangle(0xa0000000, Resize(689, 8, 991, 51));
 		driver->draw2DRectangleOutline(Resize(689, 8, 991, 51), 0xffff8080);
 	}
-	driver->draw2DImage(imageManager.tLPFrame, Resize(330, 10, 629, 30), recti(0, 0, 200, 20), 0, 0, true);
-	driver->draw2DImage(imageManager.tLPFrame, Resize(691, 10, 990, 30), recti(0, 0, 200, 20), 0, 0, true);
+	driver->draw2DImage(imageManager.tLPFrame, Resize(330, 10, 629, 30), recti(0, 0, 200, 20), nullptr, nullptr, true);
+	driver->draw2DImage(imageManager.tLPFrame, Resize(691, 10, 990, 30), recti(0, 0, 200, 20), nullptr, nullptr, true);
 	if(dInfo.start_lp) {
 		auto maxLP = dInfo.isTag ? dInfo.start_lp / 2 : dInfo.start_lp;
 		if(dInfo.lp[0] >= maxLP) {
@@ -541,23 +541,23 @@ void Game::DrawMisc() {
 			auto partialLP = dInfo.lp[0] % maxLP;
 			auto bgColorPos = (layerCount - 1) % 5;
 			auto fgColorPos = layerCount % 5; 
-			driver->draw2DImage(imageManager.tLPBar, Resize(335 + 290 * partialLP / maxLP, 12, 625, 28), recti(0, bgColorPos * 16, 16, (bgColorPos + 1) * 16), 0, 0, true);
+			driver->draw2DImage(imageManager.tLPBar, Resize(335 + 290 * partialLP / maxLP, 12, 625, 28), recti(0, bgColorPos * 16, 16, (bgColorPos + 1) * 16), nullptr, nullptr, true);
 			if(partialLP > 0) {
-				driver->draw2DImage(imageManager.tLPBar, Resize(335, 12, 335 + 290 * partialLP / maxLP, 28), recti(0, fgColorPos * 16, 16, (fgColorPos + 1) * 16), 0, 0, true);
+				driver->draw2DImage(imageManager.tLPBar, Resize(335, 12, 335 + 290 * partialLP / maxLP, 28), recti(0, fgColorPos * 16, 16, (fgColorPos + 1) * 16), nullptr, nullptr, true);
 			}
 		}
-		else driver->draw2DImage(imageManager.tLPBar, Resize(335, 12, 335 + 290 * dInfo.lp[0] / maxLP, 28), recti(0, 0, 16, 16), 0, 0, true);
+		else driver->draw2DImage(imageManager.tLPBar, Resize(335, 12, 335 + 290 * dInfo.lp[0] / maxLP, 28), recti(0, 0, 16, 16), nullptr, nullptr, true);
 		if(dInfo.lp[1] >= maxLP) {
 			auto layerCount = dInfo.lp[1] / maxLP;
 			auto partialLP = dInfo.lp[1] % maxLP;
 			auto bgColorPos = (layerCount - 1) % 5;
 			auto fgColorPos = layerCount % 5;
-			driver->draw2DImage(imageManager.tLPBar, Resize(696, 12, 986 - 290 * partialLP / maxLP, 28), recti(0, bgColorPos * 16, 16, (bgColorPos + 1) * 16), 0, 0, true);
+			driver->draw2DImage(imageManager.tLPBar, Resize(696, 12, 986 - 290 * partialLP / maxLP, 28), recti(0, bgColorPos * 16, 16, (bgColorPos + 1) * 16), nullptr, nullptr, true);
 			if(partialLP > 0) {
-				driver->draw2DImage(imageManager.tLPBar, Resize(986 - 290 * partialLP / maxLP, 12, 986, 28), recti(0, fgColorPos * 16, 16, (fgColorPos + 1) * 16), 0, 0, true);
+				driver->draw2DImage(imageManager.tLPBar, Resize(986 - 290 * partialLP / maxLP, 12, 986, 28), recti(0, fgColorPos * 16, 16, (fgColorPos + 1) * 16), nullptr, nullptr, true);
 			}
 		}
-		else driver->draw2DImage(imageManager.tLPBar, Resize(986 - 290 * dInfo.lp[1] / maxLP, 12, 986, 28), recti(0, 0, 16, 16), 0, 0, true);
+		else driver->draw2DImage(imageManager.tLPBar, Resize(986 - 290 * dInfo.lp[1] / maxLP, 12, 986, 28), recti(0, 0, 16, 16), nullptr, nullptr, true);
 	}
 	if(lpframe) {
 		dInfo.lp[lpplayer] -= lpd;
@@ -567,9 +567,9 @@ void Game::DrawMisc() {
 	}
 	if(lpcstring.size()) {
 		if(lpplayer == 0) {
-			DrawShadowText(lpcFont, lpcstring, Resize(400, 472, 922, 520), Resize(0, 2, 2, 0), lpccolor, lpccolor | 0x00ffffff, true, false, 0);
+			DrawShadowText(lpcFont, lpcstring, Resize(400, 472, 922, 520), Resize(0, 2, 2, 0), lpccolor, lpccolor | 0x00ffffff, true, false, nullptr);
 		} else {
-			DrawShadowText(lpcFont, lpcstring, Resize(400, 162, 922, 210), Resize(0, 2, 2, 0), lpccolor, lpccolor | 0x00ffffff, true, false, 0);
+			DrawShadowText(lpcFont, lpcstring, Resize(400, 162, 922, 210), Resize(0, 2, 2, 0), lpccolor, lpccolor | 0x00ffffff, true, false, nullptr);
 		}
 	}
 	if(!dInfo.isReplay && dInfo.player_type < 7 && dInfo.time_limit) {
@@ -578,29 +578,29 @@ void Game::DrawMisc() {
 		driver->draw2DRectangle(Resize(795 - dInfo.time_left[1] * 100 / dInfo.time_limit, 34, 795, 44), 0xa0e0e0e0, 0xa0e0e0e0, 0xa0c0c0c0, 0xa0c0c0c0);
 		driver->draw2DRectangleOutline(Resize(695, 34, 795, 44), 0xffffffff);
 	}
-	DrawShadowText(numFont, dInfo.strLP[0], Resize(330, 12, 631, 30), Resize(0, 1, 2, 0), 0xffffff00, 0xff000000, true, false, 0);
-	DrawShadowText(numFont, dInfo.strLP[1], Resize(691, 12, 992, 30), Resize(0, 1, 2, 0), 0xffffff00, 0xff000000, true, false, 0);
+	DrawShadowText(numFont, dInfo.strLP[0], Resize(330, 12, 631, 30), Resize(0, 1, 2, 0), 0xffffff00, 0xff000000, true, false, nullptr);
+	DrawShadowText(numFont, dInfo.strLP[1], Resize(691, 12, 992, 30), Resize(0, 1, 2, 0), 0xffffff00, 0xff000000, true, false, nullptr);
 
 	if(!gameConf.hide_player_name) {
 		recti p1size = Resize(335, 31, 629, 50);
 		recti p2size = Resize(986, 31, 986, 50);
 		if(!dInfo.isTag || !dInfo.tag_player[0])
-			textFont->drawUstring(dInfo.hostname, p1size, 0xffffffff, false, false, 0);
+			textFont->drawUstring(dInfo.hostname, p1size, 0xffffffff, false, false, nullptr);
 		else
-			textFont->drawUstring(dInfo.hostname_tag, p1size, 0xffffffff, false, false, 0);
+			textFont->drawUstring(dInfo.hostname_tag, p1size, 0xffffffff, false, false, nullptr);
 		if(!dInfo.isTag || !dInfo.tag_player[1]) {
 			auto cld = textFont->getDimension(dInfo.clientname);
 			p2size.UpperLeftCorner.X -= cld.Width;
-			textFont->drawUstring(dInfo.clientname, p2size, 0xffffffff, false, false, 0);
+			textFont->drawUstring(dInfo.clientname, p2size, 0xffffffff, false, false, nullptr);
 		} else {
 			auto cld = textFont->getDimension(dInfo.clientname_tag);
 			p2size.UpperLeftCorner.X -= cld.Width;
-			textFont->drawUstring(dInfo.clientname_tag, p2size, 0xffffffff, false, false, 0);
+			textFont->drawUstring(dInfo.clientname_tag, p2size, 0xffffffff, false, false, nullptr);
 		}
 	}
 	driver->draw2DRectangle(Resize(632, 10, 688, 30), 0x00000000, 0x00000000, 0xffffffff, 0xffffffff);
 	driver->draw2DRectangle(Resize(632, 30, 688, 50), 0xffffffff, 0xffffffff, 0x00000000, 0x00000000);
-	DrawShadowText(lpcFont, dataManager.GetNumString(dInfo.turn), Resize(635, 5, 687, 40), Resize(0, 0, 2, 0), 0x8000ffff, 0x80000000, true, false, 0);
+	DrawShadowText(lpcFont, dataManager.GetNumString(dInfo.turn), Resize(635, 5, 687, 40), Resize(0, 0, 2, 0), 0x8000ffff, 0x80000000, true, false, nullptr);
 	ClientCard* pcard;
 	for(int i = 0; i < 5; ++i) {
 		pcard = dField.mzone[0][i];
@@ -627,87 +627,87 @@ void Game::DrawMisc() {
 	if(dInfo.duel_rule < 4) {
 		pcard = dField.szone[0][6];
 		if(pcard) {
-			DrawShadowText(adFont, pcard->lscstring, Resize(427, 395, 439, 415), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, 0);
+			DrawShadowText(adFont, pcard->lscstring, Resize(427, 395, 439, 415), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, nullptr);
 		}
 		pcard = dField.szone[0][7];
 		if(pcard) {
-			DrawShadowText(adFont, pcard->rscstring, Resize(881, 395, 913, 415), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, 0);
+			DrawShadowText(adFont, pcard->rscstring, Resize(881, 395, 913, 415), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, nullptr);
 		}
 		pcard = dField.szone[1][6];
 		if(pcard) {
-			DrawShadowText(adFont, pcard->lscstring, Resize(840, 246, 872, 266), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, 0);
+			DrawShadowText(adFont, pcard->lscstring, Resize(840, 246, 872, 266), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, nullptr);
 		}
 		pcard = dField.szone[1][7];
 		if(pcard) {
-			DrawShadowText(adFont, pcard->rscstring, Resize(464, 246, 496, 266), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, 0);
+			DrawShadowText(adFont, pcard->rscstring, Resize(464, 246, 496, 266), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, nullptr);
 		}
 	} else {
 		pcard = dField.szone[0][0];
 		if(pcard && (pcard->type & TYPE_PENDULUM) && !pcard->equipTarget) {
-			DrawShadowText(adFont, pcard->lscstring, Resize(455, 431, 467, 451), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, 0);
+			DrawShadowText(adFont, pcard->lscstring, Resize(455, 431, 467, 451), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, nullptr);
 		}
 		pcard = dField.szone[0][4];
 		if(pcard && (pcard->type & TYPE_PENDULUM) && !pcard->equipTarget) {
-			DrawShadowText(adFont, pcard->rscstring, Resize(851, 431, 883, 451), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, 0);
+			DrawShadowText(adFont, pcard->rscstring, Resize(851, 431, 883, 451), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, nullptr);
 		}
 		pcard = dField.szone[1][0];
 		if(pcard && (pcard->type & TYPE_PENDULUM) && !pcard->equipTarget) {
-			DrawShadowText(adFont, pcard->lscstring, Resize(807, 223, 839, 243), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, 0);
+			DrawShadowText(adFont, pcard->lscstring, Resize(807, 223, 839, 243), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, nullptr);
 		}
 		pcard = dField.szone[1][4];
 		if(pcard && (pcard->type & TYPE_PENDULUM) && !pcard->equipTarget) {
-			DrawShadowText(adFont, pcard->rscstring, Resize(499, 223, 531, 243), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, 0);
+			DrawShadowText(adFont, pcard->rscstring, Resize(499, 223, 531, 243), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, nullptr);
 		}
 	}
 	if(dField.extra[0].size()) {
 		int offset = (dField.extra[0].size() >= 10) ? 0 : numFont->getDimension(dataManager.GetNumString(1)).Width;
-		DrawShadowText(numFont, dataManager.GetNumString(dField.extra[0].size()), Resize(320, 563, 373, 553, offset, 0, 0, 0), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
-		DrawShadowText(numFont, dataManager.GetNumString(dField.extra_p_count[0], true), Resize(340, 563, 393, 553), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+		DrawShadowText(numFont, dataManager.GetNumString(dField.extra[0].size()), Resize(320, 563, 373, 553, offset, 0, 0, 0), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
+		DrawShadowText(numFont, dataManager.GetNumString(dField.extra_p_count[0], true), Resize(340, 563, 393, 553), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 	}
 	if(dField.deck[0].size()) {
-		DrawShadowText(numFont, dataManager.GetNumString(dField.deck[0].size()), Resize(908, 563, 1023, 553), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+		DrawShadowText(numFont, dataManager.GetNumString(dField.deck[0].size()), Resize(908, 563, 1023, 553), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 	}
 	if (rule == 0) {
 		if (dField.grave[0].size()) {
-			DrawShadowText(numFont, dataManager.GetNumString(dField.grave[0].size()), Resize(837, 376, 986, 381), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+			DrawShadowText(numFont, dataManager.GetNumString(dField.grave[0].size()), Resize(837, 376, 986, 381), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 		}
 		if (dField.remove[0].size()) {
-			DrawShadowText(numFont, dataManager.GetNumString(dField.remove[0].size()), Resize(1015, 376, 959, 381), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+			DrawShadowText(numFont, dataManager.GetNumString(dField.remove[0].size()), Resize(1015, 376, 959, 381), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 		}
 	} else {
 		if (dField.grave[0].size()) {
-			DrawShadowText(numFont, dataManager.GetNumString(dField.grave[0].size()), Resize(870, 457, 1004, 462), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+			DrawShadowText(numFont, dataManager.GetNumString(dField.grave[0].size()), Resize(870, 457, 1004, 462), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 		}
 		if (dField.remove[0].size()) {
-			DrawShadowText(numFont, dataManager.GetNumString(dField.remove[0].size()), Resize(837, 376, 986, 381), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+			DrawShadowText(numFont, dataManager.GetNumString(dField.remove[0].size()), Resize(837, 376, 986, 381), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 		}
 	}
 	if(dField.extra[1].size()) {
 		int offset = (dField.extra[1].size() >= 10) ? 0 : numFont->getDimension(dataManager.GetNumString(1)).Width;
-		DrawShadowText(numFont, dataManager.GetNumString(dField.extra[1].size()), Resize(808, 208, 900, 233, offset, 0, 0, 0), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
-		DrawShadowText(numFont, dataManager.GetNumString(dField.extra_p_count[1], true), Resize(828, 208, 920, 233), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+		DrawShadowText(numFont, dataManager.GetNumString(dField.extra[1].size()), Resize(808, 208, 900, 233, offset, 0, 0, 0), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
+		DrawShadowText(numFont, dataManager.GetNumString(dField.extra_p_count[1], true), Resize(828, 208, 920, 233), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 	}
 	if(dField.deck[1].size()) {
-		DrawShadowText(numFont, dataManager.GetNumString(dField.deck[1].size()), Resize(465, 208, 483, 233), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+		DrawShadowText(numFont, dataManager.GetNumString(dField.deck[1].size()), Resize(465, 208, 483, 233), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 	}
 	if (rule == 0) {
 		if (dField.grave[1].size()) {
-			DrawShadowText(numFont, dataManager.GetNumString(dField.grave[1].size()), Resize(420, 311, 464, 282), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+			DrawShadowText(numFont, dataManager.GetNumString(dField.grave[1].size()), Resize(420, 311, 464, 282), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 		}
 		if (dField.remove[1].size()) {
-			DrawShadowText(numFont, dataManager.GetNumString(dField.remove[1].size()), Resize(300, 311, 445, 341), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+			DrawShadowText(numFont, dataManager.GetNumString(dField.remove[1].size()), Resize(300, 311, 445, 341), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 		}
 	} else {
 		if (dField.grave[1].size()) {
-			DrawShadowText(numFont, dataManager.GetNumString(dField.grave[1].size()), Resize(455, 250, 464, 300), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+			DrawShadowText(numFont, dataManager.GetNumString(dField.grave[1].size()), Resize(455, 250, 464, 300), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 		}
 		if (dField.remove[1].size()) {
-			DrawShadowText(numFont, dataManager.GetNumString(dField.remove[1].size()), Resize(420, 311, 464, 282), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, 0);
+			DrawShadowText(numFont, dataManager.GetNumString(dField.remove[1].size()), Resize(420, 311, 464, 282), Resize(0, 1, 2, 1), 0xffffff00, 0xff000000, true, false, nullptr);
 		}
 	}
 }
 void Game::DrawStatus(ClientCard* pcard, int x1, int y1, int x2, int y2) {
-	DrawShadowText(adFont, L"/", Resize(x1 - 3, y1 + 1, x1 + 5, y1 + 21), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, 0);
+	DrawShadowText(adFont, L"/", Resize(x1 - 3, y1 + 1, x1 + 5, y1 + 21), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, true, false, nullptr);
 	int w = adFont->getDimension(pcard->atkstring).Width;
 	DrawShadowText(adFont, pcard->atkstring, Resize(x1 - 4, y1 + 1, x1 - 4, y1 + 21, -w, 0, 0, 0), Resize(1, 1, 1, 1),
 		pcard->attack > pcard->base_attack ? 0xffffff00 : pcard->attack < pcard->base_attack ? 0xffff2090 : 0xffffffff, 0xff000000);
@@ -815,7 +815,7 @@ void Game::DrawSpec() {
 		case 1: {
 			driver->draw2DImage(imageManager.GetTexture(showcardcode, true), ResizeCardHint(574, 150));
 			driver->draw2DImage(imageManager.tMask, ResizeCardMid(574, 150, 574 + (showcarddif > CARD_IMG_WIDTH ? CARD_IMG_WIDTH : showcarddif), 150 + CARD_IMG_HEIGHT, midx, midy),
-								recti(CARD_IMG_HEIGHT - showcarddif, 0, CARD_IMG_HEIGHT - (showcarddif > CARD_IMG_WIDTH ? showcarddif - CARD_IMG_WIDTH : 0), CARD_IMG_HEIGHT), 0, 0, true);
+								recti(CARD_IMG_HEIGHT - showcarddif, 0, CARD_IMG_HEIGHT - (showcarddif > CARD_IMG_WIDTH ? showcarddif - CARD_IMG_WIDTH : 0), CARD_IMG_HEIGHT), nullptr, nullptr, true);
 			showcarddif += 15;
 			if(showcarddif >= CARD_IMG_HEIGHT) {
 				showcard = 2;
@@ -826,7 +826,7 @@ void Game::DrawSpec() {
 		case 2: {
 			driver->draw2DImage(imageManager.GetTexture(showcardcode, true), ResizeCardHint(574, 150));
 			driver->draw2DImage(imageManager.tMask, ResizeCardMid(574 + showcarddif, 150, 574 + CARD_IMG_WIDTH, 150 + CARD_IMG_HEIGHT, midx, midy),
-								recti(0, 0, CARD_IMG_WIDTH - showcarddif, CARD_IMG_HEIGHT), 0, 0, true);
+								recti(0, 0, CARD_IMG_WIDTH - showcarddif, CARD_IMG_HEIGHT), nullptr, nullptr, true);
 			showcarddif += 15;
 			if(showcarddif >= CARD_IMG_WIDTH) {
 				showcard = 0;
@@ -835,7 +835,7 @@ void Game::DrawSpec() {
 		}
 		case 3: {
 			driver->draw2DImage(imageManager.GetTexture(showcardcode, true), ResizeCardHint(574, 150));
-			driver->draw2DImage(imageManager.tNegated, ResizeCardMid(536 + showcarddif, 141 + showcarddif, 792 - showcarddif, 397 - showcarddif, midx, midy), recti(0, 0, 128, 128), 0, 0, true);
+			driver->draw2DImage(imageManager.tNegated, ResizeCardMid(536 + showcarddif, 141 + showcarddif, 792 - showcarddif, 397 - showcarddif, midx, midy), recti(0, 0, 128, 128), nullptr, nullptr, true);
 			if(showcarddif < 64)
 				showcarddif += 4;
 			break;
@@ -846,7 +846,7 @@ void Game::DrawSpec() {
 			matManager.c2d[2] = (showcarddif << 24) | 0xffffff;
 			matManager.c2d[3] = (showcarddif << 24) | 0xffffff;
 			driver->draw2DImage(imageManager.GetTexture(showcardcode, true), ResizeCardHint(574, 150, 574 + CARD_IMG_WIDTH, 150 + CARD_IMG_HEIGHT),
-								ResizeFit(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), 0, matManager.c2d, true);
+								ResizeFit(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), nullptr, matManager.c2d, true);
 			if(showcarddif < 255)
 				showcarddif += 17;
 			break;
@@ -857,7 +857,7 @@ void Game::DrawSpec() {
 			matManager.c2d[2] = (showcarddif << 25) | 0xffffff;
 			matManager.c2d[3] = (showcarddif << 25) | 0xffffff;
 			driver->draw2DImage(imageManager.GetTexture(showcardcode, true), ResizeCardMid(662 - showcarddif * 0.69685f, 277 - showcarddif, 662 + showcarddif * 0.69685f, 277 + showcarddif, midx, midy),
-								ResizeFit(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), 0, matManager.c2d, true);
+								ResizeFit(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), nullptr, matManager.c2d, true);
 			if(showcarddif < 127)
 				showcarddif += 9;
 			break;
@@ -865,7 +865,7 @@ void Game::DrawSpec() {
 		case 6: {
 			driver->draw2DImage(imageManager.GetTexture(showcardcode, true), ResizeCardHint(574, 150));
 			driver->draw2DImage(imageManager.tNumber, ResizeCardMid(536 + showcarddif, 141 + showcarddif, 792 - showcarddif, 397 - showcarddif, midx, midy),
-			                    recti((showcardp % 5) * 64, (showcardp / 5) * 64, (showcardp % 5 + 1) * 64, (showcardp / 5 + 1) * 64), 0, 0, true);
+			                    recti((showcardp % 5) * 64, (showcardp / 5) * 64, (showcardp % 5 + 1) * 64, (showcardp / 5 + 1) * 64), nullptr, nullptr, true);
 			if(showcarddif < 64)
 				showcarddif += 4;
 			break;
@@ -963,7 +963,7 @@ void Game::DrawSpec() {
 					if(w < 200)
 						w = 200;
 					driver->draw2DRectangle(0xa0000000, ResizeWin(640 - w / 2, 320, 690 + w / 2, 340));
-					DrawShadowText(guiFont, dInfo.vic_string, ResizeWin(640 - w / 2, 320, 690 + w / 2, 340), Resize(-2, -1, 0, 0), 0xffffffff, 0xff000000, true, true, 0);
+					DrawShadowText(guiFont, dInfo.vic_string, ResizeWin(640 - w / 2, 320, 690 + w / 2, 340), Resize(-2, -1, 0, 0), 0xffffffff, 0xff000000, true, true, nullptr);
 				}
 			} else if(showcardp < showcarddif + 10) {
 				int alpha = ((showcarddif + 10 - showcardp) * 25) << 24;
@@ -1147,13 +1147,13 @@ void Game::DrawThumb(code_pointer cp, position2di pos, const std::unordered_map<
 	if(lflist->count(lcode)) {
 		switch((*lflist).at(lcode)) {
 		case 0:
-			driver->draw2DImage(imageManager.tLim, limitloc, recti(0, 0, 64, 64), 0, 0, true);
+			driver->draw2DImage(imageManager.tLim, limitloc, recti(0, 0, 64, 64), nullptr, nullptr, true);
 			break;
 		case 1:
-			driver->draw2DImage(imageManager.tLim, limitloc, recti(64, 0, 128, 64), 0, 0, true);
+			driver->draw2DImage(imageManager.tLim, limitloc, recti(64, 0, 128, 64), nullptr, nullptr, true);
 			break;
 		case 2:
-			driver->draw2DImage(imageManager.tLim, limitloc, recti(0, 64, 64, 128), 0, 0, true);
+			driver->draw2DImage(imageManager.tLim, limitloc, recti(0, 64, 64, 128), nullptr, nullptr, true);
 			break;
 		}
 	}
@@ -1173,16 +1173,16 @@ void Game::DrawThumb(code_pointer cp, position2di pos, const std::unordered_map<
 	}
 	if(showAvail) {
 		if((cp->second.ot & AVAIL_OCG) && !(cp->second.ot & AVAIL_TCG))
-			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 128, 128, 192), 0, 0, true);
+			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 128, 128, 192), nullptr, nullptr, true);
 		else if((cp->second.ot & AVAIL_TCG) && !(cp->second.ot & AVAIL_OCG))
-			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 192, 128, 256), 0, 0, true);
+			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 192, 128, 256), nullptr, nullptr, true);
 	} else if(showNotAvail) {
 		if(cp->second.ot & AVAIL_OCG)
-			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 0, 128, 64), 0, 0, true);
+			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 0, 128, 64), nullptr, nullptr, true);
 		else if(cp->second.ot & AVAIL_TCG)
-			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 64, 128, 128), 0, 0, true);
+			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 64, 128, 128), nullptr, nullptr, true);
 		else if(!avail)
-			driver->draw2DImage(imageManager.tLim, otloc, recti(0, 0, 64, 64), 0, 0, true);
+			driver->draw2DImage(imageManager.tLim, otloc, recti(0, 0, 64, 64), nullptr, nullptr, true);
 	}
 }
 void Game::DrawDeckBd() {

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -320,8 +320,8 @@ void Game::DrawCards() {
 			DrawCard(*it);
 	}
 	for (auto cit = dField.overlay_cards.begin(); cit != dField.overlay_cards.end(); ++cit) {
-		auto pcard = (*cit);
-		auto olcard = pcard->overlayTarget;
+		auto *pcard = (*cit);
+		auto *olcard = pcard->overlayTarget;
 		if (pcard->aniFrame) {
 			DrawCard(pcard);
 		}

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -16,8 +16,9 @@ void Game::DrawSelectionLine(irr::video::S3DVertex* vec, bool strip, int width, 
 		float origin[4] = {1.0f, 1.0f, 1.0f, 1.0f};
 		glLineWidth(width);
 		glLineStipple(1, linePatternGL);
-		if(strip)
+		if(strip) {
 			glEnable(GL_LINE_STIPPLE);
+}
 		glDisable(GL_TEXTURE_2D);
 		glMaterialfv(GL_FRONT, GL_AMBIENT, cv);
 		glBegin(GL_LINE_LOOP);
@@ -94,10 +95,12 @@ void Game::DrawBackGround() {
 	if(gameConf.draw_field_spell) {
 		int fieldcode1 = -1;
 		int fieldcode2 = -1;
-		if(dField.szone[0][5] && dField.szone[0][5]->position & POS_FACEUP)
+		if(dField.szone[0][5] && dField.szone[0][5]->position & POS_FACEUP) {
 			fieldcode1 = dField.szone[0][5]->code;
-		if(dField.szone[1][5] && dField.szone[1][5]->position & POS_FACEUP)
+}
+		if(dField.szone[1][5] && dField.szone[1][5]->position & POS_FACEUP) {
 			fieldcode2 = dField.szone[1][5]->code;
+}
 		int fieldcode = (fieldcode1 > 0) ? fieldcode1 : fieldcode2;
 		if(fieldcode1 > 0 && fieldcode2 > 0 && fieldcode1 != fieldcode2) {
 			ITexture* texture = imageManager.GetTextureField(fieldcode1);
@@ -133,23 +136,27 @@ void Game::DrawBackGround() {
 		float cv[4] = {0.0f, 0.0f, 1.0f, 1.0f};
 		unsigned int filter = 0x1;
 		for (int i = 0; i < 7; ++i, filter <<= 1) {
-			if (dField.selectable_field & filter)
+			if (dField.selectable_field & filter) {
 				DrawSelectionLine(matManager.vFieldMzone[0][i], !(dField.selected_field & filter), 2, cv);
+}
 		}
 		filter = 0x100;
 		for (int i = 0; i < 8; ++i, filter <<= 1) {
-			if (dField.selectable_field & filter)
+			if (dField.selectable_field & filter) {
 				DrawSelectionLine(matManager.vFieldSzone[0][i][rule], !(dField.selected_field & filter), 2, cv);
+}
 		}
 		filter = 0x10000;
 		for (int i = 0; i < 7; ++i, filter <<= 1) {
-			if (dField.selectable_field & filter)
+			if (dField.selectable_field & filter) {
 				DrawSelectionLine(matManager.vFieldMzone[1][i], !(dField.selected_field & filter), 2, cv);
+}
 		}
 		filter = 0x1000000;
 		for (int i = 0; i < 8; ++i, filter <<= 1) {
-			if (dField.selectable_field & filter)
+			if (dField.selectable_field & filter) {
 				DrawSelectionLine(matManager.vFieldSzone[1][i][rule], !(dField.selected_field & filter), 2, cv);
+}
 		}
 	}
 	//disabled field
@@ -189,22 +196,23 @@ void Game::DrawBackGround() {
 		&& !(dInfo.duel_rule < 4 && dField.hovered_location == LOCATION_MZONE && dField.hovered_sequence > 4)
 		&& !(dInfo.duel_rule >= 4 && dField.hovered_location == LOCATION_SZONE && dField.hovered_sequence > 5)) {
 		S3DVertex *vertex = nullptr;
-		if (dField.hovered_location == LOCATION_DECK)
+		if (dField.hovered_location == LOCATION_DECK) {
 			vertex = matManager.vFieldDeck[dField.hovered_controler];
-		else if (dField.hovered_location == LOCATION_MZONE) {
+		} else if (dField.hovered_location == LOCATION_MZONE) {
 			vertex = matManager.vFieldMzone[dField.hovered_controler][dField.hovered_sequence];
 			ClientCard* pcard = dField.mzone[dField.hovered_controler][dField.hovered_sequence];
 			if(pcard && pcard->type & TYPE_LINK) {
 				DrawLinkedZones(pcard);
 			}
-		} else if (dField.hovered_location == LOCATION_SZONE)
+		} else if (dField.hovered_location == LOCATION_SZONE) {
 			vertex = matManager.vFieldSzone[dField.hovered_controler][dField.hovered_sequence][rule];
-		else if (dField.hovered_location == LOCATION_GRAVE)
+		} else if (dField.hovered_location == LOCATION_GRAVE) {
 			vertex = matManager.vFieldGrave[dField.hovered_controler][rule];
-		else if (dField.hovered_location == LOCATION_REMOVED)
+		} else if (dField.hovered_location == LOCATION_REMOVED) {
 			vertex = matManager.vFieldRemove[dField.hovered_controler][rule];
-		else if (dField.hovered_location == LOCATION_EXTRA)
+		} else if (dField.hovered_location == LOCATION_EXTRA) {
 			vertex = matManager.vFieldExtra[dField.hovered_controler];
+}
 		selFieldAlpha += selFieldDAlpha;
 		if (selFieldAlpha <= 5) {
 			selFieldAlpha = 5;
@@ -304,22 +312,31 @@ void Game::CheckMutual(ClientCard* pcard, int mark) {
 }
 void Game::DrawCards() {
 	for(int p = 0; p < 2; ++p) {
-		for(auto it = dField.mzone[p].begin(); it != dField.mzone[p].end(); ++it)
-			if(*it)
+		for(auto it = dField.mzone[p].begin(); it != dField.mzone[p].end(); ++it) {
+			if(*it) {
 				DrawCard(*it);
-		for(auto it = dField.szone[p].begin(); it != dField.szone[p].end(); ++it)
-			if(*it)
+}
+}
+		for(auto it = dField.szone[p].begin(); it != dField.szone[p].end(); ++it) {
+			if(*it) {
 				DrawCard(*it);
-		for(auto it = dField.deck[p].begin(); it != dField.deck[p].end(); ++it)
+}
+}
+		for(auto it = dField.deck[p].begin(); it != dField.deck[p].end(); ++it) {
 			DrawCard(*it);
-		for(auto it = dField.hand[p].begin(); it != dField.hand[p].end(); ++it)
+}
+		for(auto it = dField.hand[p].begin(); it != dField.hand[p].end(); ++it) {
 			DrawCard(*it);
-		for(auto it = dField.grave[p].begin(); it != dField.grave[p].end(); ++it)
+}
+		for(auto it = dField.grave[p].begin(); it != dField.grave[p].end(); ++it) {
 			DrawCard(*it);
-		for(auto it = dField.remove[p].begin(); it != dField.remove[p].end(); ++it)
+}
+		for(auto it = dField.remove[p].begin(); it != dField.remove[p].end(); ++it) {
 			DrawCard(*it);
-		for(auto it = dField.extra[p].begin(); it != dField.extra[p].end(); ++it)
+}
+		for(auto it = dField.extra[p].begin(); it != dField.extra[p].end(); ++it) {
 			DrawCard(*it);
+}
 	}
 	for (auto cit = dField.overlay_cards.begin(); cit != dField.overlay_cards.end(); ++cit) {
 		auto *pcard = (*cit);
@@ -345,8 +362,9 @@ void Game::DrawCard(ClientCard* pcard) {
 			pcard->mTransform.setTranslation(pcard->curPos);
 			pcard->mTransform.setRotationRadians(pcard->curRot);
 		}
-		if(pcard->is_fading)
+		if(pcard->is_fading) {
 			pcard->curAlpha += pcard->dAlpha;
+}
 		pcard->aniFrame--;
 		if(pcard->aniFrame == 0) {
 			pcard->is_moving = false;
@@ -367,21 +385,24 @@ void Game::DrawCard(ClientCard* pcard) {
 		driver->setMaterial(matManager.mCard);
 		driver->drawVertexPrimitiveList(matManager.vCardBack, 4, matManager.iRectangle, 2);
 	}
-	if(pcard->is_moving)
+	if(pcard->is_moving) {
 		return;
+}
 	if(pcard->is_selectable && (pcard->location & 0xe)) {
 		float cv[4] = {1.0f, 1.0f, 0.0f, 1.0f};
-		if((pcard->location == LOCATION_HAND && pcard->code) || ((pcard->location & 0xc) && (pcard->position & POS_FACEUP)))
+		if((pcard->location == LOCATION_HAND && pcard->code) || ((pcard->location & 0xc) && (pcard->position & POS_FACEUP))) {
 			DrawSelectionLine(matManager.vCardOutline, !pcard->is_selected, 2, cv);
-		else
+		} else {
 			DrawSelectionLine(matManager.vCardOutliner, !pcard->is_selected, 2, cv);
+}
 	}
 	if(pcard->is_highlighting) {
 		float cv[4] = {0.0f, 1.0f, 1.0f, 1.0f};
-		if((pcard->location == LOCATION_HAND && pcard->code) || ((pcard->location & 0xc) && (pcard->position & POS_FACEUP)))
+		if((pcard->location == LOCATION_HAND && pcard->code) || ((pcard->location & 0xc) && (pcard->position & POS_FACEUP))) {
 			DrawSelectionLine(matManager.vCardOutline, true, 2, cv);
-		else
+		} else {
 			DrawSelectionLine(matManager.vCardOutliner, true, 2, cv);
+}
 	}
 	irr::core::matrix4 im;
 	im.setTranslation(pcard->curPos);
@@ -488,8 +509,9 @@ void Game::DrawMisc() {
 	}
 	if(dField.chains.size() > 1 || mainGame->gameConf.draw_single_chain) {
 		for(size_t i = 0; i < dField.chains.size(); ++i) {
-			if(dField.chains[i].solved)
+			if(dField.chains[i].solved) {
 				break;
+}
 			matManager.mTRTexture.setTexture(0, imageManager.tChain);
 			matManager.mTRTexture.AmbientColor = 0xffffff00;
 			ic.setRotationRadians(act_rot);
@@ -522,10 +544,12 @@ void Game::DrawMisc() {
 		driver->drawVertexPrimitiveList(matManager.vNegate, 4, matManager.iRectangle, 2);
 	}
 	//finish button
-	if(btnCancelOrFinish->isVisible() && dField.select_ready)
+	if(btnCancelOrFinish->isVisible() && dField.select_ready) {
 		DrawSelectionLine(btnCancelOrFinish, 2, 0xffffff00);
-	if(btnLeaveGame->isVisible() && dField.tag_teammate_surrender)
+}
+	if(btnLeaveGame->isVisible() && dField.tag_teammate_surrender) {
 		DrawSelectionLine(btnLeaveGame, 2, 0xffffff00);
+}
 	//lp bar
 	if((dInfo.turn % 2 && dInfo.isFirst) || (!(dInfo.turn % 2) && !dInfo.isFirst)) {
 		driver->draw2DRectangle(0xa0000000, Resize(327, 8, 630, 51));
@@ -548,7 +572,8 @@ void Game::DrawMisc() {
 				driver->draw2DImage(imageManager.tLPBar, Resize(335, 12, 335 + 290 * partialLP / maxLP, 28), recti(0, fgColorPos * 16, 16, (fgColorPos + 1) * 16), nullptr, nullptr, true);
 			}
 		}
-		else driver->draw2DImage(imageManager.tLPBar, Resize(335, 12, 335 + 290 * dInfo.lp[0] / maxLP, 28), recti(0, 0, 16, 16), nullptr, nullptr, true);
+		else { driver->draw2DImage(imageManager.tLPBar, Resize(335, 12, 335 + 290 * dInfo.lp[0] / maxLP, 28), recti(0, 0, 16, 16), nullptr, nullptr, true);
+}
 		if(dInfo.lp[1] >= maxLP) {
 			auto layerCount = dInfo.lp[1] / maxLP;
 			auto partialLP = dInfo.lp[1] % maxLP;
@@ -559,7 +584,8 @@ void Game::DrawMisc() {
 				driver->draw2DImage(imageManager.tLPBar, Resize(986 - 290 * partialLP / maxLP, 12, 986, 28), recti(0, fgColorPos * 16, 16, (fgColorPos + 1) * 16), nullptr, nullptr, true);
 			}
 		}
-		else driver->draw2DImage(imageManager.tLPBar, Resize(986 - 290 * dInfo.lp[1] / maxLP, 12, 986, 28), recti(0, 0, 16, 16), nullptr, nullptr, true);
+		else { driver->draw2DImage(imageManager.tLPBar, Resize(986 - 290 * dInfo.lp[1] / maxLP, 12, 986, 28), recti(0, 0, 16, 16), nullptr, nullptr, true);
+}
 	}
 	if(lpframe) {
 		dInfo.lp[lpplayer] -= lpd;
@@ -586,10 +612,11 @@ void Game::DrawMisc() {
 	if(!gameConf.hide_player_name) {
 		recti p1size = Resize(335, 31, 629, 50);
 		recti p2size = Resize(986, 31, 986, 50);
-		if(!dInfo.isTag || !dInfo.tag_player[0])
+		if(!dInfo.isTag || !dInfo.tag_player[0]) {
 			textFont->drawUstring(dInfo.hostname, p1size, 0xffffffff, false, false, nullptr);
-		else
+		} else {
 			textFont->drawUstring(dInfo.hostname_tag, p1size, 0xffffffff, false, false, nullptr);
+}
 		if(!dInfo.isTag || !dInfo.tag_player[1]) {
 			auto cld = textFont->getDimension(dInfo.clientname);
 			p2size.UpperLeftCorner.X -= cld.Width;
@@ -606,26 +633,32 @@ void Game::DrawMisc() {
 	ClientCard* pcard = nullptr;
 	for(int i = 0; i < 5; ++i) {
 		pcard = dField.mzone[0][i];
-		if(pcard && pcard->code != 0)
+		if(pcard && pcard->code != 0) {
 			DrawStatus(pcard, 493 + i * 85, 416, 473 + i * 80, 356);
+}
 	}
 	pcard = dField.mzone[0][5];
-	if(pcard && pcard->code != 0)
+	if(pcard && pcard->code != 0) {
 		DrawStatus(pcard, 589, 338, 563, 291);
+}
 	pcard = dField.mzone[0][6];
-	if(pcard && pcard->code != 0)
+	if(pcard && pcard->code != 0) {
 		DrawStatus(pcard, 743, 338, 712, 291);
+}
 	for(int i = 0; i < 5; ++i) {
 		pcard = dField.mzone[1][i];
-		if(pcard && (pcard->position & POS_FACEUP))
+		if(pcard && (pcard->position & POS_FACEUP)) {
 			DrawStatus(pcard, 803 - i * 68, 235, 779 - i * 71, 272);
+}
 	}
 	pcard = dField.mzone[1][5];
-	if(pcard && (pcard->position & POS_FACEUP))
+	if(pcard && (pcard->position & POS_FACEUP)) {
 		DrawStatus(pcard, 739, 291, 710, 338);
+}
 	pcard = dField.mzone[1][6];
-	if(pcard && (pcard->position & POS_FACEUP))
+	if(pcard && (pcard->position & POS_FACEUP)) {
 		DrawStatus(pcard, 593, 291, 555, 338);
+}
 	if(dInfo.duel_rule < 4) {
 		pcard = dField.szone[0][6];
 		if(pcard) {
@@ -754,16 +787,19 @@ void Game::DrawGUI() {
 							btnPSDD->setDrawImage(true);
 						}
 						if(fu.guiFading == wCardSelect) {
-							for(int i = 0; i < 5; ++i)
+							for(int i = 0; i < 5; ++i) {
 								btnCardSelect[i]->setDrawImage(true);
+}
 						}
 						if(fu.guiFading == wCardDisplay) {
-							for(int i = 0; i < 5; ++i)
+							for(int i = 0; i < 5; ++i) {
 								btnCardDisplay[i]->setDrawImage(true);
+}
 						}
 						env->setFocus(fu.guiFading);
-					} else
+					} else {
 						fu.guiFading->setRelativePosition(irr::core::recti(fu.fadingUL, fu.fadingLR));
+}
 				}
 			} else {
 				if(fu.fadingFrame > 5) {
@@ -785,15 +821,18 @@ void Game::DrawGUI() {
 							btnPSDD->setDrawImage(true);
 						}
 						if(fu.guiFading == wCardSelect) {
-							for(int i = 0; i < 5; ++i)
+							for(int i = 0; i < 5; ++i) {
 								btnCardSelect[i]->setDrawImage(true);
+}
 						}
 						if(fu.guiFading == wCardDisplay) {
-							for(int i = 0; i < 5; ++i)
+							for(int i = 0; i < 5; ++i) {
 								btnCardDisplay[i]->setDrawImage(true);
+}
 						}
-					} else
+					} else {
 						fu.guiFading->setRelativePosition(irr::core::recti(fu.fadingUL, fu.fadingLR));
+}
 				}
 				if(fu.signalAction && !fu.fadingFrame) {
 					DuelClient::SendResponse();
@@ -802,10 +841,12 @@ void Game::DrawGUI() {
 			}
 		} else if(fu.autoFadeoutFrame) {
 			fu.autoFadeoutFrame--;
-			if(!fu.autoFadeoutFrame)
+			if(!fu.autoFadeoutFrame) {
 				HideElement(fu.guiFading);
-		} else
+}
+		} else {
 			fadingList.erase(fthis);
+}
 	}
 	env->drawAll();
 }
@@ -838,8 +879,9 @@ void Game::DrawSpec() {
 		case 3: {
 			driver->draw2DImage(imageManager.GetTexture(showcardcode, true), ResizeCardHint(574, 150));
 			driver->draw2DImage(imageManager.tNegated, ResizeCardMid(536 + showcarddif, 141 + showcarddif, 792 - showcarddif, 397 - showcarddif, midx, midy), recti(0, 0, 128, 128), nullptr, nullptr, true);
-			if(showcarddif < 64)
+			if(showcarddif < 64) {
 				showcarddif += 4;
+}
 			break;
 		}
 		case 4: {
@@ -849,8 +891,9 @@ void Game::DrawSpec() {
 			matManager.c2d[3] = (showcarddif << 24) | 0xffffff;
 			driver->draw2DImage(imageManager.GetTexture(showcardcode, true), ResizeCardHint(574, 150, 574 + CARD_IMG_WIDTH, 150 + CARD_IMG_HEIGHT),
 								ResizeFit(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), nullptr, matManager.c2d, true);
-			if(showcarddif < 255)
+			if(showcarddif < 255) {
 				showcarddif += 17;
+}
 			break;
 		}
 		case 5: {
@@ -860,22 +903,25 @@ void Game::DrawSpec() {
 			matManager.c2d[3] = (showcarddif << 25) | 0xffffff;
 			driver->draw2DImage(imageManager.GetTexture(showcardcode, true), ResizeCardMid(662 - showcarddif * 0.69685f, 277 - showcarddif, 662 + showcarddif * 0.69685f, 277 + showcarddif, midx, midy),
 								ResizeFit(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), nullptr, matManager.c2d, true);
-			if(showcarddif < 127)
+			if(showcarddif < 127) {
 				showcarddif += 9;
+}
 			break;
 		}
 		case 6: {
 			driver->draw2DImage(imageManager.GetTexture(showcardcode, true), ResizeCardHint(574, 150));
 			driver->draw2DImage(imageManager.tNumber, ResizeCardMid(536 + showcarddif, 141 + showcarddif, 792 - showcarddif, 397 - showcarddif, midx, midy),
 			                    recti((showcardp % 5) * 64, (showcardp / 5) * 64, (showcardp % 5 + 1) * 64, (showcardp / 5 + 1) * 64), nullptr, nullptr, true);
-			if(showcarddif < 64)
+			if(showcarddif < 64) {
 				showcarddif += 4;
+}
 			break;
 		}
 		case 7: {
 			float mul = xScale;
-			if(xScale > yScale)
+			if(xScale > yScale) {
 				mul = yScale;
+}
 			core::position2d<s32> corner[4];
 			float y = sin(showcarddif * 3.1415926f / 180.0f) * CARD_IMG_HEIGHT * mul;
 			s32 winx = midx * xScale + (574 - midx) * mul;
@@ -888,8 +934,9 @@ void Game::DrawSpec() {
 			irr::gui::Draw2DImageQuad(driver, imageManager.GetTexture(showcardcode, true), ResizeFit(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), corner);
 			showcardp++;
 			showcarddif += 9;
-			if(showcarddif >= 90)
+			if(showcarddif >= 90) {
 				showcarddif = 90;
+}
 			if(showcardp == 60) {
 				showcardp = 0;
 				showcarddif = 0;
@@ -902,10 +949,12 @@ void Game::DrawSpec() {
 				driver->draw2DImage(imageManager.tHand[showcardcode & 0x3], position2di((615 + 44.5) * xScale - 44.5, (540 - showcarddif + 64) * yScale - 64));
 				float dy = -0.333333f * showcardp + 10;
 				showcardp++;
-				if(showcardp < 30)
+				if(showcardp < 30) {
 					showcarddif += (int)dy;
-			} else
+}
+			} else {
 				showcard = 0;
+}
 			break;
 		}
 		case 101: {
@@ -962,8 +1011,9 @@ void Game::DrawSpec() {
 				DrawShadowText(lpcFont, lstr, ResizePhaseHint(660, 290, 960, 370, pos.Width), Resize(-1, -1, 0, 0), 0xffffffff);
 				if(dInfo.vic_string.size() && (showcardcode == 1 || showcardcode == 2)) {
 					int w = guiFont->getDimension(dInfo.vic_string).Width;
-					if(w < 200)
+					if(w < 200) {
 						w = 200;
+}
 					driver->draw2DRectangle(0xa0000000, ResizeWin(640 - w / 2, 320, 690 + w / 2, 340));
 					DrawShadowText(guiFont, dInfo.vic_string, ResizeWin(640 - w / 2, 320, 690 + w / 2, 340), Resize(-2, -1, 0, 0), 0xffffffff, 0xff000000, true, true, nullptr);
 				}
@@ -984,8 +1034,9 @@ void Game::DrawSpec() {
 		driver->setMaterial(matManager.mATK);
 		driver->drawVertexPrimitiveList(&matManager.vArrow[attack_sv], 12, matManager.iArrow, 10, EVT_STANDARD, EPT_TRIANGLE_STRIP);
 		attack_sv += 4;
-		if (attack_sv > 28)
+		if (attack_sv > 28) {
 			attack_sv = 0;
+}
 	}
 	bool showChat = true;
 	if(hideChat) {
@@ -1002,10 +1053,12 @@ void Game::DrawSpec() {
 		if(chatTiming[i]) {
 			chatTiming[i]--;
 			if(!is_building) {
-				if(dInfo.isStarted && i >= 5)
+				if(dInfo.isStarted && i >= 5) {
 					continue;
-				if(!showChat && i > 2)
+}
+				if(!showChat && i > 2) {
 					continue;
+}
 			}
 
 			int x = wChat->getRelativePosition().UpperLeftCorner.X;
@@ -1033,16 +1086,19 @@ void Game::DrawSpec() {
 	}
 }
 void Game::DrawBackImage(irr::video::ITexture* texture) {
-	if(!texture)
+	if(!texture) {
 		return;
+}
 	driver->draw2DImage(texture, Resize(0, 0, 1024, 640), recti(0, 0, texture->getOriginalSize().Width, texture->getOriginalSize().Height));
 }
 void Game::ShowElement(irr::gui::IGUIElement * win, int autoframe) {
 	FadingUnit fu;
 	fu.fadingSize = win->getRelativePosition();
-	for(auto fit = fadingList.begin(); fit != fadingList.end(); ++fit)
-		if(win == fit->guiFading && win != wOptions && win != wANNumber) // the size of wOptions is always setted by ClientField::ShowSelectOption before showing it
+	for(auto fit = fadingList.begin(); fit != fadingList.end(); ++fit) {
+		if(win == fit->guiFading && win != wOptions && win != wANNumber) { // the size of wOptions is always setted by ClientField::ShowSelectOption before showing it
 			fu.fadingSize = fit->fadingSize;
+}
+}
 	irr::core::position2di center = fu.fadingSize.getCenter();
 	fu.fadingDiff.X = fu.fadingSize.getWidth() / 10;
 	fu.fadingDiff.Y = (fu.fadingSize.getHeight() - 4) / 10;
@@ -1062,25 +1118,30 @@ void Game::ShowElement(irr::gui::IGUIElement * win, int autoframe) {
 		btnPSDD->setDrawImage(false);
 	}
 	if(win == wCardSelect) {
-		for(int i = 0; i < 5; ++i)
+		for(int i = 0; i < 5; ++i) {
 			btnCardSelect[i]->setDrawImage(false);
+}
 	}
 	if(win == wCardDisplay) {
-		for(int i = 0; i < 5; ++i)
+		for(int i = 0; i < 5; ++i) {
 			btnCardDisplay[i]->setDrawImage(false);
+}
 	}
 	win->setRelativePosition(irr::core::recti(center.X, center.Y, 0, 0));
 	win->setVisible(true);
 	fadingList.push_back(fu);
 }
 void Game::HideElement(irr::gui::IGUIElement * win, bool set_action) {
-	if(!win->isVisible() && !set_action)
+	if(!win->isVisible() && !set_action) {
 		return;
+}
 	FadingUnit fu;
 	fu.fadingSize = win->getRelativePosition();
-	for(auto fit = fadingList.begin(); fit != fadingList.end(); ++fit)
-		if(win == fit->guiFading)
+	for(auto fit = fadingList.begin(); fit != fadingList.end(); ++fit) {
+		if(win == fit->guiFading) {
 			fu.fadingSize = fit->fadingSize;
+}
+}
 	fu.fadingDiff.X = fu.fadingSize.getWidth() / 10;
 	fu.fadingDiff.Y = (fu.fadingSize.getHeight() - 4) / 10;
 	fu.fadingUL = fu.fadingSize.UpperLeftCorner;
@@ -1097,31 +1158,37 @@ void Game::HideElement(irr::gui::IGUIElement * win, bool set_action) {
 		btnPSDD->setDrawImage(false);
 	}
 	if(win == wCardSelect) {
-		for(int i = 0; i < 5; ++i)
+		for(int i = 0; i < 5; ++i) {
 			btnCardSelect[i]->setDrawImage(false);
+}
 		dField.conti_selecting = false;
 		stCardListTip->setVisible(false);
-		for(auto& pcard : dField.selectable_cards)
+		for(auto& pcard : dField.selectable_cards) {
 			dField.SetShowMark(pcard, false);
+}
 	}
 	if(win == wCardDisplay) {
-		for(int i = 0; i < 5; ++i)
+		for(int i = 0; i < 5; ++i) {
 			btnCardDisplay[i]->setDrawImage(false);
+}
 		stCardListTip->setVisible(false);
-		for(auto& pcard : dField.display_cards)
+		for(auto& pcard : dField.display_cards) {
 			dField.SetShowMark(pcard, false);
+}
 	}
 	fadingList.push_back(fu);
 }
 void Game::PopupElement(irr::gui::IGUIElement * element, int hideframe) {
 	soundManager.PlayDialogSound(element);
 	element->getParent()->bringToFront(element);
-	if(!is_building)
+	if(!is_building) {
 		dField.panel = element;
+}
 	env->setFocus(element);
-	if(!hideframe)
+	if(!hideframe) {
 		ShowElement(element);
-	else ShowElement(element, hideframe);
+	} else { ShowElement(element, hideframe);
+}
 }
 void Game::WaitFrameSignal(int frame) {
 	frameSignal.Reset();
@@ -1131,11 +1198,13 @@ void Game::WaitFrameSignal(int frame) {
 void Game::DrawThumb(code_pointer cp, position2di pos, const std::unordered_map<int,int>* lflist, bool drag) {
 	int code = cp->first;
 	int lcode = cp->second.alias;
-	if(lcode == 0)
+	if(lcode == 0) {
 		lcode = code;
+}
 	irr::video::ITexture* img = imageManager.GetTextureThumb(code);
-	if(img == nullptr)
+	if(img == nullptr) {
 		return; //nullptr->getSize() will cause a crash
+}
 	dimension2d<u32> size = img->getOriginalSize();
 	recti dragloc = mainGame->Resize(pos.X, pos.Y, pos.X + CARD_THUMB_WIDTH, pos.Y + CARD_THUMB_HEIGHT);
 	recti limitloc = mainGame->Resize(pos.X, pos.Y, pos.X + 20, pos.Y + 20);
@@ -1174,17 +1243,19 @@ void Game::DrawThumb(code_pointer cp, position2di pos, const std::unordered_map<
 		showNotAvail = true;
 	}
 	if(showAvail) {
-		if((cp->second.ot & AVAIL_OCG) && !(cp->second.ot & AVAIL_TCG))
+		if((cp->second.ot & AVAIL_OCG) && !(cp->second.ot & AVAIL_TCG)) {
 			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 128, 128, 192), nullptr, nullptr, true);
-		else if((cp->second.ot & AVAIL_TCG) && !(cp->second.ot & AVAIL_OCG))
+		} else if((cp->second.ot & AVAIL_TCG) && !(cp->second.ot & AVAIL_OCG)) {
 			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 192, 128, 256), nullptr, nullptr, true);
+}
 	} else if(showNotAvail) {
-		if(cp->second.ot & AVAIL_OCG)
+		if(cp->second.ot & AVAIL_OCG) {
 			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 0, 128, 64), nullptr, nullptr, true);
-		else if(cp->second.ot & AVAIL_TCG)
+		} else if(cp->second.ot & AVAIL_TCG) {
 			driver->draw2DImage(imageManager.tOT, otloc, recti(0, 64, 128, 128), nullptr, nullptr, true);
-		else if(!avail)
+		} else if(!avail) {
 			driver->draw2DImage(imageManager.tLim, otloc, recti(0, 0, 64, 64), nullptr, nullptr, true);
+}
 	}
 }
 void Game::DrawDeckBd() {
@@ -1205,13 +1276,16 @@ void Game::DrawDeckBd() {
 		lx = 10;
 	} else if(deckBuilder.showing_pack) {
 		lx = 10;
-		if(mainsize > 10 * 7)
+		if(mainsize > 10 * 7) {
 			lx = 11;
-		if(mainsize > 11 * 7)
+}
+		if(mainsize > 11 * 7) {
 			lx = 12;
+}
 		dx = (mainGame->scrPackCards->isVisible() ? 414.0f : 436.0f) / (lx - 1);
-		if(mainsize > 60)
+		if(mainsize > 60) {
 			dy = 66;
+}
 	} else {
 		lx = (mainsize - 41) / 4 + 11;
 		dx = 436.0f / (lx - 1);
@@ -1220,8 +1294,9 @@ void Game::DrawDeckBd() {
 	for(int i = 0; i < mainsize - padding && i < 7 * lx; ++i) {
 		int j = i + padding;
 		DrawThumb(deckManager.current_deck.main[j], position2di(314 + (i % lx) * dx, 164 + (i / lx) * dy), deckBuilder.filterList);
-		if(deckBuilder.hovered_pos == 1 && deckBuilder.hovered_seq == j)
+		if(deckBuilder.hovered_pos == 1 && deckBuilder.hovered_seq == j) {
 			driver->draw2DRectangleOutline(Resize(313 + (i % lx) * dx, 163 + (i / lx) * dy, 359 + (i % lx) * dx, 228 + (i / lx) * dy));
+}
 	}
 	if(!deckBuilder.showing_pack) {
 		//extra deck
@@ -1231,13 +1306,15 @@ void Game::DrawDeckBd() {
 		DrawShadowText(numFont, dataManager.GetNumString(deckManager.current_deck.extra.size()), Resize(380, 441, 440, 461), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
 		driver->draw2DRectangle(Resize(310, 463, 797, 533), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 		driver->draw2DRectangleOutline(Resize(309, 462, 797, 533));
-		if(deckManager.current_deck.extra.size() <= 10)
+		if(deckManager.current_deck.extra.size() <= 10) {
 			dx = 436.0f / 9;
-		else dx = 436.0f / (deckManager.current_deck.extra.size() - 1);
+		} else { dx = 436.0f / (deckManager.current_deck.extra.size() - 1);
+}
 		for(size_t i = 0; i < deckManager.current_deck.extra.size(); ++i) {
 			DrawThumb(deckManager.current_deck.extra[i], position2di(314 + i * dx, 466), deckBuilder.filterList);
-			if(deckBuilder.hovered_pos == 2 && deckBuilder.hovered_seq == (int)i)
+			if(deckBuilder.hovered_pos == 2 && deckBuilder.hovered_seq == (int)i) {
 				driver->draw2DRectangleOutline(Resize(313 + i * dx, 465, 359 + i * dx, 531));
+}
 		}
 		//side deck
 		driver->draw2DRectangle(Resize(310, 537, 410, 557), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
@@ -1246,13 +1323,15 @@ void Game::DrawDeckBd() {
 		DrawShadowText(numFont, dataManager.GetNumString(deckManager.current_deck.side.size()), Resize(380, 538, 440, 558), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
 		driver->draw2DRectangle(Resize(310, 560, 797, 630), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 		driver->draw2DRectangleOutline(Resize(309, 559, 797, 630));
-		if(deckManager.current_deck.side.size() <= 10)
+		if(deckManager.current_deck.side.size() <= 10) {
 			dx = 436.0f / 9;
-		else dx = 436.0f / (deckManager.current_deck.side.size() - 1);
+		} else { dx = 436.0f / (deckManager.current_deck.side.size() - 1);
+}
 		for(size_t i = 0; i < deckManager.current_deck.side.size(); ++i) {
 			DrawThumb(deckManager.current_deck.side[i], position2di(314 + i * dx, 564), deckBuilder.filterList);
-			if(deckBuilder.hovered_pos == 3 && deckBuilder.hovered_seq == (int)i)
+			if(deckBuilder.hovered_pos == 3 && deckBuilder.hovered_seq == (int)i) {
 				driver->draw2DRectangleOutline(Resize(313 + i * dx, 563, 359 + i * dx, 629));
+}
 		}
 	}
 	if(is_siding) {
@@ -1275,16 +1354,18 @@ void Game::DrawDeckBd() {
 			imageManager.GetTextureThumb(ptr->second.code);
 			break;
 		}
-		if(deckBuilder.hovered_pos == 4 && deckBuilder.hovered_seq == (int)i)
+		if(deckBuilder.hovered_pos == 4 && deckBuilder.hovered_seq == (int)i) {
 			driver->draw2DRectangle(0x80000000, Resize(806, 164 + i * 66, 1019, 230 + i * 66));
+}
 		DrawThumb(ptr, position2di(810, 165 + i * 66), deckBuilder.filterList);
 		const wchar_t* availBuffer = L"";
-		if ((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_OCG)
+		if ((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_OCG) {
 			availBuffer = L" [OCG]";
-		else if ((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_TCG)
+		} else if ((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_TCG) {
 			availBuffer = L" [TCG]";
-		else if ((ptr->second.ot & AVAIL_CUSTOM) == AVAIL_CUSTOM)
+		} else if ((ptr->second.ot & AVAIL_CUSTOM) == AVAIL_CUSTOM) {
 			availBuffer = L" [Custom]";
+}
 		if(ptr->second.type & TYPE_MONSTER) {
 			myswprintf(textBuffer, L"%ls", dataManager.GetName(ptr->first));
 			DrawShadowText(textFont, textBuffer, Resize(860, 165 + i * 66, 955, 185 + i * 66), Resize(1, 1, 0, 0));
@@ -1292,22 +1373,25 @@ void Game::DrawDeckBd() {
 			wchar_t adBuffer[32]{};
 			wchar_t scaleBuffer[16]{};
 			if(!(ptr->second.type & TYPE_LINK)) {
-				if(ptr->second.type & TYPE_XYZ)
+				if(ptr->second.type & TYPE_XYZ) {
 					form = L"\u2606";
-				if(ptr->second.attack < 0 && ptr->second.defense < 0)
+}
+				if(ptr->second.attack < 0 && ptr->second.defense < 0) {
 					myswprintf(adBuffer, L"?/?");
-				else if(ptr->second.attack < 0)
+				} else if(ptr->second.attack < 0) {
 					myswprintf(adBuffer, L"?/%d", ptr->second.defense);
-				else if(ptr->second.defense < 0)
+				} else if(ptr->second.defense < 0) {
 					myswprintf(adBuffer, L"%d/?", ptr->second.attack);
-				else
+				} else {
 					myswprintf(adBuffer, L"%d/%d", ptr->second.attack, ptr->second.defense);
+}
 			} else {
 				form = L"LINK-";
-				if(ptr->second.attack < 0)
+				if(ptr->second.attack < 0) {
 					myswprintf(adBuffer, L"?/-");
-				else
+				} else {
 					myswprintf(adBuffer, L"%d/-", ptr->second.attack);
+}
 			}
 			myswprintf(textBuffer, L"%ls/%ls %ls%d", dataManager.FormatAttribute(ptr->second.attribute).c_str(), dataManager.FormatRace(ptr->second.race).c_str(),
 				form, ptr->second.level);

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1,3 +1,5 @@
+#include <math.h>
+
 #include "game.h"
 #include "client_card.h"
 #include "materials.h"
@@ -220,7 +222,7 @@ void Game::DrawBackGround() {
 }
 void Game::DrawLinkedZones(ClientCard* pcard) {
 	auto mark = pcard->link_marker;
-	ClientCard* pcard2;
+	ClientCard* pcard2 = nullptr;
 	if (dField.hovered_sequence < 5) {
 		if (mark & LINK_MARKER_LEFT && dField.hovered_sequence > 0) {
 			pcard2 = dField.mzone[dField.hovered_controler][dField.hovered_sequence - 1];
@@ -601,7 +603,7 @@ void Game::DrawMisc() {
 	driver->draw2DRectangle(Resize(632, 10, 688, 30), 0x00000000, 0x00000000, 0xffffffff, 0xffffffff);
 	driver->draw2DRectangle(Resize(632, 30, 688, 50), 0xffffffff, 0xffffffff, 0x00000000, 0x00000000);
 	DrawShadowText(lpcFont, dataManager.GetNumString(dInfo.turn), Resize(635, 5, 687, 40), Resize(0, 0, 2, 0), 0x8000ffff, 0x80000000, true, false, nullptr);
-	ClientCard* pcard;
+	ClientCard* pcard = nullptr;
 	for(int i = 0; i < 5; ++i) {
 		pcard = dField.mzone[0][i];
 		if(pcard && pcard->code != 0)
@@ -1195,9 +1197,9 @@ void Game::DrawDeckBd() {
 	DrawShadowText(numFont, dataManager.GetNumString(mainsize), Resize(380, 138, 440, 158), Resize(1, 1, 1, 1), 0xffffffff, 0xff000000, false, true);
 	driver->draw2DRectangle(Resize(310, 160, 797, deckBuilder.showing_pack ? 630 : 436), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 	driver->draw2DRectangleOutline(Resize(309, 159, 797, deckBuilder.showing_pack ? 630 : 436));
-	int lx;
+	int lx = 0;
 	int dy = 68;
-	float dx;
+	float dx = NAN;
 	if(mainsize <= 40) {
 		dx = 436.0f / 9;
 		lx = 10;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -40,12 +40,14 @@ std::set<std::pair<unsigned int, unsigned short>> DuelClient::remotes;
 event* DuelClient::resp_event = nullptr;
 
 bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_game) {
-	if(connect_state)
+	if(connect_state) {
 		return false;
+}
 	sockaddr_in sin;
 	client_base = event_base_new();
-	if(!client_base)
+	if(!client_base) {
 		return false;
+}
 	std::memset(&sin, 0, sizeof sin);
 	sin.sin_family = AF_INET;
 	sin.sin_addr.s_addr = htonl(ip);
@@ -70,8 +72,9 @@ bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_g
 	return true;
 }
 void DuelClient::ConnectTimeout(evutil_socket_t fd, short events, void* arg) {
-	if(connect_state == 0x7)
+	if(connect_state == 0x7) {
 		return;
+}
 	if(!is_closing) {
 		mainGame->btnCreateHost->setEnabled(true);
 		mainGame->btnJoinHost->setEnabled(true);
@@ -79,10 +82,11 @@ void DuelClient::ConnectTimeout(evutil_socket_t fd, short events, void* arg) {
 		mainGame->btnStartBot->setEnabled(true);
 		mainGame->btnBotCancel->setEnabled(true);
 		mainGame->gMutex.lock();
-		if(bot_mode && !mainGame->wSinglePlay->isVisible())
+		if(bot_mode && !mainGame->wSinglePlay->isVisible()) {
 			mainGame->ShowElement(mainGame->wSinglePlay);
-		else if(!bot_mode && !mainGame->wLanWindow->isVisible())
+		} else if(!bot_mode && !mainGame->wLanWindow->isVisible()) {
 			mainGame->ShowElement(mainGame->wLanWindow);
+}
 		soundManager.PlaySoundEffect(SOUND_INFO);
 		mainGame->env->addMessageBox(L"", dataManager.GetSysString(1400));
 		mainGame->gMutex.unlock();
@@ -90,8 +94,9 @@ void DuelClient::ConnectTimeout(evutil_socket_t fd, short events, void* arg) {
 	event_base_loopbreak(client_base);
 }
 void DuelClient::StopClient(bool is_exiting) {
-	if(connect_state != 0x7)
+	if(connect_state != 0x7) {
 		return;
+}
 	is_closing = is_exiting;
 	if(!is_closing) {
 
@@ -101,17 +106,20 @@ void DuelClient::StopClient(bool is_exiting) {
 void DuelClient::ClientRead(bufferevent* bev, void* ctx) {
 	evbuffer* input = bufferevent_get_input(bev);
 	int len = evbuffer_get_length(input);
-	if (len < 2)
+	if (len < 2) {
 		return;
+}
 	unsigned char* duel_client_read = new unsigned char[SIZE_NETWORK_BUFFER];
 	uint16_t packet_len = 0;
 	while (len >= 2) {
 		evbuffer_copyout(input, &packet_len, sizeof packet_len);
-		if (len < packet_len + 2)
+		if (len < packet_len + 2) {
 			break;
+}
 		int read_len = evbuffer_remove(input, duel_client_read, packet_len + 2);
-		if (read_len > 2)
+		if (read_len > 2) {
 			HandleSTOCPacketLan(&duel_client_read[2], read_len - 2);
+}
 		len -= packet_len + 2;
 	}
 	delete[] duel_client_read;
@@ -172,10 +180,11 @@ void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 				mainGame->btnStartBot->setEnabled(true);
 				mainGame->btnBotCancel->setEnabled(true);
 				mainGame->gMutex.lock();
-				if(bot_mode && !mainGame->wSinglePlay->isVisible())
+				if(bot_mode && !mainGame->wSinglePlay->isVisible()) {
 					mainGame->ShowElement(mainGame->wSinglePlay);
-				else if(!bot_mode && !mainGame->wLanWindow->isVisible())
+				} else if(!bot_mode && !mainGame->wLanWindow->isVisible()) {
 					mainGame->ShowElement(mainGame->wLanWindow);
+}
 				soundManager.PlaySoundEffect(SOUND_INFO);
 				mainGame->env->addMessageBox(L"", dataManager.GetSysString(1400));
 				mainGame->gMutex.unlock();
@@ -188,15 +197,17 @@ void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 					mainGame->btnBotCancel->setEnabled(true);
 					mainGame->gMutex.lock();
 					mainGame->HideElement(mainGame->wHostPrepare);
-					if(bot_mode)
+					if(bot_mode) {
 						mainGame->ShowElement(mainGame->wSinglePlay);
-					else
+					} else {
 						mainGame->ShowElement(mainGame->wLanWindow);
+}
 					mainGame->wChat->setVisible(false);
 					soundManager.PlaySoundEffect(SOUND_INFO);
-					if(events & BEV_EVENT_EOF)
+					if(events & BEV_EVENT_EOF) {
 						mainGame->env->addMessageBox(L"", dataManager.GetSysString(1401));
-					else mainGame->env->addMessageBox(L"", dataManager.GetSysString(1402));
+					} else { mainGame->env->addMessageBox(L"", dataManager.GetSysString(1402));
+}
 					mainGame->gMutex.unlock();
 				} else {
 					mainGame->gMutex.lock();
@@ -219,10 +230,11 @@ void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 					mainGame->is_building = false;
 					mainGame->ResizeChatInputWindow();
 					mainGame->device->setEventReceiver(&mainGame->menuHandler);
-					if(bot_mode)
+					if(bot_mode) {
 						mainGame->ShowElement(mainGame->wSinglePlay);
-					else
+					} else {
 						mainGame->ShowElement(mainGame->wLanWindow);
+}
 					mainGame->gMutex.unlock();
 				}
 			}
@@ -244,14 +256,16 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 	unsigned char pktType = BufferIO::ReadUInt8(pdata);
 	switch(pktType) {
 	case STOC_GAME_MSG: {
-		if (len < 1 + (int)sizeof(unsigned char))
+		if (len < 1 + (int)sizeof(unsigned char)) {
 			return;
+}
 		ClientAnalyze(pdata, len - 1);
 		break;
 	}
 	case STOC_ERROR_MSG: {
-		if (len < 1 + (int)sizeof(STOC_ErrorMsg))
+		if (len < 1 + (int)sizeof(STOC_ErrorMsg)) {
 			return;
+}
 		STOC_ErrorMsg packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -264,12 +278,13 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 			mainGame->btnBotCancel->setEnabled(true);
 			mainGame->gMutex.lock();
 			soundManager.PlaySoundEffect(SOUND_INFO);
-			if(pkt->code == 0)
+			if(pkt->code == 0) {
 				mainGame->env->addMessageBox(L"", dataManager.GetSysString(1403));
-			else if(pkt->code == 1)
+			} else if(pkt->code == 1) {
 				mainGame->env->addMessageBox(L"", dataManager.GetSysString(1404));
-			else if(pkt->code == 2)
+			} else if(pkt->code == 2) {
 				mainGame->env->addMessageBox(L"", dataManager.GetSysString(1405));
+}
 			mainGame->gMutex.unlock();
 			event_base_loopbreak(client_base);
 			break;
@@ -306,10 +321,11 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 				break;
 			}
 			case DECKERROR_EXTRACOUNT: {
-				if(code>0)
+				if(code>0) {
 					myswprintf(msgbuf, dataManager.GetSysString(1418), code);
-				else
+				} else {
 					myswprintf(msgbuf, dataManager.GetSysString(1420));
+}
 				break;
 			}
 			case DECKERROR_SIDECOUNT: {
@@ -368,8 +384,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HAND_RESULT: {
-		if (len < 1 + (int)sizeof(STOC_HandResult))
+		if (len < 1 + (int)sizeof(STOC_HandResult)) {
 			return;
+}
 		STOC_HandResult packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -396,8 +413,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		mainGame->wDeckEdit->setVisible(false);
 		mainGame->wFilter->setVisible(false);
 		mainGame->wSort->setVisible(false);
-		if(mainGame->dInfo.player_type < 7)
+		if(mainGame->dInfo.player_type < 7) {
 			mainGame->btnLeaveGame->setVisible(false);
+}
 		mainGame->btnSideOK->setVisible(true);
 		mainGame->btnSideShuffle->setVisible(true);
 		mainGame->btnSideSort->setVisible(true);
@@ -427,8 +445,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_DECK_COUNT: {
-		if (len < 1 + (int)sizeof(int16_t) * 6)
+		if (len < 1 + (int)sizeof(int16_t) * 6) {
 			return;
+}
 		mainGame->gMutex.lock();
 		int deckc = BufferIO::ReadInt16(pdata);
 		int extrac = BufferIO::ReadInt16(pdata);
@@ -442,8 +461,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_JOIN_GAME: {
-		if (len < 1 + (int)sizeof(STOC_JoinGame))
+		if (len < 1 + (int)sizeof(STOC_JoinGame)) {
 			return;
+}
 		STOC_JoinGame packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -503,8 +523,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		mainGame->dInfo.time_left[0] = 0;
 		mainGame->dInfo.time_left[1] = 0;
 		mainGame->deckBuilder.filterList = deckManager.GetLFListContent(pkt->info.lflist);
-		if(mainGame->deckBuilder.filterList == nullptr)
+		if(mainGame->deckBuilder.filterList == nullptr) {
 			mainGame->deckBuilder.filterList = &deckManager._lfList[0].content;
+}
 		mainGame->stHostPrepOB->setText(L"");
 		mainGame->SetStaticText(mainGame->stHostPrepRule, 180, mainGame->guiFont, str.c_str());
 		mainGame->RefreshCategoryDeck(mainGame->cbCategorySelect, mainGame->cbDeckSelect);
@@ -515,8 +536,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		mainGame->HideElement(mainGame->wSinglePlay);
 		mainGame->ShowElement(mainGame->wHostPrepare);
 		mainGame->ResizeChatInputWindow();
-		if(!mainGame->chkIgnore1->isChecked())
+		if(!mainGame->chkIgnore1->isChecked()) {
 			mainGame->wChat->setVisible(true);
+}
 		mainGame->gMutex.unlock();
 		mainGame->dInfo.duel_rule = pkt->info.duel_rule;
 		mainGame->dInfo.start_lp = pkt->info.start_lp;
@@ -525,8 +547,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_TYPE_CHANGE: {
-		if (len < 1 + (int)sizeof(STOC_TypeChange))
+		if (len < 1 + (int)sizeof(STOC_TypeChange)) {
 			return;
+}
 		STOC_TypeChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -574,12 +597,14 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 			mainGame->btnHostPrepDuelist->setEnabled(true);
 			if(is_host) {
 				mainGame->btnHostPrepStart->setVisible(true);
-				for(int i = 0; i < 4; ++i)
+				for(int i = 0; i < 4; ++i) {
 					mainGame->btnHostPrepKick[i]->setVisible(true);
+}
 			} else {
 				mainGame->btnHostPrepStart->setVisible(false);
-				for(int i = 0; i < 4; ++i)
+				for(int i = 0; i < 4; ++i) {
 					mainGame->btnHostPrepKick[i]->setVisible(false);
+}
 			}
 			if(selftype < 4) {
 				mainGame->chkHostPrepReady[selftype]->setEnabled(true);
@@ -631,8 +656,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		mainGame->btnEP->setVisible(false);
 		mainGame->btnShuffle->setVisible(false);
 		mainGame->ResizeChatInputWindow();
-		if(!mainGame->chkIgnore1->isChecked())
+		if(!mainGame->chkIgnore1->isChecked()) {
 			mainGame->wChat->setVisible(true);
+}
 		if(mainGame->chkDefaultShowChain->isChecked()) {
 			mainGame->always_chain = true;
 			mainGame->ignore_chain = false;
@@ -680,8 +706,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 	}
 	case STOC_DUEL_END: {
 		mainGame->gMutex.lock();
-		if(mainGame->dInfo.player_type < 7)
+		if(mainGame->dInfo.player_type < 7) {
 			mainGame->btnLeaveGame->setVisible(false);
+}
 		mainGame->CloseGameButtons();
 		mainGame->stMessage->setText(dataManager.GetSysString(1500));
 		mainGame->PopupElement(mainGame->wMessage);
@@ -705,32 +732,37 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		mainGame->stTip->setVisible(false);
 		mainGame->ResizeChatInputWindow();
 		mainGame->device->setEventReceiver(&mainGame->menuHandler);
-		if(bot_mode)
+		if(bot_mode) {
 			mainGame->ShowElement(mainGame->wSinglePlay);
-		else
+		} else {
 			mainGame->ShowElement(mainGame->wLanWindow);
+}
 		mainGame->gMutex.unlock();
 		event_base_loopbreak(client_base);
-		if(exit_on_return)
+		if(exit_on_return) {
 			mainGame->device->closeDevice();
+}
 		break;
 	}
 	case STOC_REPLAY: {
-		if (len < 1 + (int)sizeof(ReplayHeader))
+		if (len < 1 + (int)sizeof(ReplayHeader)) {
 			return;
+}
 		mainGame->gMutex.lock();
 		mainGame->wPhase->setVisible(false);
-		if(mainGame->dInfo.player_type < 7)
+		if(mainGame->dInfo.player_type < 7) {
 			mainGame->btnLeaveGame->setVisible(false);
+}
 		mainGame->CloseGameButtons();
 		auto *prep = pdata;
 		Replay new_replay;
 		std::memcpy(&new_replay.pheader, prep, sizeof(new_replay.pheader));
 		time_t starttime = 0;
-		if (new_replay.pheader.flag & REPLAY_UNIFORM)
+		if (new_replay.pheader.flag & REPLAY_UNIFORM) {
 			starttime = new_replay.pheader.start_time;
-		else
+		} else {
 			starttime = new_replay.pheader.seed;
+}
 		
 		wchar_t timetext[40];
 		std::wcsftime(timetext, sizeof timetext / sizeof timetext[0], L"%Y-%m-%d %H-%M-%S", std::localtime(&starttime));
@@ -755,53 +787,62 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 			prep += sizeof(ReplayHeader);
 			std::memcpy(new_replay.comp_data, prep, len - sizeof(ReplayHeader) - 1);
 			new_replay.comp_size = len - sizeof(ReplayHeader) - 1;
-			if(mainGame->actionParam)
+			if(mainGame->actionParam) {
 				new_replay.SaveReplay(mainGame->ebRSName->getText());
-			else
+			} else {
 				new_replay.SaveReplay(L"_LastReplay");
+}
 		}
 		break;
 	}
 	case STOC_TIME_LIMIT: {
-		if (len < 1 + (int)sizeof(STOC_TimeLimit))
+		if (len < 1 + (int)sizeof(STOC_TimeLimit)) {
 			return;
+}
 		STOC_TimeLimit packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
 		int lplayer = mainGame->LocalPlayer(pkt->player);
-		if(lplayer == 0)
+		if(lplayer == 0) {
 			DuelClient::SendPacketToServer(CTOS_TIME_CONFIRM);
+}
 		mainGame->dInfo.time_player = lplayer;
 		mainGame->dInfo.time_left[lplayer] = pkt->left_time;
 		break;
 	}
 	case STOC_CHAT: {
 		const int chat_msg_size = len - 1 - sizeof(uint16_t);
-		if (!check_msg_size(chat_msg_size))
+		if (!check_msg_size(chat_msg_size)) {
 			return;
+}
 		uint16_t chat_player_type = buffer_read<uint16_t>(pdata);
 		uint16_t chat_msg[LEN_CHAT_MSG];
 		buffer_read_block(pdata, chat_msg, chat_msg_size);
 		const int chat_msg_len = chat_msg_size / sizeof(uint16_t);
-		if (chat_msg[chat_msg_len - 1] != 0)
+		if (chat_msg[chat_msg_len - 1] != 0) {
 			return;
+}
 		int player = chat_player_type;
 		auto play_sound = false;
 		if(player < 4) {
-			if(mainGame->chkIgnore1->isChecked())
+			if(mainGame->chkIgnore1->isChecked()) {
 				break;
+}
 			auto localplayer = mainGame->ChatLocalPlayer(player);
 			player = localplayer & 0xf;
-			if(!(localplayer & 0x10))
+			if(!(localplayer & 0x10)) {
 				play_sound = true;
+}
 		} else {
 			if(player == 8) { //system custom message.
 				play_sound = true;
-				if(mainGame->chkIgnore1->isChecked())
+				if(mainGame->chkIgnore1->isChecked()) {
 					break;
+}
 			} else if(player < 11 || player > 19) {
-				if(mainGame->chkIgnore2->isChecked())
+				if(mainGame->chkIgnore2->isChecked()) {
 					break;
+}
 				player = 10;
 			}
 		}
@@ -814,72 +855,81 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HS_PLAYER_ENTER: {
-		if (len < 1 + STOC_HS_PlayerEnter_size)
+		if (len < 1 + STOC_HS_PlayerEnter_size) {
 			return;
+}
 		soundManager.PlaySoundEffect(SOUND_PLAYER_ENTER);
 		STOC_HS_PlayerEnter packet;
 		std::memcpy(&packet, pdata, STOC_HS_PlayerEnter_size);
 		auto *pkt = &packet;
-		if(pkt->pos > 3)
+		if(pkt->pos > 3) {
 			break;
+}
 		wchar_t name[20];
 		BufferIO::NullTerminate(pkt->name);
 		BufferIO::CopyCharArray(pkt->name, name);
 		if(mainGame->dInfo.isTag) {
-			if(pkt->pos == 0)
+			if(pkt->pos == 0) {
 				BufferIO::CopyCharArray(pkt->name, mainGame->dInfo.hostname);
-			else if(pkt->pos == 1)
+			} else if(pkt->pos == 1) {
 				BufferIO::CopyCharArray(pkt->name, mainGame->dInfo.hostname_tag);
-			else if(pkt->pos == 2)
+			} else if(pkt->pos == 2) {
 				BufferIO::CopyCharArray(pkt->name, mainGame->dInfo.clientname);
-			else if(pkt->pos == 3)
+			} else if(pkt->pos == 3) {
 				BufferIO::CopyCharArray(pkt->name, mainGame->dInfo.clientname_tag);
+}
 		} else {
-			if(pkt->pos == 0)
+			if(pkt->pos == 0) {
 				BufferIO::CopyCharArray(pkt->name, mainGame->dInfo.hostname);
-			else if(pkt->pos == 1)
+			} else if(pkt->pos == 1) {
 				BufferIO::CopyCharArray(pkt->name, mainGame->dInfo.clientname);
+}
 		}
 		mainGame->gMutex.lock();
-		if(mainGame->gameConf.hide_player_name)
+		if(mainGame->gameConf.hide_player_name) {
 			mainGame->stHostPrepDuelist[pkt->pos]->setText(L"[********]");
-		else
+		} else {
 			mainGame->stHostPrepDuelist[pkt->pos]->setText(name);
+}
 		mainGame->stHostPrepDuelist[pkt->pos]->setToolTipText(name);
 		mainGame->gMutex.unlock();
 		mainGame->FlashWindow();
 		break;
 	}
 	case STOC_HS_PLAYER_CHANGE: {
-		if (len < 1 + (int)sizeof(STOC_HS_PlayerChange))
+		if (len < 1 + (int)sizeof(STOC_HS_PlayerChange)) {
 			return;
+}
 		STOC_HS_PlayerChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
 		unsigned char pos = (pkt->status >> 4) & 0xf;
 		unsigned char state = pkt->status & 0xf;
-		if(pos > 3)
+		if(pos > 3) {
 			break;
+}
 		mainGame->gMutex.lock();
 		if(state < 8) {
 			soundManager.PlaySoundEffect(SOUND_PLAYER_ENTER);
 			const wchar_t* prename = mainGame->stHostPrepDuelist[pos]->getToolTipText().c_str();
-			if(mainGame->gameConf.hide_player_name)
+			if(mainGame->gameConf.hide_player_name) {
 				mainGame->stHostPrepDuelist[state]->setText(L"[********]");
-			else
+			} else {
 				mainGame->stHostPrepDuelist[state]->setText(prename);
+}
 			mainGame->stHostPrepDuelist[state]->setToolTipText(prename);
 			mainGame->stHostPrepDuelist[pos]->setText(L"");
 			mainGame->stHostPrepDuelist[pos]->setToolTipText(L"");
 			mainGame->chkHostPrepReady[pos]->setChecked(false);
-			if(pos == 0)
+			if(pos == 0) {
 				BufferIO::CopyCharArray(prename, mainGame->dInfo.hostname);
-			else if(pos == 1)
+			} else if(pos == 1) {
 				BufferIO::CopyCharArray(prename, mainGame->dInfo.hostname_tag);
-			else if(pos == 2)
+			} else if(pos == 2) {
 				BufferIO::CopyCharArray(prename, mainGame->dInfo.clientname);
-			else if(pos == 3)
+			} else if(pos == 3) {
 				BufferIO::CopyCharArray(prename, mainGame->dInfo.clientname_tag);
+}
 		} else if(state == PLAYERCHANGE_READY) {
 			mainGame->chkHostPrepReady[pos]->setChecked(true);
 			if(pos == selftype) {
@@ -915,8 +965,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HS_WATCH_CHANGE: {
-		if (len < 1 + (int)sizeof(STOC_HS_WatchChange))
+		if (len < 1 + (int)sizeof(STOC_HS_WatchChange)) {
 			return;
+}
 		STOC_HS_WatchChange packet;
 		std::memcpy(&packet, pdata, sizeof packet);
 		const auto* pkt = &packet;
@@ -929,8 +980,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_TEAMMATE_SURRENDER: {
-		if(!mainGame->dField.tag_surrender)
+		if(!mainGame->dField.tag_surrender) {
 			mainGame->dField.tag_teammate_surrender = true;
+}
 		mainGame->btnLeaveGame->setText(dataManager.GetSysString(1355));
 		break;
 	}
@@ -962,8 +1014,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->WaitFrameSignal(11);
 		}
 	}
-	if(mainGame->dInfo.time_player == 1)
+	if(mainGame->dInfo.time_player == 1) {
 		mainGame->dInfo.time_player = 2;
+}
 	if(is_swapping) {
 		mainGame->gMutex.lock();
 		mainGame->dField.ReplaySwap();
@@ -1047,14 +1100,16 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->btnBotCancel->setEnabled(true);
 			mainGame->stTip->setVisible(false);
 			mainGame->device->setEventReceiver(&mainGame->menuHandler);
-			if(bot_mode)
+			if(bot_mode) {
 				mainGame->ShowElement(mainGame->wSinglePlay);
-			else
+			} else {
 				mainGame->ShowElement(mainGame->wLanWindow);
+}
 			mainGame->gMutex.unlock();
 			event_base_loopbreak(client_base);
-			if(exit_on_return)
+			if(exit_on_return) {
 				mainGame->device->closeDevice();
+}
 		}
 		return false;
 	}
@@ -1062,8 +1117,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int type = BufferIO::ReadUInt8(pbuf);
 		int player = BufferIO::ReadUInt8(pbuf);
 		int data = BufferIO::ReadInt32(pbuf);
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		switch (type) {
 		case HINT_EVENT: {
 			myswprintf(event_string, L"%ls", dataManager.GetDesc(data));
@@ -1148,35 +1204,38 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			break;
 		}
 		case HINT_ZONE: {
-			if(mainGame->LocalPlayer(player) == 1)
+			if(mainGame->LocalPlayer(player) == 1) {
 				data = (data >> 16) | (data << 16);
+}
 			for(unsigned filter = 0x1; filter != 0; filter <<= 1) {
 				std::wstring str;
 				if(unsigned s = filter & data) {
 					if(s & 0x60) {
 						str += dataManager.GetSysString(1081);
 						data &= ~0x600000;
-					} else if(s & 0xffff)
+					} else if(s & 0xffff) {
 						str += dataManager.GetSysString(102);
-					else if(s & 0xffff0000) {
+					} else if(s & 0xffff0000) {
 						str += dataManager.GetSysString(103);
 						s >>= 16;
 					}
-					if(s & 0x1f)
+					if(s & 0x1f) {
 						str += dataManager.GetSysString(1002);
-					else if(s & 0xff00) {
+					} else if(s & 0xff00) {
 						s >>= 8;
-						if(s & 0x1f)
+						if(s & 0x1f) {
 							str += dataManager.GetSysString(1003);
-						else if(s & 0x20)
+						} else if(s & 0x20) {
 							str += dataManager.GetSysString(1008);
-						else if(s & 0xc0)
+						} else if(s & 0xc0) {
 							str += dataManager.GetSysString(1009);
+}
 					}
 					int seq = 1;
 					for(int i = 0x1; i < 0x100; i <<= 1) {
-						if(s & i)
+						if(s & i) {
 							break;
+}
 						++seq;
 					}
 					str += L"(" + std::to_wstring(seq) + L")";
@@ -1200,9 +1259,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->showcardp = 0;
 		mainGame->dInfo.vic_string = L"";
 		wchar_t vic_buf[256];
-		if(player == 2)
+		if(player == 2) {
 			mainGame->showcardcode = 3;
-		else {
+		} else {
 			wchar_t vic_name[20];
 			if(mainGame->LocalPlayer(player) == 0) {
 				mainGame->showcardcode = 1;
@@ -1212,14 +1271,16 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				mainGame->showcardcode = 2;
 				myswprintf(vic_name, L"%ls", mainGame->dInfo.hostname);
 			}
-			if(mainGame->gameConf.hide_player_name)
+			if(mainGame->gameConf.hide_player_name) {
 				myswprintf(vic_name, L"********");
-			if(match_kill)
+}
+			if(match_kill) {
 				myswprintf(vic_buf, dataManager.GetVictoryString(0xffff), dataManager.GetName(match_kill));
-			else if(type < 0x10)
+			} else if(type < 0x10) {
 				myswprintf(vic_buf, L"[%ls] %ls", vic_name, dataManager.GetVictoryString(type));
-			else
+			} else {
 				myswprintf(vic_buf, L"%ls", dataManager.GetVictoryString(type));
+}
 			mainGame->dInfo.vic_string = vic_buf;
 		}
 		mainGame->showcard = 101;
@@ -1248,13 +1309,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dInfo.isInDuel = true;
 		int playertype = BufferIO::ReadUInt8(pbuf);
 		mainGame->dInfo.isFirst =  (playertype & 0xf) ? false : true;
-		if(playertype & 0xf0)
+		if(playertype & 0xf0) {
 			mainGame->dInfo.player_type = 7;
+}
 		if(mainGame->dInfo.isTag) {
-			if(mainGame->dInfo.isFirst)
+			if(mainGame->dInfo.isFirst) {
 				mainGame->dInfo.tag_player[1] = true;
-			else
+			} else {
 				mainGame->dInfo.tag_player[0] = true;
+}
 		}
 		mainGame->dInfo.duel_rule = BufferIO::ReadUInt8(pbuf);
 		mainGame->dInfo.lp[mainGame->LocalPlayer(0)] = BufferIO::ReadInt32(pbuf);
@@ -1329,12 +1392,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			} else {
 				pcard->cmdFlag |= COMMAND_ACTIVATE;
 				if(pcard->controler == 0) {
-					if(pcard->location == LOCATION_GRAVE)
+					if(pcard->location == LOCATION_GRAVE) {
 						mainGame->dField.grave_act = true;
-					else if(pcard->location == LOCATION_REMOVED)
+					} else if(pcard->location == LOCATION_REMOVED) {
 						mainGame->dField.remove_act = true;
-					else if(pcard->location == LOCATION_EXTRA)
+					} else if(pcard->location == LOCATION_EXTRA) {
 						mainGame->dField.extra_act = true;
+}
 				}
 			}
 		}
@@ -1393,16 +1457,17 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			if (pcard->location == LOCATION_DECK) {
 				pcard->SetCode(code);
 				mainGame->dField.deck_act = true;
-			} else if (pcard->location == LOCATION_GRAVE)
+			} else if (pcard->location == LOCATION_GRAVE) {
 				mainGame->dField.grave_act = true;
-			else if (pcard->location == LOCATION_REMOVED)
+			} else if (pcard->location == LOCATION_REMOVED) {
 				mainGame->dField.remove_act = true;
-			else if (pcard->location == LOCATION_EXTRA)
+			} else if (pcard->location == LOCATION_EXTRA) {
 				mainGame->dField.extra_act = true;
-			else {
+			} else {
 				int left_seq = mainGame->dInfo.duel_rule >= 4 ? 0 : 6;
-				if (pcard->location == LOCATION_SZONE && pcard->sequence == left_seq && (pcard->type & TYPE_PENDULUM) && !pcard->equipTarget)
+				if (pcard->location == LOCATION_SZONE && pcard->sequence == left_seq && (pcard->type & TYPE_PENDULUM) && !pcard->equipTarget) {
 					mainGame->dField.pzone_act[pcard->controler] = true;
+}
 			}
 		}
 		mainGame->dField.reposable_cards.clear();
@@ -1463,12 +1528,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			} else {
 				pcard->cmdFlag |= COMMAND_ACTIVATE;
 				if(pcard->controler == 0) {
-					if(pcard->location == LOCATION_GRAVE)
+					if(pcard->location == LOCATION_GRAVE) {
 						mainGame->dField.grave_act = true;
-					else if(pcard->location == LOCATION_REMOVED)
+					} else if(pcard->location == LOCATION_REMOVED) {
 						mainGame->dField.remove_act = true;
-					else if(pcard->location == LOCATION_EXTRA)
+					} else if(pcard->location == LOCATION_EXTRA) {
 						mainGame->dField.extra_act = true;
+}
 				}
 			}
 		}
@@ -1496,8 +1562,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		unsigned int l = BufferIO::ReadUInt8(pbuf);
 		int s = BufferIO::ReadUInt8(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
-		if (pcard->code != code)
+		if (pcard->code != code) {
 			pcard->SetCode(code);
+}
 		BufferIO::ReadUInt8(pbuf);
 		if(l != LOCATION_DECK) {
 			pcard->is_highlighting = true;
@@ -1537,8 +1604,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
 		int count = BufferIO::ReadUInt8(pbuf);
 		mainGame->dField.select_options.clear();
-		for (int i = 0; i < count; ++i)
+		for (int i = 0; i < count; ++i) {
 			mainGame->dField.select_options.push_back(BufferIO::ReadInt32(pbuf));
+}
 		mainGame->dField.ShowSelectOption(select_hint);
 		select_hint = 0;
 		return false;
@@ -1566,28 +1634,33 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			l = BufferIO::ReadUInt8(pbuf);
 			s = BufferIO::ReadUInt8(pbuf);
 			ss = BufferIO::ReadUInt8(pbuf);
-			if (l & LOCATION_OVERLAY)
+			if (l & LOCATION_OVERLAY) {
 				pcard = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
-			else
+			} else {
 				pcard = mainGame->dField.GetCard(c, l, s);
-			if (code != 0 && pcard->code != code)
+}
+			if (code != 0 && pcard->code != code) {
 				pcard->SetCode(code);
+}
 			pcard->select_seq = i;
 			mainGame->dField.selectable_cards.push_back(pcard);
 			pcard->is_selectable = true;
 			pcard->is_selected = false;
-			if (l & 0xf1)
+			if (l & 0xf1) {
 				panelmode = true;
+}
 			if((l & LOCATION_HAND) && hand_count[c] >= 10) {
-				if(++select_count_in_hand[c] > 1)
+				if(++select_count_in_hand[c] > 1) {
 					panelmode = true;
+}
 			}
 		}
 		std::sort(mainGame->dField.selectable_cards.begin(), mainGame->dField.selectable_cards.end(), ClientCard::client_card_sort);
-		if(select_hint)
+		if(select_hint) {
 			myswprintf(textBuffer, L"%ls(%d-%d)", dataManager.GetDesc(select_hint),
 			           mainGame->dField.select_min, mainGame->dField.select_max);
-		else myswprintf(textBuffer, L"%ls(%d-%d)", dataManager.GetSysString(560), mainGame->dField.select_min, mainGame->dField.select_max);
+		} else { myswprintf(textBuffer, L"%ls(%d-%d)", dataManager.GetSysString(560), mainGame->dField.select_min, mainGame->dField.select_max);
+}
 		select_hint = 0;
 		if (panelmode) {
 			mainGame->gMutex.lock();
@@ -1631,21 +1704,25 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			l = BufferIO::ReadUInt8(pbuf);
 			s = BufferIO::ReadUInt8(pbuf);
 			ss = BufferIO::ReadUInt8(pbuf);
-			if (l & LOCATION_OVERLAY)
+			if (l & LOCATION_OVERLAY) {
 				pcard = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
-			else
+			} else {
 				pcard = mainGame->dField.GetCard(c, l, s);
-			if (code != 0 && pcard->code != code)
+}
+			if (code != 0 && pcard->code != code) {
 				pcard->SetCode(code);
+}
 			pcard->select_seq = i;
 			mainGame->dField.selectable_cards.push_back(pcard);
 			pcard->is_selectable = true;
 			pcard->is_selected = false;
-			if (l & 0xf1)
+			if (l & 0xf1) {
 				panelmode = true;
+}
 			if((l & LOCATION_HAND) && hand_count[c] >= 10) {
-				if(++select_count_in_hand[c] > 1)
+				if(++select_count_in_hand[c] > 1) {
 					panelmode = true;
+}
 			}
 		}
 		int count2 = BufferIO::ReadUInt8(pbuf);
@@ -1655,30 +1732,36 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			l = BufferIO::ReadUInt8(pbuf);
 			s = BufferIO::ReadUInt8(pbuf);
 			ss = BufferIO::ReadUInt8(pbuf);
-			if (l & LOCATION_OVERLAY)
+			if (l & LOCATION_OVERLAY) {
 				pcard = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
-			else
+			} else {
 				pcard = mainGame->dField.GetCard(c, l, s);
-			if (code != 0 && pcard->code != code)
+}
+			if (code != 0 && pcard->code != code) {
 				pcard->SetCode(code);
+}
 			pcard->select_seq = i;
 			mainGame->dField.selectable_cards.push_back(pcard);
 			pcard->is_selectable = true;
 			pcard->is_selected = true;
-			if (l & 0xf1)
+			if (l & 0xf1) {
 				panelmode = true;
+}
 			if((l & LOCATION_HAND) && hand_count[c] >= 10) {
-				if(++select_count_in_hand[c] > 1)
+				if(++select_count_in_hand[c] > 1) {
 					panelmode = true;
+}
 			}
 		}
 		std::sort(mainGame->dField.selectable_cards.begin(), mainGame->dField.selectable_cards.end(), ClientCard::client_card_sort);
-		if(select_hint)
+		if(select_hint) {
 			select_unselect_hint = select_hint;
-		if(select_unselect_hint)
+}
+		if(select_unselect_hint) {
 			myswprintf(textBuffer, L"%ls(%d-%d)", dataManager.GetDesc(select_unselect_hint),
 			           mainGame->dField.select_min, mainGame->dField.select_max);
-		else myswprintf(textBuffer, L"%ls(%d-%d)", dataManager.GetSysString(560), mainGame->dField.select_min, mainGame->dField.select_max);
+		} else { myswprintf(textBuffer, L"%ls(%d-%d)", dataManager.GetSysString(560), mainGame->dField.select_min, mainGame->dField.select_max);
+}
 		select_hint = 0;
 		if (panelmode) {
 			mainGame->gMutex.lock();
@@ -1698,8 +1781,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				mainGame->dField.ShowCancelOrFinishButton(1);
 			}
 		}
-		else
+		else {
 			mainGame->dField.ShowCancelOrFinishButton(0);
+}
 		return false;
 	}
 	case MSG_SELECT_CHAIN: {
@@ -1738,21 +1822,23 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				conti_exist = true;
 			} else {
 				pcard->is_selectable = true;
-				if(flag == EDESC_RESET)
+				if(flag == EDESC_RESET) {
 					pcard->cmdFlag |= COMMAND_RESET;
-				else
+				} else {
 					pcard->cmdFlag |= COMMAND_ACTIVATE;
+}
 				if(pcard->location == LOCATION_DECK) {
 					pcard->SetCode(code);
 					mainGame->dField.deck_act = true;
-				} else if(l == LOCATION_GRAVE)
+				} else if(l == LOCATION_GRAVE) {
 					mainGame->dField.grave_act = true;
-				else if(l == LOCATION_REMOVED)
+				} else if(l == LOCATION_REMOVED) {
 					mainGame->dField.remove_act = true;
-				else if(l == LOCATION_EXTRA)
+				} else if(l == LOCATION_EXTRA) {
 					mainGame->dField.extra_act = true;
-				else if(l == LOCATION_OVERLAY)
+				} else if(l == LOCATION_OVERLAY) {
 					panelmode = true;
+}
 			}
 		}
 		if(!select_trigger && !forced && (mainGame->ignore_chain || ((count == 0 || specount == 0) && !mainGame->always_chain)) && (count == 0 || !mainGame->chain_when_avail)) {
@@ -1771,10 +1857,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			return true;
 		}
 		mainGame->gMutex.lock();
-		if(!conti_exist)
+		if(!conti_exist) {
 			mainGame->stHintMsg->setText(dataManager.GetSysString(550));
-		else
+		} else {
 			mainGame->stHintMsg->setText(dataManager.GetSysString(556));
+}
 		mainGame->stHintMsg->setVisible(true);
 		if(panelmode) {
 			mainGame->dField.list_command = COMMAND_ACTIVATE;
@@ -1785,12 +1872,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->dField.ShowChainCard();
 		} else {
 			if(!forced) {
-				if(count == 0)
+				if(count == 0) {
 					myswprintf(textBuffer, L"%ls\n%ls", dataManager.GetSysString(201), dataManager.GetSysString(202));
-				else if(select_trigger)
+				} else if(select_trigger) {
 					myswprintf(textBuffer, L"%ls\n%ls\n%ls", event_string, dataManager.GetSysString(222), dataManager.GetSysString(223));
-				else
+				} else {
 					myswprintf(textBuffer, L"%ls\n%ls", event_string, dataManager.GetSysString(203));
+}
 				mainGame->SetStaticText(mainGame->stQMessage, 310, mainGame->guiFont, textBuffer);
 				mainGame->PopupElement(mainGame->wQuery);
 			}
@@ -1806,21 +1894,24 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.select_ready = false;
 		mainGame->dField.select_cancelable = count == 0;
 		mainGame->dField.selectable_field = ~BufferIO::ReadInt32(pbuf);
-		if(selecting_player == mainGame->LocalPlayer(1))
+		if(selecting_player == mainGame->LocalPlayer(1)) {
 			mainGame->dField.selectable_field = (mainGame->dField.selectable_field >> 16) | (mainGame->dField.selectable_field << 16);
+}
 		mainGame->dField.selected_field = 0;
 		unsigned char respbuf[SIZE_RETURN_VALUE];
 		int pzone = 0;
 		if (mainGame->dInfo.curMsg == MSG_SELECT_PLACE) {
 			if (select_hint) {
 				myswprintf(textBuffer, dataManager.GetSysString(569), dataManager.GetName(select_hint));
-			} else
+			} else {
 				myswprintf(textBuffer, dataManager.GetSysString(560));
+}
 		} else {
 			if (select_hint) {
 				myswprintf(textBuffer, dataManager.GetDesc(select_hint));
-			} else
+			} else {
 				myswprintf(textBuffer, dataManager.GetSysString(570));
+}
 		}
 		select_hint = 0;
 		mainGame->stHintMsg->setText(textBuffer);
@@ -1862,17 +1953,19 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 						respbuf[2] = rnd.get_random_integer(0, 6);
 					} while(!(filter & (1 << respbuf[2])));
 				} else {
-					if (filter & 0x40) respbuf[2] = 6;
-					else if (filter & 0x20) respbuf[2] = 5;
-					else if (filter & 0x4) respbuf[2] = 2;
-					else if (filter & 0x2) respbuf[2] = 1;
-					else if (filter & 0x8) respbuf[2] = 3;
-					else if (filter & 0x1) respbuf[2] = 0;
-					else if (filter & 0x10) respbuf[2] = 4;
+					if (filter & 0x40) { respbuf[2] = 6;
+					} else if (filter & 0x20) { respbuf[2] = 5;
+					} else if (filter & 0x4) { respbuf[2] = 2;
+					} else if (filter & 0x2) { respbuf[2] = 1;
+					} else if (filter & 0x8) { respbuf[2] = 3;
+					} else if (filter & 0x1) { respbuf[2] = 0;
+					} else if (filter & 0x10) { respbuf[2] = 4;
+}
 				}
 			} else {
-				if (filter & 0x1) respbuf[2] = 6;
-				else if (filter & 0x2) respbuf[2] = 7;
+				if (filter & 0x1) { respbuf[2] = 6;
+				} else if (filter & 0x2) { respbuf[2] = 7;
+}
 			}
 			mainGame->dField.selectable_field = 0;
 			SetResponseB(respbuf, 3);
@@ -1894,34 +1987,40 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		}
 		int count = 0, filter = 0x1, startpos = 0;
 		while(filter != 0x10) {
-			if(positions & filter) count++;
+			if(positions & filter) { count++;
+}
 			filter <<= 1;
 		}
-		if(count == 4) startpos = 10;
-		else if(count == 3) startpos = 82;
-		else startpos = 155;
+		if(count == 4) { startpos = 10;
+		} else if(count == 3) { startpos = 82;
+		} else { startpos = 155;
+}
 		if(positions & 0x1) {
 			mainGame->imageLoading.insert(std::make_pair(mainGame->btnPSAU, code));
 			mainGame->btnPSAU->setRelativePosition(rect<s32>(startpos, 45, startpos + 140, 185));
 			mainGame->btnPSAU->setVisible(true);
 			startpos += 145;
-		} else mainGame->btnPSAU->setVisible(false);
+		} else { mainGame->btnPSAU->setVisible(false);
+}
 		if(positions & 0x2) {
 			mainGame->btnPSAD->setRelativePosition(rect<s32>(startpos, 45, startpos + 140, 185));
 			mainGame->btnPSAD->setVisible(true);
 			startpos += 145;
-		} else mainGame->btnPSAD->setVisible(false);
+		} else { mainGame->btnPSAD->setVisible(false);
+}
 		if(positions & 0x4) {
 			mainGame->imageLoading.insert(std::make_pair(mainGame->btnPSDU, code));
 			mainGame->btnPSDU->setRelativePosition(rect<s32>(startpos, 45, startpos + 140, 185));
 			mainGame->btnPSDU->setVisible(true);
 			startpos += 145;
-		} else mainGame->btnPSDU->setVisible(false);
+		} else { mainGame->btnPSDU->setVisible(false);
+}
 		if(positions & 0x8) {
 			mainGame->btnPSDD->setRelativePosition(rect<s32>(startpos, 45, startpos + 140, 185));
 			mainGame->btnPSDD->setVisible(true);
 			startpos += 145;
-		} else mainGame->btnPSDD->setVisible(false);
+		} else { mainGame->btnPSDD->setVisible(false);
+}
 		mainGame->gMutex.lock();
 		mainGame->PopupElement(mainGame->wPosSelect);
 		mainGame->gMutex.unlock();
@@ -1949,8 +2048,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			s = BufferIO::ReadUInt8(pbuf);
 			t = BufferIO::ReadUInt8(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
-			if (code && pcard->code != code)
+			if (code && pcard->code != code) {
 				pcard->SetCode(code);
+}
 			mainGame->dField.selectable_cards.push_back(pcard);
 			mainGame->dField.selectsum_all.push_back(pcard);
 			pcard->opParam = t << 16 | 1;
@@ -1958,10 +2058,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			pcard->is_selectable = true;
 		}
 		mainGame->dField.CheckSelectTribute();
-		if(select_hint)
+		if(select_hint) {
 			myswprintf(textBuffer, L"%ls(%d-%d)", dataManager.GetDesc(select_hint),
 			           mainGame->dField.select_min, mainGame->dField.select_max);
-		else myswprintf(textBuffer, L"%ls(%d-%d)", dataManager.GetSysString(531), mainGame->dField.select_min, mainGame->dField.select_max);
+		} else { myswprintf(textBuffer, L"%ls(%d-%d)", dataManager.GetSysString(531), mainGame->dField.select_min, mainGame->dField.select_max);
+}
 		select_hint = 0;
 		mainGame->gMutex.lock();
 		mainGame->stHintMsg->setText(textBuffer);
@@ -2016,8 +2117,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			unsigned int l = BufferIO::ReadUInt8(pbuf);
 			int s = BufferIO::ReadUInt8(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
-			if (code != 0 && pcard->code != code)
+			if (code != 0 && pcard->code != code) {
 				pcard->SetCode(code);
+}
 			pcard->opParam = BufferIO::ReadInt32(pbuf);
 			pcard->select_seq = 0;
 			mainGame->dField.selected_cards.push_back(pcard);
@@ -2029,13 +2131,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			unsigned int l = BufferIO::ReadUInt8(pbuf);
 			int s = BufferIO::ReadUInt8(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
-			if (code != 0 && pcard->code != code)
+			if (code != 0 && pcard->code != code) {
 				pcard->SetCode(code);
+}
 			pcard->opParam = BufferIO::ReadInt32(pbuf);
 			pcard->select_seq = i;
 			mainGame->dField.selectsum_all.push_back(pcard);
-			if ((l & 0xe) == 0)
+			if ((l & 0xe) == 0) {
 				mainGame->dField.select_panalmode = true;
+}
 		}
 		std::sort(mainGame->dField.selectsum_all.begin(), mainGame->dField.selectsum_all.end(), ClientCard::client_card_sort);
 		mainGame->dField.select_hint = select_hint;
@@ -2057,8 +2161,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			l = BufferIO::ReadUInt8(pbuf);
 			s = BufferIO::ReadUInt8(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
-			if (code != 0 && pcard->code != code)
+			if (code != 0 && pcard->code != code) {
 				pcard->SetCode(code);
+}
 			mainGame->dField.selectable_cards.push_back(pcard);
 			mainGame->dField.sort_list.push_back(0);
 		}
@@ -2078,11 +2183,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			code = BufferIO::ReadInt32(pbuf);
 			pbuf += 3;
 			pcard = *(mainGame->dField.deck[player].rbegin() + i);
-			if (code != 0)
+			if (code != 0) {
 				pcard->SetCode(code);
+}
 		}
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		soundManager.PlaySoundEffect(SOUND_REVEAL);
 		myswprintf(textBuffer, dataManager.GetSysString(207), count);
 		mainGame->AddLog(textBuffer);
@@ -2093,11 +2200,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->AddLog(textBuffer, pcard->code);
 			mainGame->gMutex.unlock();
 			float shift = -0.15f;
-			if (player == 1) shift = 0.15f;
+			if (player == 1) { shift = 0.15f;
+}
 			pcard->dPos = irr::core::vector3df(shift, 0, 0);
-			if(!mainGame->dField.deck_reversed)
+			if(!mainGame->dField.deck_reversed) {
 				pcard->dRot = irr::core::vector3df(0, 3.14159f / 5.0f, 0);
-			else pcard->dRot = irr::core::vector3df(0, 0, 0);
+			} else { pcard->dRot = irr::core::vector3df(0, 0, 0);
+}
 			pcard->is_moving = true;
 			pcard->aniFrame = 5;
 			mainGame->WaitFrameSignal(count > 5 ? 12 : 45);
@@ -2116,11 +2225,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			code = BufferIO::ReadInt32(pbuf);
 			pbuf += 3;
 			pcard = *(mainGame->dField.extra[player].rbegin() + i + mainGame->dField.extra_p_count[player]);
-			if (code != 0)
+			if (code != 0) {
 				pcard->SetCode(code);
+}
 		}
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		soundManager.PlaySoundEffect(SOUND_REVEAL);
 		myswprintf(textBuffer, dataManager.GetSysString(207), count);
 		mainGame->AddLog(textBuffer);
@@ -2130,10 +2241,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			myswprintf(textBuffer, L"*[%ls]", dataManager.GetName(pcard->code));
 			mainGame->AddLog(textBuffer, pcard->code);
 			mainGame->gMutex.unlock();
-			if (player == 0)
+			if (player == 0) {
 				pcard->dPos = irr::core::vector3df(0, -0.20f, 0);
-			else
+			} else {
 				pcard->dPos = irr::core::vector3df(0.15f, 0, 0);
+}
 			pcard->dRot = irr::core::vector3df(0, 3.14159f / 5.0f, 0);
 			pcard->is_moving = true;
 			pcard->aniFrame = 5;
@@ -2164,8 +2276,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			l = BufferIO::ReadUInt8(pbuf);
 			s = BufferIO::ReadUInt8(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
-			if (code != 0)
+			if (code != 0) {
 				pcard->SetCode(code);
+}
 			mainGame->gMutex.lock();
 			myswprintf(textBuffer, L"*[%ls]", dataManager.GetName(code));
 			mainGame->AddLog(textBuffer, code);
@@ -2173,23 +2286,27 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			if (l & 0x41) {
 				if(count == 1) {
 					float shift = -0.15f;
-					if (c == 0 && l == 0x40) shift = 0.15f;
+					if (c == 0 && l == 0x40) { shift = 0.15f;
+}
 					pcard->dPos = irr::core::vector3df(shift, 0, 0);
-					if((l == LOCATION_DECK) && mainGame->dField.deck_reversed)
+					if((l == LOCATION_DECK) && mainGame->dField.deck_reversed) {
 						pcard->dRot = irr::core::vector3df(0, 0, 0);
-					else pcard->dRot = irr::core::vector3df(0, 3.14159f / 5.0f, 0);
+					} else { pcard->dRot = irr::core::vector3df(0, 3.14159f / 5.0f, 0);
+}
 					pcard->is_moving = true;
 					pcard->aniFrame = 5;
 					mainGame->WaitFrameSignal(45);
 					mainGame->dField.MoveCard(pcard, 5);
 					mainGame->WaitFrameSignal(5);
 				} else {
-					if(!mainGame->dInfo.isReplay)
+					if(!mainGame->dInfo.isReplay) {
 						panel_confirm.push_back(pcard);
+}
 				}
 			} else {
-				if(!mainGame->dInfo.isReplay || (l & LOCATION_ONFIELD))
+				if(!mainGame->dInfo.isReplay || (l & LOCATION_ONFIELD)) {
 					field_confirm.push_back(pcard);
+}
 			}
 		}
 		if (field_confirm.size() > 0) {
@@ -2202,28 +2319,32 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					mainGame->dField.MoveCard(pcard, 5);
 					pcard->is_highlighting = true;
 				} else if (l == LOCATION_MZONE) {
-					if (pcard->position & POS_FACEUP)
+					if (pcard->position & POS_FACEUP) {
 						continue;
+}
 					pcard->dPos = irr::core::vector3df(0, 0, 0);
-					if (pcard->position == POS_FACEDOWN_ATTACK)
+					if (pcard->position == POS_FACEDOWN_ATTACK) {
 						pcard->dRot = irr::core::vector3df(0, 3.14159f / 5.0f, 0);
-					else
+					} else {
 						pcard->dRot = irr::core::vector3df(3.14159f / 5.0f, 0, 0);
+}
 					pcard->is_moving = true;
 					pcard->aniFrame = 5;
 				} else if (l == LOCATION_SZONE) {
-					if (pcard->position & POS_FACEUP)
+					if (pcard->position & POS_FACEUP) {
 						continue;
+}
 					pcard->dPos = irr::core::vector3df(0, 0, 0);
 					pcard->dRot = irr::core::vector3df(0, 3.14159f / 5.0f, 0);
 					pcard->is_moving = true;
 					pcard->aniFrame = 5;
 				}
 			}
-			if (mainGame->dInfo.isReplay)
+			if (mainGame->dInfo.isReplay) {
 				mainGame->WaitFrameSignal(30);
-			else
+			} else {
 				mainGame->WaitFrameSignal(90);
+}
 			for(int i = 0; i < (int)field_confirm.size(); ++i) {
 				pcard = field_confirm[i];
 				mainGame->dField.MoveCard(pcard, 5);
@@ -2246,14 +2367,16 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SHUFFLE_DECK: {
 		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		if(mainGame->dField.deck[player].size() < 2)
+		if(mainGame->dField.deck[player].size() < 2) {
 			return true;
+}
 		bool rev = mainGame->dField.deck_reversed;
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			mainGame->dField.deck_reversed = false;
 			if(rev) {
-				for (size_t i = 0; i < mainGame->dField.deck[player].size(); ++i)
+				for (size_t i = 0; i < mainGame->dField.deck[player].size(); ++i) {
 					mainGame->dField.MoveCard(mainGame->dField.deck[player][i], 10);
+}
 				mainGame->WaitFrameSignal(10);
 			}
 		}
@@ -2271,14 +2394,16 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					(*cit)->aniFrame = 3;
 				}
 				mainGame->WaitFrameSignal(3);
-				for (auto cit = mainGame->dField.deck[player].begin(); cit != mainGame->dField.deck[player].end(); ++cit)
+				for (auto cit = mainGame->dField.deck[player].begin(); cit != mainGame->dField.deck[player].end(); ++cit) {
 					mainGame->dField.MoveCard(*cit, 3);
+}
 				mainGame->WaitFrameSignal(3);
 			}
 			mainGame->dField.deck_reversed = rev;
 			if(rev) {
-				for (size_t i = 0; i < mainGame->dField.deck[player].size(); ++i)
+				for (size_t i = 0; i < mainGame->dField.deck[player].size(); ++i) {
 					mainGame->dField.MoveCard(mainGame->dField.deck[player][i], 10);
+}
 			}
 		}
 		return true;
@@ -2287,12 +2412,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		int count = BufferIO::ReadUInt8(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
-			if(count > 1)
+			if(count > 1) {
 				soundManager.PlaySoundEffect(SOUND_SHUFFLE);
+}
 			mainGame->WaitFrameSignal(5);
 			if(player == 1 && !mainGame->dInfo.isReplay && !mainGame->dInfo.isSingleMode) {
 				bool flip = false;
-				for (auto cit = mainGame->dField.hand[player].begin(); cit != mainGame->dField.hand[player].end(); ++cit)
+				for (auto cit = mainGame->dField.hand[player].begin(); cit != mainGame->dField.hand[player].end(); ++cit) {
 					if((*cit)->code) {
 						(*cit)->dPos = irr::core::vector3df(0, 0, 0);
 						(*cit)->dRot = irr::core::vector3df(1.322f / 5, 3.1415926f / 5, 0);
@@ -2301,8 +2427,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 						(*cit)->aniFrame = 5;
 						flip = true;
 					}
-				if(flip)
+}
+				if(flip) {
 					mainGame->WaitFrameSignal(5);
+}
 			}
 			for (auto cit = mainGame->dField.hand[player].begin(); cit != mainGame->dField.hand[player].end(); ++cit) {
 				(*cit)->dPos = irr::core::vector3df((3.9f - (*cit)->curPos.X) / 5, 0, 0);
@@ -2329,11 +2457,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_SHUFFLE_EXTRA: {
 		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		int count = BufferIO::ReadUInt8(pbuf);
-		if((mainGame->dField.extra[player].size() - mainGame->dField.extra_p_count[player]) < 2)
+		if((mainGame->dField.extra[player].size() - mainGame->dField.extra_p_count[player]) < 2) {
 			return true;
+}
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
-			if(count > 1)
+			if(count > 1) {
 				soundManager.PlaySoundEffect(SOUND_SHUFFLE);
+}
 			for (int i = 0; i < 5; ++i) {
 				for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit) {
 					if(!((*cit)->position & POS_FACEUP)) {
@@ -2344,15 +2474,19 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					}
 				}
 				mainGame->WaitFrameSignal(3);
-				for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit)
-					if(!((*cit)->position & POS_FACEUP))
+				for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit) {
+					if(!((*cit)->position & POS_FACEUP)) {
 						mainGame->dField.MoveCard(*cit, 3);
+}
+}
 				mainGame->WaitFrameSignal(3);
 			}
 		}
-		for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit)
-			if(!((*cit)->position & POS_FACEUP))
+		for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit) {
+			if(!((*cit)->position & POS_FACEUP)) {
 				(*cit)->SetCode(BufferIO::ReadInt32(pbuf));
+}
+}
 		return true;
 	}
 	case MSG_REFRESH_DECK: {
@@ -2363,8 +2497,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			mainGame->dField.grave[player].swap(mainGame->dField.deck[player]);
-			for (auto cit = mainGame->dField.grave[player].begin(); cit != mainGame->dField.grave[player].end(); ++cit)
+			for (auto cit = mainGame->dField.grave[player].begin(); cit != mainGame->dField.grave[player].end(); ++cit) {
 				(*cit)->location = LOCATION_GRAVE;
+}
 			int m = 0;
 			for (auto cit = mainGame->dField.deck[player].begin(); cit != mainGame->dField.deck[player].end(); ) {
 				if ((*cit)->type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK)) {
@@ -2406,10 +2541,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_REVERSE_DECK: {
 		mainGame->dField.deck_reversed = !mainGame->dField.deck_reversed;
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
-			for(size_t i = 0; i < mainGame->dField.deck[0].size(); ++i)
+			for(size_t i = 0; i < mainGame->dField.deck[0].size(); ++i) {
 				mainGame->dField.MoveCard(mainGame->dField.deck[0][i], 10);
-			for(size_t i = 0; i < mainGame->dField.deck[1].size(); ++i)
+}
+			for(size_t i = 0; i < mainGame->dField.deck[1].size(); ++i) {
 				mainGame->dField.MoveCard(mainGame->dField.deck[1][i], 10);
+}
 		}
 		return true;
 	}
@@ -2430,10 +2567,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		std::vector<ClientCard*>* lst = nullptr;
 		unsigned int loc = BufferIO::ReadUInt8(pbuf);
 		int count = BufferIO::ReadUInt8(pbuf);
-		if(loc == LOCATION_MZONE)
+		if(loc == LOCATION_MZONE) {
 			lst = mainGame->dField.mzone;
-		else
+		} else {
 			lst = mainGame->dField.szone;
+}
 		ClientCard* mc[5]{ nullptr };
 		ClientCard* swp = nullptr;
 		int c = 0, s = 0, ps = 0;
@@ -2452,8 +2590,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				mc[i]->aniFrame = 10;
 			}
 		}
-		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping)
+		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			mainGame->WaitFrameSignal(20);
+}
 		for (int i = 0; i < count; ++i) {
 			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 			l = BufferIO::ReadUInt8(pbuf);
@@ -2472,8 +2611,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			soundManager.PlaySoundEffect(SOUND_SHUFFLE);
 			for (int i = 0; i < count; ++i) {
 				mainGame->dField.MoveCard(mc[i], 10);
-				for (auto cit = mc[i]->overlayed.begin(); cit != mc[i]->overlayed.end(); ++cit)
+				for (auto cit = mc[i]->overlayed.begin(); cit != mc[i]->overlayed.end(); ++cit) {
 					mainGame->dField.MoveCard(*cit, 10);
+}
 			}
 			mainGame->WaitFrameSignal(11);
 		}
@@ -2503,10 +2643,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			}
 		}
 		if(mainGame->dInfo.isTag && mainGame->dInfo.turn != 1) {
-			if(player == 0)
+			if(player == 0) {
 				mainGame->dInfo.tag_player[0] = !mainGame->dInfo.tag_player[0];
-			else
+			} else {
 				mainGame->dInfo.tag_player[1] = !mainGame->dInfo.tag_player[1];
+}
 		}
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			soundManager.PlaySoundEffect(SOUND_NEXT_TURN);
@@ -2576,10 +2717,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		unsigned int cp = BufferIO::ReadUInt8(pbuf);
 		int reason = BufferIO::ReadInt32(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
-			if(cl & LOCATION_REMOVED && pl != cl)
+			if(cl & LOCATION_REMOVED && pl != cl) {
 				soundManager.PlaySoundEffect(SOUND_BANISHED);
-			else if(reason & REASON_DESTROY && pl != cl)
+			} else if(reason & REASON_DESTROY && pl != cl) {
 				soundManager.PlaySoundEffect(SOUND_DESTROYED);
+}
 		}
 		int appear = mainGame->gameConf.quick_animation ? 12 : 20;
 		if (pl == 0) {
@@ -2594,35 +2736,42 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				pcard->curAlpha = 5;
 				mainGame->dField.FadeCard(pcard, 255, appear);
 				mainGame->WaitFrameSignal(appear);
-			} else
+			} else {
 				mainGame->dField.AddCard(pcard, cc, cl, cs);
+}
 		} else if (cl == 0) {
 			ClientCard* pcard = mainGame->dField.GetCard(pc, pl, ps);
-			if (code != 0 && pcard->code != code)
+			if (code != 0 && pcard->code != code) {
 				pcard->SetCode(code);
+}
 			pcard->ClearTarget();
-			for(auto eqit = pcard->equipped.begin(); eqit != pcard->equipped.end(); ++eqit)
+			for(auto eqit = pcard->equipped.begin(); eqit != pcard->equipped.end(); ++eqit) {
 				(*eqit)->equipTarget = nullptr;
+}
 			if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 				mainGame->dField.FadeCard(pcard, 5, appear);
 				mainGame->WaitFrameSignal(appear);
 				mainGame->gMutex.lock();
 				mainGame->dField.RemoveCard(pc, pl, ps);
 				mainGame->gMutex.unlock();
-				if(pcard == mainGame->dField.hovered_card)
+				if(pcard == mainGame->dField.hovered_card) {
 					mainGame->dField.hovered_card = nullptr;
-			} else
+}
+			} else {
 				mainGame->dField.RemoveCard(pc, pl, ps);
+}
 			delete pcard;
 		} else {
 			if (!(pl & LOCATION_OVERLAY) && !(cl & LOCATION_OVERLAY)) {
 				ClientCard* pcard = mainGame->dField.GetCard(pc, pl, ps);
-				if (pcard->code != code && (code != 0 || cl == 0x40))
+				if (pcard->code != code && (code != 0 || cl == 0x40)) {
 					pcard->SetCode(code);
+}
 				pcard->cHint = 0;
 				pcard->chValue = 0;
-				if((pl & LOCATION_ONFIELD) && (cl != pl))
+				if((pl & LOCATION_ONFIELD) && (cl != pl)) {
 					pcard->counters.clear();
+}
 				if(cl != pl) {
 					pcard->ClearTarget();
 					if(pcard->equipTarget) {
@@ -2648,7 +2797,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					if (pl == cl && pc == cc && (cl & 0x71)) {
 						pcard->dPos = irr::core::vector3df(-0.3f, 0, 0);
 						pcard->dRot = irr::core::vector3df(0, 0, 0);
-						if (pc == 1) pcard->dPos.X = 0.3f;
+						if (pc == 1) { pcard->dPos.X = 0.3f;
+}
 						pcard->is_moving = true;
 						pcard->aniFrame = 5;
 						mainGame->WaitFrameSignal(5);
@@ -2657,22 +2807,26 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					} else {
 						if (cl == 0x4 && pcard->overlayed.size() > 0) {
 							mainGame->gMutex.lock();
-							for (size_t i = 0; i < pcard->overlayed.size(); ++i)
+							for (size_t i = 0; i < pcard->overlayed.size(); ++i) {
 								mainGame->dField.MoveCard(pcard->overlayed[i], 10);
+}
 							mainGame->gMutex.unlock();
 							mainGame->WaitFrameSignal(10);
 						}
 						if (cl == 0x2) {
 							mainGame->gMutex.lock();
-							for (size_t i = 0; i < mainGame->dField.hand[cc].size(); ++i)
+							for (size_t i = 0; i < mainGame->dField.hand[cc].size(); ++i) {
 								mainGame->dField.MoveCard(mainGame->dField.hand[cc][i], 10);
+}
 							mainGame->gMutex.unlock();
 						} else {
 							mainGame->gMutex.lock();
 							mainGame->dField.MoveCard(pcard, 10);
-							if (pl == 0x2)
-								for (size_t i = 0; i < mainGame->dField.hand[pc].size(); ++i)
+							if (pl == 0x2) {
+								for (size_t i = 0; i < mainGame->dField.hand[pc].size(); ++i) {
 									mainGame->dField.MoveCard(mainGame->dField.hand[pc][i], 10);
+}
+}
 							mainGame->gMutex.unlock();
 						}
 						mainGame->WaitFrameSignal(5);
@@ -2680,8 +2834,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				}
 			} else if (!(pl & LOCATION_OVERLAY)) {
 				ClientCard* pcard = mainGame->dField.GetCard(pc, pl, ps);
-				if (code != 0 && pcard->code != code)
+				if (code != 0 && pcard->code != code) {
 					pcard->SetCode(code);
+}
 				pcard->counters.clear();
 				pcard->ClearTarget();
 				if(pcard->equipTarget) {
@@ -2712,9 +2867,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					if (olcard->location == LOCATION_MZONE) {
 						mainGame->gMutex.lock();
 						mainGame->dField.MoveCard(pcard, 10);
-						if (pl == 0x2)
-							for (size_t i = 0; i < mainGame->dField.hand[pc].size(); ++i)
+						if (pl == 0x2) {
+							for (size_t i = 0; i < mainGame->dField.hand[pc].size(); ++i) {
 								mainGame->dField.MoveCard(mainGame->dField.hand[pc][i], 10);
+}
+}
 						mainGame->gMutex.unlock();
 						mainGame->WaitFrameSignal(5);
 					}
@@ -2728,8 +2885,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					pcard->position = cp;
 					mainGame->dField.AddCard(pcard, cc, cl, cs);
 					mainGame->dField.overlay_cards.erase(pcard);
-					for (size_t i = 0; i < olcard->overlayed.size(); ++i)
+					for (size_t i = 0; i < olcard->overlayed.size(); ++i) {
 						olcard->overlayed[i]->sequence = (unsigned char)i;
+}
 				} else {
 					mainGame->gMutex.lock();
 					olcard->overlayed.erase(olcard->overlayed.begin() + pcard->sequence);
@@ -2792,8 +2950,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			pcard->counters.clear();
 			pcard->ClearTarget();
 		}
-		if (code != 0 && pcard->code != code)
+		if (code != 0 && pcard->code != code) {
 			pcard->SetCode(code);
+}
 		pcard->position = cp;
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			myswprintf(event_string, dataManager.GetSysString(1600));
@@ -2808,8 +2967,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		/*int cl = */BufferIO::ReadUInt8(pbuf);
 		/*int cs = */BufferIO::ReadUInt8(pbuf);
 		/*int cp = */BufferIO::ReadUInt8(pbuf);
-		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping)
+		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			soundManager.PlaySoundEffect(SOUND_SET);
+}
 		myswprintf(event_string, dataManager.GetSysString(1601));
 		return true;
 	}
@@ -2835,10 +2995,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->dField.AddCard(pc2, c1, l1, s1);
 			mainGame->dField.MoveCard(pc1, 10);
 			mainGame->dField.MoveCard(pc2, 10);
-			for (size_t i = 0; i < pc1->overlayed.size(); ++i)
+			for (size_t i = 0; i < pc1->overlayed.size(); ++i) {
 				mainGame->dField.MoveCard(pc1->overlayed[i], 10);
-			for (size_t i = 0; i < pc2->overlayed.size(); ++i)
+}
+			for (size_t i = 0; i < pc2->overlayed.size(); ++i) {
 				mainGame->dField.MoveCard(pc2->overlayed[i], 10);
+}
 			mainGame->gMutex.unlock();
 			mainGame->WaitFrameSignal(11);
 		} else {
@@ -2851,8 +3013,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_FIELD_DISABLED: {
 		unsigned int disabled = BufferIO::ReadInt32(pbuf);
-		if (!mainGame->dInfo.isFirst)
+		if (!mainGame->dInfo.isFirst) {
 			disabled = (disabled >> 16) | (disabled << 16);
+}
 		mainGame->dField.disabled_field = disabled;
 		return true;
 	}
@@ -2887,10 +3050,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		/*int cp = */BufferIO::ReadUInt8(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			CardData cd;
-			if(dataManager.GetData(code, &cd) && (cd.type & TYPE_TOKEN))
+			if(dataManager.GetData(code, &cd) && (cd.type & TYPE_TOKEN)) {
 				soundManager.PlaySoundEffect(SOUND_TOKEN);
-			else
+			} else {
 				soundManager.PlaySoundEffect(SOUND_SPECIAL_SUMMON);
+}
 			myswprintf(event_string, dataManager.GetSysString(1605), dataManager.GetName(code));
 			mainGame->showcardcode = code;
 			mainGame->showcarddif = 1;
@@ -2944,8 +3108,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int cs = BufferIO::ReadUInt8(pbuf);
 		int desc = BufferIO::ReadInt32(pbuf);
 		/*int ct = */BufferIO::ReadUInt8(pbuf);
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		soundManager.PlaySoundEffect(SOUND_ACTIVATE);
 		ClientCard* pcard = mainGame->dField.GetCard(pcc, pcl, pcs, subs);
 		if(pcard->code != code) {
@@ -2958,15 +3123,17 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		pcard->is_highlighting = true;
 		if(pcard->location & 0x30) {
 			float shift = -0.15f;
-			if(cc == 1) shift = 0.15f;
+			if(cc == 1) { shift = 0.15f;
+}
 			pcard->dPos = irr::core::vector3df(shift, 0, 0);
 			pcard->dRot = irr::core::vector3df(0, 0, 0);
 			pcard->is_moving = true;
 			pcard->aniFrame = 5;
 			mainGame->WaitFrameSignal(30);
 			mainGame->dField.MoveCard(pcard, 5);
-		} else
+		} else {
 			mainGame->WaitFrameSignal(30);
+}
 		pcard->is_highlighting = false;
 		mainGame->dField.current_chain.chain_card = pcard;
 		mainGame->dField.current_chain.code = code;
@@ -2980,39 +3147,46 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int chc = 0;
 		for(auto chit = mainGame->dField.chains.begin(); chit != mainGame->dField.chains.end(); ++chit) {
 			if (cl == 0x10 || cl == 0x20) {
-				if (chit->controler == cc && chit->location == cl)
+				if (chit->controler == cc && chit->location == cl) {
 					chc++;
+}
 			} else {
-				if (chit->controler == cc && chit->location == cl && chit->sequence == cs)
+				if (chit->controler == cc && chit->location == cl && chit->sequence == cs) {
 					chc++;
+}
 			}
 		}
-		if(cl == LOCATION_HAND)
+		if(cl == LOCATION_HAND) {
 			mainGame->dField.current_chain.chain_pos.X += 0.35f;
-		else
+		} else {
 			mainGame->dField.current_chain.chain_pos.Y += chc * 0.25f;
+}
 		return true;
 	}
 	case MSG_CHAINED: {
 		int ct = BufferIO::ReadUInt8(pbuf);
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		myswprintf(event_string, dataManager.GetSysString(1609), dataManager.GetName(mainGame->dField.current_chain.code));
 		mainGame->gMutex.lock();
 		mainGame->dField.chains.push_back(mainGame->dField.current_chain);
 		mainGame->gMutex.unlock();
-		if (ct > 1)
+		if (ct > 1) {
 			mainGame->WaitFrameSignal(20);
+}
 		mainGame->dField.last_chain = true;
 		return true;
 	}
 	case MSG_CHAIN_SOLVING: {
 		int ct = BufferIO::ReadUInt8(pbuf);
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		if(mainGame->dField.chains.size() > 1 || mainGame->gameConf.draw_single_chain) {
-			if (mainGame->dField.last_chain)
+			if (mainGame->dField.last_chain) {
 				mainGame->WaitFrameSignal(11);
+}
 			for(int i = 0; i < 5; ++i) {
 				mainGame->dField.chains[ct - 1].solved = false;
 				mainGame->WaitFrameSignal(3);
@@ -3029,8 +3203,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_CHAIN_END: {
 		for(auto chit = mainGame->dField.chains.begin(); chit != mainGame->dField.chains.end(); ++chit) {
-			for(auto tgit = chit->target.begin(); tgit != chit->target.end(); ++tgit)
+			for(auto tgit = chit->target.begin(); tgit != chit->target.end(); ++tgit) {
 				(*tgit)->is_showchaintarget = false;
+}
 			chit->chain_card->is_showchaintarget = false;
 		}
 		mainGame->dField.chains.clear();
@@ -3065,15 +3240,17 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			unsigned int l = BufferIO::ReadUInt8(pbuf);
 			int s = BufferIO::ReadUInt8(pbuf);
 			int ss = BufferIO::ReadUInt8(pbuf);
-			if (l & LOCATION_OVERLAY)
+			if (l & LOCATION_OVERLAY) {
 				pcards[i] = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
-			else
+			} else {
 				pcards[i] = mainGame->dField.GetCard(c, l, s);
+}
 			pcards[i]->is_highlighting = true;
 		}
 		mainGame->WaitFrameSignal(30);
-		for(int i = 0; i < count; ++i)
+		for(int i = 0; i < count; ++i) {
 			pcards[i]->is_highlighting = false;
+}
 		return true;
 	}
 	case MSG_BECOME_TARGET: {
@@ -3100,15 +3277,17 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				}
 			} else if(pcard->location & 0x30) {
 				float shift = -0.15f;
-				if(c == 1) shift = 0.15f;
+				if(c == 1) { shift = 0.15f;
+}
 				pcard->dPos = irr::core::vector3df(shift, 0, 0);
 				pcard->dRot = irr::core::vector3df(0, 0, 0);
 				pcard->is_moving = true;
 				pcard->aniFrame = 5;
 				mainGame->WaitFrameSignal(30);
 				mainGame->dField.MoveCard(pcard, 5);
-			} else
+			} else {
 				mainGame->WaitFrameSignal(30);
+}
 			myswprintf(textBuffer, dataManager.GetSysString(1610), dataManager.GetName(pcard->code), dataManager.FormatLocation(l, s), s + 1);
 			mainGame->AddLog(textBuffer, pcard->code);
 			pcard->is_highlighting = false;
@@ -3122,8 +3301,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		for (int i = 0; i < count; ++i) {
 			unsigned int code = BufferIO::ReadInt32(pbuf);
 			pcard = mainGame->dField.GetCard(player, LOCATION_DECK, mainGame->dField.deck[player].size() - 1 - i);
-			if(!mainGame->dField.deck_reversed || code)
+			if(!mainGame->dField.deck_reversed || code) {
 				pcard->SetCode(code & 0x7fffffff);
+}
 		}
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			for (int i = 0; i < count; ++i) {
@@ -3138,23 +3318,26 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				pcard = mainGame->dField.GetCard(player, LOCATION_DECK, mainGame->dField.deck[player].size() - 1);
 				mainGame->dField.deck[player].erase(mainGame->dField.deck[player].end() - 1);
 				mainGame->dField.AddCard(pcard, player, LOCATION_HAND, 0);
-				for(int j = 0; j < (int)mainGame->dField.hand[player].size(); ++j)
+				for(int j = 0; j < (int)mainGame->dField.hand[player].size(); ++j) {
 					mainGame->dField.MoveCard(mainGame->dField.hand[player][j], 10);
+}
 				mainGame->gMutex.unlock();
 				mainGame->WaitFrameSignal(5);
 			}
 		}
-		if (player == 0)
+		if (player == 0) {
 			myswprintf(event_string, dataManager.GetSysString(1611), count);
-		else myswprintf(event_string, dataManager.GetSysString(1612), count);
+		} else { myswprintf(event_string, dataManager.GetSysString(1612), count);
+}
 		return true;
 	}
 	case MSG_DAMAGE: {
 		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		int val = BufferIO::ReadInt32(pbuf);
 		int final = mainGame->dInfo.lp[player] - val;
-		if (final < 0)
+		if (final < 0) {
 			final = 0;
+}
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			mainGame->dInfo.lp[player] = final;
 			myswprintf(mainGame->dInfo.strLP[player], L"%d", mainGame->dInfo.lp[player]);
@@ -3162,10 +3345,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		}
 		soundManager.PlaySoundEffect(SOUND_DAMAGE);
 		mainGame->lpd = (mainGame->dInfo.lp[player] - final) / 10;
-		if (player == 0)
+		if (player == 0) {
 			myswprintf(event_string, dataManager.GetSysString(1613), val);
-		else
+		} else {
 			myswprintf(event_string, dataManager.GetSysString(1614), val);
+}
 		mainGame->lpccolor = 0xffff0000;
 		mainGame->lpplayer = player;
 		myswprintf(textBuffer, L"-%d", val);
@@ -3191,10 +3375,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		}
 		soundManager.PlaySoundEffect(SOUND_RECOVER);
 		mainGame->lpd = (mainGame->dInfo.lp[player] - final) / 10;
-		if (player == 0)
+		if (player == 0) {
 			myswprintf(event_string, dataManager.GetSysString(1615), val);
-		else
+		} else {
 			myswprintf(event_string, dataManager.GetSysString(1616), val);
+}
 		mainGame->lpccolor = 0xff00ff00;
 		mainGame->lpplayer = player;
 		myswprintf(textBuffer, L"+%d", val);
@@ -3221,8 +3406,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pc1 = mainGame->dField.GetCard(c1, l1, s1);
 		ClientCard* pc2 = mainGame->dField.GetCard(c2, l2, s2);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
-			if(pc1->equipTarget)
+			if(pc1->equipTarget) {
 				pc1->equipTarget->equipped.erase(pc1);
+}
 			pc1->equipTarget = pc2;
 			pc2->equipped.insert(pc1);
 		} else {
@@ -3235,10 +3421,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			}
 			pc1->equipTarget = pc2;
 			pc2->equipped.insert(pc1);
-			if (mainGame->dField.hovered_card == pc1)
+			if (mainGame->dField.hovered_card == pc1) {
 				pc2->is_showequip = true;
-			else if (mainGame->dField.hovered_card == pc2)
+			} else if (mainGame->dField.hovered_card == pc2) {
 				pc1->is_showequip = true;
+}
 			mainGame->gMutex.unlock();
 		}
 		return true;
@@ -3272,10 +3459,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			pc->equipTarget = nullptr;
 		} else {
 			mainGame->gMutex.lock();
-			if (mainGame->dField.hovered_card == pc)
+			if (mainGame->dField.hovered_card == pc) {
 				pc->equipTarget->is_showequip = false;
-			else if (mainGame->dField.hovered_card == pc->equipTarget)
+			} else if (mainGame->dField.hovered_card == pc->equipTarget) {
 				pc->is_showequip = false;
+}
 			pc->equipTarget->equipped.erase(pc);
 			pc->equipTarget = nullptr;
 			mainGame->gMutex.unlock();
@@ -3300,10 +3488,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->gMutex.lock();
 			pc1->cardTarget.insert(pc2);
 			pc2->ownerTarget.insert(pc1);
-			if (mainGame->dField.hovered_card == pc1)
+			if (mainGame->dField.hovered_card == pc1) {
 				pc2->is_showtarget = true;
-			else if (mainGame->dField.hovered_card == pc2)
+			} else if (mainGame->dField.hovered_card == pc2) {
 				pc1->is_showtarget = true;
+}
 			mainGame->gMutex.unlock();
 		}
 		break;
@@ -3326,10 +3515,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->gMutex.lock();
 			pc1->cardTarget.erase(pc2);
 			pc2->ownerTarget.erase(pc1);
-			if (mainGame->dField.hovered_card == pc1)
+			if (mainGame->dField.hovered_card == pc1) {
 				pc2->is_showtarget = false;
-			else if (mainGame->dField.hovered_card == pc2)
+			} else if (mainGame->dField.hovered_card == pc2) {
 				pc1->is_showtarget = false;
+}
 			mainGame->gMutex.unlock();
 		}
 		break;
@@ -3338,8 +3528,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		int cost = BufferIO::ReadInt32(pbuf);
 		int final = mainGame->dInfo.lp[player] - cost;
-		if (final < 0)
+		if (final < 0) {
 			final = 0;
+}
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			mainGame->dInfo.lp[player] = final;
 			myswprintf(mainGame->dInfo.strLP[player], L"%d", mainGame->dInfo.lp[player]);
@@ -3368,11 +3559,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int s = BufferIO::ReadUInt8(pbuf);
 		int count = BufferIO::ReadInt16(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c, l, s);
-		if (pc->counters.count(type))
+		if (pc->counters.count(type)) {
 			pc->counters[type] += count;
-		else pc->counters[type] = count;
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		} else { pc->counters[type] = count;
+}
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		soundManager.PlaySoundEffect(SOUND_COUNTER_ADD);
 		myswprintf(textBuffer, dataManager.GetSysString(1617), dataManager.GetName(pc->code), count, dataManager.GetCounterName(type));
 		pc->is_highlighting = true;
@@ -3392,10 +3585,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int count = BufferIO::ReadInt16(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c, l, s);
 		pc->counters[type] -= count;
-		if (pc->counters[type] <= 0)
+		if (pc->counters[type] <= 0) {
 			pc->counters.erase(type);
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+}
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		soundManager.PlaySoundEffect(SOUND_COUNTER_REMOVE);
 		myswprintf(textBuffer, dataManager.GetSysString(1618), dataManager.GetName(pc->code), count, dataManager.GetCounterName(type));
 		pc->is_highlighting = true;
@@ -3417,8 +3612,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		unsigned int ld = BufferIO::ReadUInt8(pbuf);
 		int sd = BufferIO::ReadUInt8(pbuf);
 		BufferIO::ReadUInt8(pbuf);
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		float sy = NAN;
 		if (ld != 0) {
 			soundManager.PlaySoundEffect(SOUND_ATTACK);
@@ -3431,10 +3627,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			float yd = mainGame->dField.attack_target->curPos.Y;
 			sy = (float)sqrt((xa - xd) * (xa - xd) + (ya - yd) * (ya - yd)) / 2;
 			mainGame->atk_t = vector3df((xa + xd) / 2, (ya + yd) / 2, 0);
-			if (ca == 0)
+			if (ca == 0) {
 				mainGame->atk_r = vector3df(0, 0, -atan((xd - xa) / (yd - ya)));
-			else
+			} else {
 				mainGame->atk_r = vector3df(0, 0, 3.1415926 - atan((xd - xa) / (yd - ya)));
+}
 		} else {
 			soundManager.PlaySoundEffect(SOUND_DIRECT_ATTACK);
 			myswprintf(event_string, dataManager.GetSysString(1620), dataManager.GetName(mainGame->dField.attacker->code));
@@ -3442,14 +3639,16 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			float ya = mainGame->dField.attacker->curPos.Y;
 			float xd = 3.95f;
 			float yd = 3.5f;
-			if (ca == 0)
+			if (ca == 0) {
 				yd = -3.5f;
+}
 			sy = (float)sqrt((xa - xd) * (xa - xd) + (ya - yd) * (ya - yd)) / 2;
 			mainGame->atk_t = vector3df((xa + xd) / 2, (ya + yd) / 2, 0);
-			if (ca == 0)
+			if (ca == 0) {
 				mainGame->atk_r = vector3df(0, 0, -atan((xd - xa) / (yd - ya)));
-			else
+			} else {
 				mainGame->atk_r = vector3df(0, 0, 3.1415926 - atan((xd - xa) / (yd - ya)));
+}
 		}
 		matManager.GenArrow(sy);
 		mainGame->attack_sv = 0;
@@ -3473,8 +3672,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int datk = BufferIO::ReadInt32(pbuf);
 		int ddef = BufferIO::ReadInt32(pbuf);
 		/*int dd = */BufferIO::ReadUInt8(pbuf);
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		mainGame->gMutex.lock();
 		ClientCard* pcard = mainGame->dField.GetCard(ca, la, sa);
 		if(aatk != pcard->attack) {
@@ -3528,8 +3728,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			*pwbuf++ = L']';
 		}
 		*pwbuf = 0;
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		soundManager.PlaySoundEffect(SOUND_COIN);
 		mainGame->gMutex.lock();
 		mainGame->AddLog(textBuffer);
@@ -3551,8 +3752,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			*pwbuf++ = L']';
 		}
 		*pwbuf = 0;
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		soundManager.PlaySoundEffect(SOUND_DICE);
 		mainGame->gMutex.lock();
 		mainGame->AddLog(textBuffer);
@@ -3564,8 +3766,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_ROCK_PAPER_SCISSORS: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		mainGame->gMutex.lock();
 		mainGame->PopupElement(mainGame->wHand);
 		mainGame->gMutex.unlock();
@@ -3573,15 +3776,17 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_HAND_RES: {
 		int res = BufferIO::ReadUInt8(pbuf);
-		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			return true;
+}
 		mainGame->stHintMsg->setVisible(false);
 		int res1 = (res & 0x3) - 1;
 		int res2 = ((res >> 2) & 0x3) - 1;
-		if(mainGame->dInfo.isFirst)
+		if(mainGame->dInfo.isFirst) {
 			mainGame->showcardcode = res1 + (res2 << 16);
-		else
+		} else {
 			mainGame->showcardcode = res2 + (res1 << 16);
+}
 		mainGame->showcarddif = 50;
 		mainGame->showcardp = 0;
 		mainGame->showcard = 100;
@@ -3594,13 +3799,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int available = BufferIO::ReadInt32(pbuf);
 		for(int i = 0, filter = 0x1; i < RACES_COUNT; ++i, filter <<= 1) {
 			mainGame->chkRace[i]->setChecked(false);
-			if(filter & available)
+			if(filter & available) {
 				mainGame->chkRace[i]->setVisible(true);
-			else mainGame->chkRace[i]->setVisible(false);
+			} else { mainGame->chkRace[i]->setVisible(false);
+}
 		}
-		if(select_hint)
+		if(select_hint) {
 			myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
-		else myswprintf(textBuffer, dataManager.GetSysString(563));
+		} else { myswprintf(textBuffer, dataManager.GetSysString(563));
+}
 		select_hint = 0;
 		mainGame->gMutex.lock();
 		mainGame->wANRace->setText(textBuffer);
@@ -3614,13 +3821,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int available = BufferIO::ReadInt32(pbuf);
 		for(int i = 0, filter = 0x1; i < 7; ++i, filter <<= 1) {
 			mainGame->chkAttribute[i]->setChecked(false);
-			if(filter & available)
+			if(filter & available) {
 				mainGame->chkAttribute[i]->setVisible(true);
-			else mainGame->chkAttribute[i]->setVisible(false);
+			} else { mainGame->chkAttribute[i]->setVisible(false);
+}
 		}
-		if(select_hint)
+		if(select_hint) {
 			myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
-		else myswprintf(textBuffer, dataManager.GetSysString(562));
+		} else { myswprintf(textBuffer, dataManager.GetSysString(562));
+}
 		select_hint = 0;
 		mainGame->gMutex.lock();
 		mainGame->wANAttribute->setText(textBuffer);
@@ -3632,11 +3841,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		int count = BufferIO::ReadUInt8(pbuf);
 		mainGame->dField.declare_opcodes.clear();
-		for (int i = 0; i < count; ++i)
+		for (int i = 0; i < count; ++i) {
 			mainGame->dField.declare_opcodes.push_back(buffer_read<uint32_t>(pbuf));
-		if(select_hint)
+}
+		if(select_hint) {
 			myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
-		else myswprintf(textBuffer, dataManager.GetSysString(564));
+		} else { myswprintf(textBuffer, dataManager.GetSysString(564));
+}
 		select_hint = 0;
 		mainGame->gMutex.lock();
 		mainGame->ebANCard->setText(L"");
@@ -3689,9 +3900,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			pos.LowerRightCorner.Y = pos.UpperLeftCorner.Y + 95;
 			mainGame->wANNumber->setRelativePosition(pos);
 		}
-		if(select_hint)
+		if(select_hint) {
 			myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
-		else myswprintf(textBuffer, dataManager.GetSysString(565));
+		} else { myswprintf(textBuffer, dataManager.GetSysString(565));
+}
 		select_hint = 0;
 		mainGame->wANNumber->setText(textBuffer);
 		mainGame->PopupElement(mainGame->wANNumber);
@@ -3706,24 +3918,29 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int chtype = BufferIO::ReadUInt8(pbuf);
 		int value = BufferIO::ReadInt32(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
-		if(!pcard)
+		if(!pcard) {
 			return true;
+}
 		if(chtype == CHINT_DESC_ADD) {
 			pcard->desc_hints[value]++;
 		} else if(chtype == CHINT_DESC_REMOVE) {
 			pcard->desc_hints[value]--;
-			if(pcard->desc_hints[value] == 0)
+			if(pcard->desc_hints[value] == 0) {
 				pcard->desc_hints.erase(value);
+}
 		} else {
 			pcard->cHint = chtype;
 			pcard->chValue = value;
 			if(chtype == CHINT_TURN) {
-				if(value == 0)
+				if(value == 0) {
 					return true;
-				if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
+}
+				if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 					return true;
-				if(pcard->location & LOCATION_ONFIELD)
+}
+				if(pcard->location & LOCATION_ONFIELD) {
 					pcard->is_highlighting = true;
+}
 				mainGame->showcardcode = pcard->code;
 				mainGame->showcarddif = 0;
 				mainGame->showcardp = value - 1;
@@ -3751,8 +3968,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			player_desc_hints[value]++;
 		} else if(chtype == PHINT_DESC_REMOVE) {
 			player_desc_hints[value]--;
-			if(player_desc_hints[value] == 0)
+			if(player_desc_hints[value] == 0) {
 				player_desc_hints.erase(value);
+}
 		}
 		return true;
 	}
@@ -3769,22 +3987,25 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int topcode = BufferIO::ReadInt32(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			for (auto cit = mainGame->dField.deck[player].begin(); cit != mainGame->dField.deck[player].end(); ++cit) {
-				if(player == 0) (*cit)->dPos.Y = 0.4f;
-				else (*cit)->dPos.Y = -0.6f;
+				if(player == 0) { (*cit)->dPos.Y = 0.4f;
+				} else { (*cit)->dPos.Y = -0.6f;
+}
 				(*cit)->dRot = irr::core::vector3df(0, 0, 0);
 				(*cit)->is_moving = true;
 				(*cit)->aniFrame = 5;
 			}
 			for (auto cit = mainGame->dField.hand[player].begin(); cit != mainGame->dField.hand[player].end(); ++cit) {
-				if(player == 0) (*cit)->dPos.Y = 0.4f;
-				else (*cit)->dPos.Y = -0.6f;
+				if(player == 0) { (*cit)->dPos.Y = 0.4f;
+				} else { (*cit)->dPos.Y = -0.6f;
+}
 				(*cit)->dRot = irr::core::vector3df(0, 0, 0);
 				(*cit)->is_moving = true;
 				(*cit)->aniFrame = 5;
 			}
 			for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit) {
-				if(player == 0) (*cit)->dPos.Y = 0.4f;
-				else (*cit)->dPos.Y = -0.6f;
+				if(player == 0) { (*cit)->dPos.Y = 0.4f;
+				} else { (*cit)->dPos.Y = -0.6f;
+}
 				(*cit)->dRot = irr::core::vector3df(0, 0, 0);
 				(*cit)->is_moving = true;
 				(*cit)->aniFrame = 5;
@@ -3792,8 +4013,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->WaitFrameSignal(5);
 		}
 		//
-		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping)
+		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			mainGame->gMutex.lock();
+}
 		if(mainGame->dField.deck[player].size() > mcount) {
 			while(mainGame->dField.deck[player].size() > mcount) {
 				ClientCard* ccard = *mainGame->dField.deck[player].rbegin();
@@ -3840,33 +4062,38 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			}
 		}
 		mainGame->dField.extra_p_count[player] = pcount;
-		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping)
+		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			mainGame->gMutex.unlock();
+}
 		//
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			for (auto cit = mainGame->dField.deck[player].begin(); cit != mainGame->dField.deck[player].end(); ++cit) {
 				ClientCard* pcard = *cit;
 				mainGame->dField.GetCardLocation(pcard, &pcard->curPos, &pcard->curRot);
-				if(player == 0) pcard->curPos.Y += 2.0f;
-				else pcard->curPos.Y -= 3.0f;
+				if(player == 0) { pcard->curPos.Y += 2.0f;
+				} else { pcard->curPos.Y -= 3.0f;
+}
 				mainGame->dField.MoveCard(*cit, 5);
 			}
-			if(mainGame->dField.deck[player].size())
+			if(mainGame->dField.deck[player].size()) {
 				(*mainGame->dField.deck[player].rbegin())->code = topcode;
+}
 			for (auto cit = mainGame->dField.hand[player].begin(); cit != mainGame->dField.hand[player].end(); ++cit) {
 				ClientCard* pcard = *cit;
 				pcard->code = BufferIO::ReadInt32(pbuf);
 				mainGame->dField.GetCardLocation(pcard, &pcard->curPos, &pcard->curRot);
-				if(player == 0) pcard->curPos.Y += 2.0f;
-				else pcard->curPos.Y -= 3.0f;
+				if(player == 0) { pcard->curPos.Y += 2.0f;
+				} else { pcard->curPos.Y -= 3.0f;
+}
 				mainGame->dField.MoveCard(*cit, 5);
 			}
 			for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit) {
 				ClientCard* pcard = *cit;
 				pcard->code = BufferIO::ReadInt32(pbuf) & 0x7fffffff;
 				mainGame->dField.GetCardLocation(pcard, &pcard->curPos, &pcard->curRot);
-				if(player == 0) pcard->curPos.Y += 2.0f;
-				else pcard->curPos.Y -= 3.0f;
+				if(player == 0) { pcard->curPos.Y += 2.0f;
+				} else { pcard->curPos.Y -= 3.0f;
+}
 				mainGame->dField.MoveCard(*cit, 5);
 			}
 			mainGame->WaitFrameSignal(5);
@@ -3963,17 +4190,20 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			int chc = 0;
 			for(auto chit = mainGame->dField.chains.begin(); chit != mainGame->dField.chains.end(); ++chit) {
 				if(cl == 0x10 || cl == 0x20) {
-					if(chit->controler == cc && chit->location == cl)
+					if(chit->controler == cc && chit->location == cl) {
 						chc++;
+}
 				} else {
-					if(chit->controler == cc && chit->location == cl && chit->sequence == cs)
+					if(chit->controler == cc && chit->location == cl && chit->sequence == cs) {
 						chc++;
+}
 				}
 			}
-			if(cl == LOCATION_HAND)
+			if(cl == LOCATION_HAND) {
 				mainGame->dField.current_chain.chain_pos.X += 0.35f;
-			else
+			} else {
 				mainGame->dField.current_chain.chain_pos.Y += chc * 0.25f;
+}
 			mainGame->dField.chains.push_back(mainGame->dField.current_chain);
 		}
 		if(val) {
@@ -3994,8 +4224,9 @@ void DuelClient::SetResponseI(int32_t respI) {
 	response_len = sizeof respI;
 }
 void DuelClient::SetResponseB(void* respB, size_t len) {
-	if (len > SIZE_RETURN_VALUE)
+	if (len > SIZE_RETURN_VALUE) {
 		len = SIZE_RETURN_VALUE;
+}
 	std::memcpy(response_buf, respB, len);
 	response_len = len;
 }
@@ -4036,8 +4267,9 @@ void DuelClient::SendResponse() {
 	}
 }
 void DuelClient::BeginRefreshHost() {
-	if(is_refreshing)
+	if(is_refreshing) {
 		return;
+}
 	is_refreshing = true;
 	mainGame->btnLanRefresh->setEnabled(false);
 	mainGame->lstHostList->clear();
@@ -4047,8 +4279,9 @@ void DuelClient::BeginRefreshHost() {
 	char hname[256];
 	gethostname(hname, 256);
 	hostent* host = gethostbyname(hname);
-	if(!host)
+	if(!host) {
 		return;
+}
 	SOCKET reply = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	sockaddr_in reply_addr;
 	std::memset(&reply_addr, 0, sizeof reply_addr);
@@ -4074,14 +4307,16 @@ void DuelClient::BeginRefreshHost() {
 	HostRequest hReq;
 	hReq.identifier = NETWORK_CLIENT_ID;
 	for(int i = 0; i < 8; ++i) {
-		if(host->h_addr_list[i] == nullptr)
+		if(host->h_addr_list[i] == nullptr) {
 			break;
+}
 		unsigned int local_addr = 0;
 		std::memcpy(&local_addr, host->h_addr_list[i], sizeof local_addr);
 		local.sin_addr.s_addr = local_addr;
 		SOCKET sSend = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-		if(sSend == INVALID_SOCKET)
+		if(sSend == INVALID_SOCKET) {
 			break;
+}
 		int opt = TRUE;
 		setsockopt(sSend, SOL_SOCKET, SO_BROADCAST, (const char*)&opt, sizeof opt);
 		if(bind(sSend, (sockaddr*)&local, sizeof(sockaddr)) == SOCKET_ERROR) {
@@ -4106,8 +4341,9 @@ void DuelClient::BroadcastReply(evutil_socket_t fd, short events, void * arg) {
 	if(events & EV_TIMEOUT) {
 		evutil_closesocket(fd);
 		event_base_loopbreak((event_base*)arg);
-		if(!is_closing)
+		if(!is_closing) {
 			mainGame->btnLanRefresh->setEnabled(true);
+}
 	} else if(events & EV_READ) {
 		sockaddr_in bc_addr;
 		socklen_t sz = sizeof(sockaddr_in);
@@ -4116,10 +4352,12 @@ void DuelClient::BroadcastReply(evutil_socket_t fd, short events, void * arg) {
 		HostPacket packet;
 		std::memcpy(&packet, buf, sizeof packet);
 		HostPacket* pHP = &packet;
-		if(is_closing || pHP->identifier != NETWORK_SERVER_ID)
+		if(is_closing || pHP->identifier != NETWORK_SERVER_ID) {
 			return;
-		if(pHP->version != PRO_VERSION)
+}
+		if(pHP->version != PRO_VERSION) {
 			return;
+}
 		unsigned int ipaddr = bc_addr.sin_addr.s_addr;
 		const auto remote = std::make_pair(ipaddr, pHP->port);
 		if(remotes.find(remote) == remotes.end()) {
@@ -4137,9 +4375,10 @@ void DuelClient::BroadcastReply(evutil_socket_t fd, short events, void * arg) {
 			hoststr.append(L"][");
 			if(pHP->host.draw_count == 1 && pHP->host.start_hand == 5 && pHP->host.start_lp == 8000
 			        && !pHP->host.no_check_deck && !pHP->host.no_shuffle_deck
-			        && pHP->host.duel_rule == DEFAULT_DUEL_RULE)
+			        && pHP->host.duel_rule == DEFAULT_DUEL_RULE) {
 				hoststr.append(dataManager.GetSysString(1247));
-			else hoststr.append(dataManager.GetSysString(1248));
+			} else { hoststr.append(dataManager.GetSysString(1248));
+}
 			hoststr.append(L"]");
 			wchar_t gamename[20];
 			BufferIO::CopyCharArray(pHP->name, gamename);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -721,7 +721,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		if(mainGame->dInfo.player_type < 7)
 			mainGame->btnLeaveGame->setVisible(false);
 		mainGame->CloseGameButtons();
-		auto prep = pdata;
+		auto *prep = pdata;
 		Replay new_replay;
 		std::memcpy(&new_replay.pheader, prep, sizeof(new_replay.pheader));
 		time_t starttime;
@@ -817,7 +817,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		soundManager.PlaySoundEffect(SOUND_PLAYER_ENTER);
 		STOC_HS_PlayerEnter packet;
 		std::memcpy(&packet, pdata, STOC_HS_PlayerEnter_size);
-		auto pkt = &packet;
+		auto *pkt = &packet;
 		if(pkt->pos > 3)
 			break;
 		wchar_t name[20];
@@ -971,7 +971,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	switch(mainGame->dInfo.curMsg) {
 	case MSG_RETRY: {
 		if(last_successful_msg_length) {
-			auto p = last_successful_msg;
+			auto *p = last_successful_msg;
 			auto last_msg = BufferIO::ReadUInt8(p);
 			int err_desc = 1421;
 			switch(last_msg) {

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1,5 +1,7 @@
 #include "config.h"
 #include "duelclient.h"
+
+#include <math.h>
 #include "client_card.h"
 #include "materials.h"
 #include "image_manager.h"
@@ -724,7 +726,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		auto *prep = pdata;
 		Replay new_replay;
 		std::memcpy(&new_replay.pheader, prep, sizeof(new_replay.pheader));
-		time_t starttime;
+		time_t starttime = 0;
 		if (new_replay.pheader.flag & REPLAY_UNIFORM)
 			starttime = new_replay.pheader.start_time;
 		else
@@ -1299,9 +1301,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SELECT_BATTLECMD: {
 		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
-		int desc, count, con, seq/*, diratt*/;
-		unsigned int code, loc;
-		ClientCard* pcard;
+		int desc = 0, count = 0, con = 0, seq = 0/*, diratt*/;
+		unsigned int code = 0, loc = 0;
+		ClientCard* pcard = nullptr;
 		mainGame->dField.activatable_cards.clear();
 		mainGame->dField.activatable_descs.clear();
 		mainGame->dField.conti_cards.clear();
@@ -1364,9 +1366,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SELECT_IDLECMD: {
 		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
-		int desc, count, con, seq;
-		unsigned int code, loc;
-		ClientCard* pcard;
+		int desc = 0, count = 0, con = 0, seq = 0;
+		unsigned int code = 0, loc = 0;
+		ClientCard* pcard = nullptr;
 		mainGame->dField.summonable_cards.clear();
 		count = BufferIO::ReadUInt8(pbuf);
 		for (int i = 0; i < count; ++i) {
@@ -1549,15 +1551,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int count = BufferIO::ReadUInt8(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
-		int c, s, ss;
-		unsigned int l;
-		unsigned int code;
+		int c = 0, s = 0, ss = 0;
+		unsigned int l = 0;
+		unsigned int code = 0;
 		bool panelmode = false;
 		size_t hand_count[2] = { mainGame->dField.hand[0].size(), mainGame->dField.hand[1].size() };
 		int select_count_in_hand[2] = { 0, 0 };
 		bool select_ready = mainGame->dField.select_min == 0;
 		mainGame->dField.select_ready = select_ready;
-		ClientCard* pcard;
+		ClientCard* pcard = nullptr;
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
@@ -1615,14 +1617,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int count1 = BufferIO::ReadUInt8(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
-		int c, s, ss;
-		unsigned int l;
-		unsigned int code;
+		int c = 0, s = 0, ss = 0;
+		unsigned int l = 0;
+		unsigned int code = 0;
 		bool panelmode = false;
 		size_t hand_count[2] = { mainGame->dField.hand[0].size(), mainGame->dField.hand[1].size() };
 		int select_count_in_hand[2] = { 0, 0 };
 		mainGame->dField.select_ready = false;
-		ClientCard* pcard;
+		ClientCard* pcard = nullptr;
 		for (int i = 0; i < count1; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
@@ -1707,9 +1709,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int forced = BufferIO::ReadUInt8(pbuf);
 		/*int hint0 = */BufferIO::ReadInt32(pbuf);
 		/*int hint1 = */BufferIO::ReadInt32(pbuf);
-		int c, s, ss, desc;
-		unsigned int code,l;
-		ClientCard* pcard;
+		int c = 0, s = 0, ss = 0, desc = 0;
+		unsigned int code = 0,l = 0;
+		ClientCard* pcard = nullptr;
 		bool panelmode = false;
 		bool conti_exist = false;
 		bool select_trigger = (specount == 0x7f);
@@ -1826,7 +1828,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		if (mainGame->dInfo.curMsg == MSG_SELECT_PLACE && (
 			(mainGame->chkMAutoPos->isChecked() && mainGame->dField.selectable_field & 0x7f007f) ||
 			(mainGame->chkSTAutoPos->isChecked() && !(mainGame->dField.selectable_field & 0x7f007f)))) {
-			unsigned int filter;
+			unsigned int filter = 0;
 			if (mainGame->dField.selectable_field & 0x7f) {
 				respbuf[0] = mainGame->LocalPlayer(0);
 				respbuf[1] = LOCATION_MZONE;
@@ -1890,7 +1892,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			SetResponseI(positions);
 			return true;
 		}
-		int count = 0, filter = 0x1, startpos;
+		int count = 0, filter = 0x1, startpos = 0;
 		while(filter != 0x10) {
 			if(positions & filter) count++;
 			filter <<= 1;
@@ -1936,9 +1938,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.selectsum_all.clear();
 		mainGame->dField.selectsum_cards.clear();
 		mainGame->dField.select_panalmode = false;
-		int c, s, t;
-		unsigned int code, l;
-		ClientCard* pcard;
+		int c = 0, s = 0, t = 0;
+		unsigned int code = 0, l = 0;
+		ClientCard* pcard = nullptr;
 		mainGame->dField.select_ready = false;
 		for (int i = 0; i < count; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
@@ -1976,9 +1978,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.select_counter_count = BufferIO::ReadInt16(pbuf);
 		int count = BufferIO::ReadUInt8(pbuf);
 		mainGame->dField.selectable_cards.clear();
-		int c, s, t/*, code*/;
-		unsigned int l;
-		ClientCard* pcard;
+		int c = 0, s = 0, t = 0/*, code*/;
+		unsigned int l = 0;
+		ClientCard* pcard = nullptr;
 		for (int i = 0; i < count; ++i) {
 			/*code = */BufferIO::ReadInt32(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
@@ -2046,9 +2048,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
 		mainGame->dField.sort_list.clear();
-		int c, s;
-		unsigned int code, l;
-		ClientCard* pcard;
+		int c = 0, s = 0;
+		unsigned int code = 0, l = 0;
+		ClientCard* pcard = nullptr;
 		for (int i = 0; i < count; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
@@ -2069,8 +2071,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_CONFIRM_DECKTOP: {
 		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		int count = BufferIO::ReadUInt8(pbuf);
-		unsigned int code;
-		ClientCard* pcard;
+		unsigned int code = 0;
+		ClientCard* pcard = nullptr;
 		mainGame->dField.selectable_cards.clear();
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
@@ -2107,8 +2109,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_CONFIRM_EXTRATOP: {
 		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		int count = BufferIO::ReadUInt8(pbuf);
-		unsigned int code;
-		ClientCard* pcard;
+		unsigned int code = 0;
+		ClientCard* pcard = nullptr;
 		mainGame->dField.selectable_cards.clear();
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
@@ -2144,11 +2146,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_CONFIRM_CARDS: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		int count = BufferIO::ReadUInt8(pbuf);
-		int c, s;
-		unsigned int code, l;
+		int c = 0, s = 0;
+		unsigned int code = 0, l = 0;
 		std::vector<ClientCard*> field_confirm;
 		std::vector<ClientCard*> panel_confirm;
-		ClientCard* pcard;
+		ClientCard* pcard = nullptr;
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			pbuf += count * 7;
 			return true;
@@ -2433,9 +2435,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		else
 			lst = mainGame->dField.szone;
 		ClientCard* mc[5]{ nullptr };
-		ClientCard* swp;
-		int c, s, ps;
-		unsigned int l;
+		ClientCard* swp = nullptr;
+		int c = 0, s = 0, ps = 0;
+		unsigned int l = 0;
 		for (int i = 0; i < count; ++i) {
 			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 			l = BufferIO::ReadUInt8(pbuf);
@@ -3116,7 +3118,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_DRAW: {
 		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		int count = BufferIO::ReadUInt8(pbuf);
-		ClientCard* pcard;
+		ClientCard* pcard = nullptr;
 		for (int i = 0; i < count; ++i) {
 			unsigned int code = BufferIO::ReadInt32(pbuf);
 			pcard = mainGame->dField.GetCard(player, LOCATION_DECK, mainGame->dField.deck[player].size() - 1 - i);
@@ -3417,7 +3419,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		BufferIO::ReadUInt8(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
-		float sy;
+		float sy = NAN;
 		if (ld != 0) {
 			soundManager.PlaySoundEffect(SOUND_ATTACK);
 			mainGame->dField.attack_target = mainGame->dField.GetCard(cd, ld, sd);
@@ -4092,7 +4094,7 @@ void DuelClient::BeginRefreshHost() {
 }
 int DuelClient::RefreshThread(event_base* broadev) {
 	event_base_dispatch(broadev);
-	evutil_socket_t fd;
+	evutil_socket_t fd = 0;
 	event_get_assignment(resp_event, nullptr, &fd, nullptr, nullptr, nullptr);
 	evutil_closesocket(fd);
 	event_free(resp_event);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -18,8 +18,8 @@ size_t DuelClient::response_len = 0;
 unsigned int DuelClient::watching = 0;
 unsigned char DuelClient::selftype = 0;
 bool DuelClient::is_host = false;
-event_base* DuelClient::client_base = 0;
-bufferevent* DuelClient::client_bev = 0;
+event_base* DuelClient::client_base = nullptr;
+bufferevent* DuelClient::client_bev = nullptr;
 unsigned char DuelClient::duel_client_write[SIZE_NETWORK_BUFFER];
 bool DuelClient::is_closing = false;
 bool DuelClient::is_swapping = false;
@@ -35,7 +35,7 @@ bool DuelClient::is_refreshing = false;
 int DuelClient::match_kill = 0;
 std::vector<HostPacket> DuelClient::hosts;
 std::set<std::pair<unsigned int, unsigned short>> DuelClient::remotes;
-event* DuelClient::resp_event = 0;
+event* DuelClient::resp_event = nullptr;
 
 bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_game) {
 	if(connect_state)
@@ -53,15 +53,15 @@ bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_g
 	if (bufferevent_socket_connect(client_bev, (sockaddr*)&sin, sizeof(sin)) < 0) {
 		bufferevent_free(client_bev);
 		event_base_free(client_base);
-		client_bev = 0;
-		client_base = 0;
+		client_bev = nullptr;
+		client_base = nullptr;
 		return false;
 	}
 	connect_state = 0x1;
 	rnd.reset((uint_fast32_t)std::random_device()());
 	if(!create_game) {
 		timeval timeout = {5, 0};
-		event* timeout_event = event_new(client_base, 0, EV_TIMEOUT, ConnectTimeout, 0);
+		event* timeout_event = event_new(client_base, 0, EV_TIMEOUT, ConnectTimeout, nullptr);
 		event_add(timeout_event, &timeout);
 	}
 	std::thread(ClientThread).detach();
@@ -225,15 +225,15 @@ void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 				}
 			}
 		}
-		event_base_loopexit(client_base, 0);
+		event_base_loopexit(client_base, nullptr);
 	}
 }
 int DuelClient::ClientThread() {
 	event_base_dispatch(client_base);
 	bufferevent_free(client_bev);
 	event_base_free(client_base);
-	client_bev = 0;
-	client_base = 0;
+	client_bev = nullptr;
+	client_base = nullptr;
 	connect_state = 0;
 	return 0;
 }
@@ -1524,7 +1524,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_SELECT_YESNO: {
 		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
 		int desc = BufferIO::ReadInt32(pbuf);
-		mainGame->dField.highlighting_card = 0;
+		mainGame->dField.highlighting_card = nullptr;
 		mainGame->gMutex.lock();
 		mainGame->SetStaticText(mainGame->stQMessage, 310, mainGame->guiFont, dataManager.GetDesc(desc));
 		mainGame->PopupElement(mainGame->wQuery);
@@ -2425,7 +2425,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_SHUFFLE_SET_CARD: {
-		std::vector<ClientCard*>* lst = 0;
+		std::vector<ClientCard*>* lst = nullptr;
 		unsigned int loc = BufferIO::ReadUInt8(pbuf);
 		int count = BufferIO::ReadUInt8(pbuf);
 		if(loc == LOCATION_MZONE)
@@ -2600,7 +2600,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				pcard->SetCode(code);
 			pcard->ClearTarget();
 			for(auto eqit = pcard->equipped.begin(); eqit != pcard->equipped.end(); ++eqit)
-				(*eqit)->equipTarget = 0;
+				(*eqit)->equipTarget = nullptr;
 			if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 				mainGame->dField.FadeCard(pcard, 5, appear);
 				mainGame->WaitFrameSignal(appear);
@@ -2608,7 +2608,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				mainGame->dField.RemoveCard(pc, pl, ps);
 				mainGame->gMutex.unlock();
 				if(pcard == mainGame->dField.hovered_card)
-					mainGame->dField.hovered_card = 0;
+					mainGame->dField.hovered_card = nullptr;
 			} else
 				mainGame->dField.RemoveCard(pc, pl, ps);
 			delete pcard;
@@ -2626,7 +2626,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					if(pcard->equipTarget) {
 						pcard->equipTarget->is_showequip = false;
 						pcard->equipTarget->equipped.erase(pcard);
-						pcard->equipTarget = 0;
+						pcard->equipTarget = nullptr;
 					}
 				}
 				pcard->is_hovered = false;
@@ -2685,7 +2685,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				if(pcard->equipTarget) {
 					pcard->equipTarget->is_showequip = false;
 					pcard->equipTarget->equipped.erase(pcard);
-					pcard->equipTarget = 0;
+					pcard->equipTarget = nullptr;
 				}
 				pcard->is_showequip = false;
 				pcard->is_showtarget = false;
@@ -2722,7 +2722,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				ClientCard* pcard = olcard->overlayed[pp];
 				if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 					olcard->overlayed.erase(olcard->overlayed.begin() + pcard->sequence);
-					pcard->overlayTarget = 0;
+					pcard->overlayTarget = nullptr;
 					pcard->position = cp;
 					mainGame->dField.AddCard(pcard, cc, cl, cs);
 					mainGame->dField.overlay_cards.erase(pcard);
@@ -2731,7 +2731,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				} else {
 					mainGame->gMutex.lock();
 					olcard->overlayed.erase(olcard->overlayed.begin() + pcard->sequence);
-					pcard->overlayTarget = 0;
+					pcard->overlayTarget = nullptr;
 					pcard->position = cp;
 					mainGame->dField.AddCard(pcard, cc, cl, cs);
 					mainGame->dField.overlay_cards.erase(pcard);
@@ -3267,7 +3267,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pc = mainGame->dField.GetCard(c1, l1, s1);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			pc->equipTarget->equipped.erase(pc);
-			pc->equipTarget = 0;
+			pc->equipTarget = nullptr;
 		} else {
 			mainGame->gMutex.lock();
 			if (mainGame->dField.hovered_card == pc)
@@ -3275,7 +3275,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			else if (mainGame->dField.hovered_card == pc->equipTarget)
 				pc->is_showequip = false;
 			pc->equipTarget->equipped.erase(pc);
-			pc->equipTarget = 0;
+			pc->equipTarget = nullptr;
 			mainGame->gMutex.unlock();
 		}
 		return true;
@@ -4072,7 +4072,7 @@ void DuelClient::BeginRefreshHost() {
 	HostRequest hReq;
 	hReq.identifier = NETWORK_CLIENT_ID;
 	for(int i = 0; i < 8; ++i) {
-		if(host->h_addr_list[i] == 0)
+		if(host->h_addr_list[i] == nullptr)
 			break;
 		unsigned int local_addr = 0;
 		std::memcpy(&local_addr, host->h_addr_list[i], sizeof local_addr);
@@ -4093,7 +4093,7 @@ void DuelClient::BeginRefreshHost() {
 int DuelClient::RefreshThread(event_base* broadev) {
 	event_base_dispatch(broadev);
 	evutil_socket_t fd;
-	event_get_assignment(resp_event, 0, &fd, 0, 0, 0);
+	event_get_assignment(resp_event, nullptr, &fd, nullptr, nullptr, nullptr);
 	evutil_closesocket(fd);
 	event_free(resp_event);
 	event_base_free(broadev);

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -16,12 +16,14 @@
 namespace ygo {
 
 bool ClientField::OnEvent(const irr::SEvent& event) {
-	if(OnCommonEvent(event))
+	if(OnCommonEvent(event)) {
 		return false;
+}
 	switch(event.EventType) {
 	case irr::EET_GUI_EVENT: {
-		if(mainGame->fadingList.size())
+		if(mainGame->fadingList.size()) {
 			break;
+}
 		s32 id = event.GUIEvent.Caller->getID();
 		switch(event.GUIEvent.EventType) {
 		case irr::gui::EGET_BUTTON_CLICKED: {
@@ -52,8 +54,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_REPLAY_START: {
-				if(!mainGame->dInfo.isReplay)
+				if(!mainGame->dInfo.isReplay) {
 					break;
+}
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
 				mainGame->btnReplayStart->setVisible(false);
 				mainGame->btnReplayPause->setVisible(true);
@@ -63,8 +66,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_REPLAY_PAUSE: {
-				if(!mainGame->dInfo.isReplay)
+				if(!mainGame->dInfo.isReplay) {
 					break;
+}
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
 				mainGame->btnReplayStart->setVisible(true);
 				mainGame->btnReplayPause->setVisible(false);
@@ -74,37 +78,42 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_REPLAY_STEP: {
-				if(!mainGame->dInfo.isReplay)
+				if(!mainGame->dInfo.isReplay) {
 					break;
+}
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
 				ReplayMode::Pause(false, true);
 				break;
 			}
 			case BUTTON_REPLAY_EXIT: {
-				if(!mainGame->dInfo.isReplay)
+				if(!mainGame->dInfo.isReplay) {
 					break;
+}
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
 				ReplayMode::StopReplay();
 				break;
 			}
 			case BUTTON_REPLAY_SWAP: {
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
-				if(mainGame->dInfo.isReplay)
+				if(mainGame->dInfo.isReplay) {
 					ReplayMode::SwapField();
-				else if(mainGame->dInfo.player_type == 7)
+				} else if(mainGame->dInfo.player_type == 7) {
 					DuelClient::SwapField();
+}
 				break;
 			}
 			case BUTTON_REPLAY_UNDO: {
-				if(!mainGame->dInfo.isReplay)
+				if(!mainGame->dInfo.isReplay) {
 					break;
+}
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
 				ReplayMode::Undo();
 				break;
 			}
 			case BUTTON_REPLAY_SAVE: {
-				if(mainGame->ebRSName->getText()[0] == 0)
+				if(mainGame->ebRSName->getText()[0] == 0) {
 					break;
+}
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
 				mainGame->actionParam = 1;
 				mainGame->HideElement(mainGame->wReplaySave);
@@ -137,15 +146,18 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					mainGame->btnJoinCancel->setEnabled(true);
 					mainGame->btnStartBot->setEnabled(true);
 					mainGame->btnBotCancel->setEnabled(true);
-					if(bot_mode)
+					if(bot_mode) {
 						mainGame->ShowElement(mainGame->wSinglePlay);
-					else
+					} else {
 						mainGame->ShowElement(mainGame->wLanWindow);
-					if(exit_on_return)
+}
+					if(exit_on_return) {
 						mainGame->device->closeDevice();
+}
 				} else {
-					if(!(mainGame->dInfo.isTag && mainGame->dField.tag_surrender))
+					if(!(mainGame->dInfo.isTag && mainGame->dField.tag_surrender)) {
 						mainGame->PopupElement(mainGame->wSurrender);
+}
 				}
 				break;
 			}
@@ -202,8 +214,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				switch(mainGame->dInfo.curMsg) {
 				case MSG_SELECT_YESNO:
 				case MSG_SELECT_EFFECTYN: {
-					if(highlighting_card)
+					if(highlighting_card) {
 						highlighting_card->is_highlighting = false;
+}
 					highlighting_card = nullptr;
 					DuelClient::SetResponseI(1);
 					mainGame->HideElement(mainGame->wQuery, true);
@@ -213,8 +226,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				case MSG_SELECT_TRIBUTE:
 				case MSG_SELECT_SUM: {
 					mainGame->HideElement(mainGame->wQuery);
-					if(select_panalmode)
+					if(select_panalmode) {
 						mainGame->dField.ShowSelectCard(true);
+}
 					break;
 				}
 				case MSG_SELECT_CHAIN: {
@@ -236,8 +250,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				switch(mainGame->dInfo.curMsg) {
 				case MSG_SELECT_YESNO:
 				case MSG_SELECT_EFFECTYN: {
-					if(highlighting_card)
+					if(highlighting_card) {
 						highlighting_card->is_highlighting = false;
+}
 					highlighting_card = nullptr;
 					DuelClient::SetResponseI(0);
 					mainGame->HideElement(mainGame->wQuery, true);
@@ -288,8 +303,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
 				selected_option--;
 				mainGame->btnOptionn->setVisible(true);
-				if(selected_option == 0)
+				if(selected_option == 0) {
 					mainGame->btnOptionp->setVisible(false);
+}
 				mainGame->SetStaticText(mainGame->stOptions, 310, mainGame->guiFont, dataManager.GetDesc(select_options[selected_option]));
 				break;
 			}
@@ -297,8 +313,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
 				selected_option++;
 				mainGame->btnOptionp->setVisible(true);
-				if(selected_option == select_options.size() - 1)
+				if(selected_option == select_options.size() - 1) {
 					mainGame->btnOptionn->setVisible(false);
+}
 				mainGame->SetStaticText(mainGame->stOptions, 310, mainGame->guiFont, dataManager.GetDesc(select_options[selected_option]));
 				break;
 			}
@@ -354,8 +371,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			case BUTTON_ANCARD_OK: {
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
 				int sel = mainGame->lstANCard->getSelected();
-				if(sel == -1)
+				if(sel == -1) {
 					break;
+}
 				DuelClient::SetResponseI(ancard[sel]);
 				mainGame->HideElement(mainGame->wANCard, true);
 				break;
@@ -371,18 +389,21 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				HideMenu();
 				ShowCancelOrFinishButton(0);
 				if(!list_command) {
-					if(!menu_card)
+					if(!menu_card) {
 						break;
+}
 					select_options.clear();
 					select_options_index.clear();
 					for (size_t i = 0; i < activatable_cards.size(); ++i) {
 						if (activatable_cards[i] == menu_card) {
-							if(activatable_descs[i].second == EDESC_OPERATION)
+							if(activatable_descs[i].second == EDESC_OPERATION) {
 								continue;
-							else if(activatable_descs[i].second == EDESC_RESET) {
-								if(id == BUTTON_CMD_ACTIVATE) continue;
+							} else if(activatable_descs[i].second == EDESC_RESET) {
+								if(id == BUTTON_CMD_ACTIVATE) { continue;
+}
 							} else {
-								if(id == BUTTON_CMD_RESET) continue;
+								if(id == BUTTON_CMD_RESET) { continue;
+}
 							}
 							select_options.push_back(activatable_descs[i].first);
 							select_options_index.push_back(i);
@@ -409,27 +430,35 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					conti_selecting = false;
 					switch(command_location) {
 					case LOCATION_DECK: {
-						for(size_t i = 0; i < deck[command_controler].size(); ++i)
-							if(deck[command_controler][i]->cmdFlag & COMMAND_ACTIVATE)
+						for(size_t i = 0; i < deck[command_controler].size(); ++i) {
+							if(deck[command_controler][i]->cmdFlag & COMMAND_ACTIVATE) {
 								selectable_cards.push_back(deck[command_controler][i]);
+}
+}
 						break;
 					}
 					case LOCATION_GRAVE: {
-						for(size_t i = 0; i < grave[command_controler].size(); ++i)
-							if(grave[command_controler][i]->cmdFlag & COMMAND_ACTIVATE)
+						for(size_t i = 0; i < grave[command_controler].size(); ++i) {
+							if(grave[command_controler][i]->cmdFlag & COMMAND_ACTIVATE) {
 								selectable_cards.push_back(grave[command_controler][i]);
+}
+}
 						break;
 					}
 					case LOCATION_REMOVED: {
-						for(size_t i = 0; i < remove[command_controler].size(); ++i)
-							if(remove[command_controler][i]->cmdFlag & COMMAND_ACTIVATE)
+						for(size_t i = 0; i < remove[command_controler].size(); ++i) {
+							if(remove[command_controler][i]->cmdFlag & COMMAND_ACTIVATE) {
 								selectable_cards.push_back(remove[command_controler][i]);
+}
+}
 						break;
 					}
 					case LOCATION_EXTRA: {
-						for(size_t i = 0; i < extra[command_controler].size(); ++i)
-							if(extra[command_controler][i]->cmdFlag & COMMAND_ACTIVATE)
+						for(size_t i = 0; i < extra[command_controler].size(); ++i) {
+							if(extra[command_controler][i]->cmdFlag & COMMAND_ACTIVATE) {
 								selectable_cards.push_back(extra[command_controler][i]);
+}
+}
 						break;
 					}
 					case POSITION_HINT: {
@@ -455,8 +484,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_CMD_SUMMON: {
 				HideMenu();
-				if(!menu_card)
+				if(!menu_card) {
 					break;
+}
 				for(size_t i = 0; i < summonable_cards.size(); ++i) {
 					if(summonable_cards[i] == menu_card) {
 						ClearCommandFlag();
@@ -470,8 +500,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			case BUTTON_CMD_SPSUMMON: {
 				HideMenu();
 				if(!list_command) {
-					if(!menu_card)
+					if(!menu_card) {
 						break;
+}
 					for(size_t i = 0; i < spsummonable_cards.size(); ++i) {
 						if(spsummonable_cards[i] == menu_card) {
 							ClearCommandFlag();
@@ -484,21 +515,27 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					selectable_cards.clear();
 					switch(command_location) {
 					case LOCATION_DECK: {
-						for(size_t i = 0; i < deck[command_controler].size(); ++i)
-							if(deck[command_controler][i]->cmdFlag & COMMAND_SPSUMMON)
+						for(size_t i = 0; i < deck[command_controler].size(); ++i) {
+							if(deck[command_controler][i]->cmdFlag & COMMAND_SPSUMMON) {
 								selectable_cards.push_back(deck[command_controler][i]);
+}
+}
 						break;
 					}
 					case LOCATION_GRAVE: {
-						for(size_t i = 0; i < grave[command_controler].size(); ++i)
-							if(grave[command_controler][i]->cmdFlag & COMMAND_SPSUMMON)
+						for(size_t i = 0; i < grave[command_controler].size(); ++i) {
+							if(grave[command_controler][i]->cmdFlag & COMMAND_SPSUMMON) {
 								selectable_cards.push_back(grave[command_controler][i]);
+}
+}
 						break;
 					}
 					case LOCATION_EXTRA: {
-						for(size_t i = 0; i < extra[command_controler].size(); ++i)
-							if(extra[command_controler][i]->cmdFlag & COMMAND_SPSUMMON)
+						for(size_t i = 0; i < extra[command_controler].size(); ++i) {
+							if(extra[command_controler][i]->cmdFlag & COMMAND_SPSUMMON) {
 								selectable_cards.push_back(extra[command_controler][i]);
+}
+}
 						break;
 					}
 					}
@@ -512,8 +549,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_CMD_MSET: {
 				HideMenu();
-				if(!menu_card)
+				if(!menu_card) {
 					break;
+}
 				for(size_t i = 0; i < msetable_cards.size(); ++i) {
 					if(msetable_cards[i] == menu_card) {
 						DuelClient::SetResponseI((i << 16) + 3);
@@ -525,8 +563,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_CMD_SSET: {
 				HideMenu();
-				if(!menu_card)
+				if(!menu_card) {
 					break;
+}
 				for(size_t i = 0; i < ssetable_cards.size(); ++i) {
 					if(ssetable_cards[i] == menu_card) {
 						DuelClient::SetResponseI((i << 16) + 4);
@@ -538,8 +577,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_CMD_REPOS: {
 				HideMenu();
-				if(!menu_card)
+				if(!menu_card) {
 					break;
+}
 				for(size_t i = 0; i < reposable_cards.size(); ++i) {
 					if(reposable_cards[i] == menu_card) {
 						DuelClient::SetResponseI((i << 16) + 2);
@@ -551,8 +591,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_CMD_ATTACK: {
 				HideMenu();
-				if(!menu_card)
+				if(!menu_card) {
 					break;
+}
 				for(size_t i = 0; i < attackable_cards.size(); ++i) {
 					if(attackable_cards[i] == menu_card) {
 						DuelClient::SetResponseI((i << 16) + 1);
@@ -637,18 +678,21 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			case BUTTON_CARD_2:
 			case BUTTON_CARD_3:
 			case BUTTON_CARD_4: {
-				if(mainGame->dInfo.isReplay)
+				if(mainGame->dInfo.isReplay) {
 					break;
+}
 				switch(mainGame->dInfo.curMsg) {
 				case MSG_SELECT_IDLECMD:
 				case MSG_SELECT_BATTLECMD:
 				case MSG_SELECT_CHAIN: {
-					if(list_command == COMMAND_LIST)
+					if(list_command == COMMAND_LIST) {
 						break;
+}
 					if(list_command == COMMAND_SPSUMMON) {
 						command_card = selectable_cards[id - BUTTON_CARD_0 + mainGame->scrCardList->getPos() / 10];
 						int index = 0;
-						while(spsummonable_cards[index] != command_card) index++;
+						while(spsummonable_cards[index] != command_card) { index++;
+}
 						DuelClient::SetResponseI((index << 16) + 1);
 						mainGame->HideElement(mainGame->wCardSelect, true);
 						ShowCancelOrFinishButton(0);
@@ -661,9 +705,11 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						for (size_t i = 0; i < activatable_cards.size(); ++i) {
 							if (activatable_cards[i] == command_card) {
 								if(activatable_descs[i].second == EDESC_OPERATION) {
-									if(list_command == COMMAND_ACTIVATE) continue;
+									if(list_command == COMMAND_ACTIVATE) { continue;
+}
 								} else {
-									if(list_command == COMMAND_OPERATION) continue;
+									if(list_command == COMMAND_OPERATION) { continue;
+}
 								}
 								select_options.push_back(activatable_descs[i].first);
 								select_options_index.push_back(i);
@@ -692,11 +738,13 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					if (command_card->is_selected) {
 						command_card->is_selected = false;
 						int i = 0;
-						while(selected_cards[i] != command_card) i++;
+						while(selected_cards[i] != command_card) { i++;
+}
 						selected_cards.erase(selected_cards.begin() + i);
-						if(command_card->controler)
+						if(command_card->controler) {
 							mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffd0d0d0);
-						else mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffffff);
+						} else { mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffffff);
+}
 					} else {
 						command_card->is_selected = true;
 						mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffff00);
@@ -714,10 +762,11 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					} else {
 						select_ready = false;
 						mainGame->btnSelectOK->setVisible(false);
-						if (select_cancelable && sel == 0)
+						if (select_cancelable && sel == 0) {
 							ShowCancelOrFinishButton(1);
-						else
+						} else {
 							ShowCancelOrFinishButton(0);
+}
 					}
 					break;
 				}
@@ -725,9 +774,10 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					command_card = selectable_cards[id - BUTTON_CARD_0 + mainGame->scrCardList->getPos() / 10];
 					if (command_card->is_selected) {
 						command_card->is_selected = false;
-						if(command_card->controler)
+						if(command_card->controler) {
 							mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffd0d0d0);
-						else mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffffff);
+						} else { mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffffff);
+}
 					} else {
 						command_card->is_selected = true;
 						mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffff00);
@@ -745,11 +795,13 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					if (command_card->is_selected) {
 						command_card->is_selected = false;
 						int i = 0;
-						while(selected_cards[i] != command_card) i++;
+						while(selected_cards[i] != command_card) { i++;
+}
 						selected_cards.erase(selected_cards.begin() + i);
-						if(command_card->controler)
+						if(command_card->controler) {
 							mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffd0d0d0);
-						else mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffffff);
+						} else { mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffffff);
+}
 					} else {
 						command_card->is_selected = true;
 						mainGame->stCardPos[id - BUTTON_CARD_0]->setBackgroundColor(0xffffff00);
@@ -766,16 +818,20 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						select_min--;
 						int sel = sort_list[sel_seq];
 						sort_list[sel_seq] = 0;
-						for(int i = 0; i < select_max; ++i)
-							if(sort_list[i] > sel)
+						for(int i = 0; i < select_max; ++i) {
+							if(sort_list[i] > sel) {
 								sort_list[i]--;
+}
+}
 						for(int i = 0; i < 5; ++i) {
-							if(offset + i >= select_max)
+							if(offset + i >= select_max) {
 								break;
+}
 							if(sort_list[offset + i]) {
 								myswprintf(formatBuffer, L"%d", sort_list[offset + i]);
 								mainGame->stCardPos[i]->setText(formatBuffer);
-							} else mainGame->stCardPos[i]->setText(L"");
+							} else { mainGame->stCardPos[i]->setText(L"");
+}
 						}
 					} else {
 						select_min++;
@@ -784,8 +840,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						mainGame->stCardPos[id - BUTTON_CARD_0]->setText(formatBuffer);
 						if(select_min == select_max) {
 							unsigned char respbuf[SIZE_RETURN_VALUE];
-							for(int i = 0; i < select_max; ++i)
+							for(int i = 0; i < select_max; ++i) {
 								respbuf[i] = sort_list[i] - 1;
+}
 							DuelClient::SetResponseB(respbuf, select_max);
 							mainGame->HideElement(mainGame->wCardSelect, true);
 							sort_list.clear();
@@ -818,8 +875,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					mainGame->HideElement(mainGame->wCardSelect, true);
 				} else {
 					mainGame->HideElement(mainGame->wCardSelect);
-					if(mainGame->dInfo.curMsg == MSG_SELECT_CHAIN && !chain_forced)
+					if(mainGame->dInfo.curMsg == MSG_SELECT_CHAIN && !chain_forced) {
 						ShowCancelOrFinishButton(1);
+}
 					break;
 				}
 				break;
@@ -892,62 +950,70 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					// draw selectable_cards[i + pos] in btnCardSelect[i]
 					mainGame->stCardPos[i]->enableOverrideColor(false);
 					// image
-					if(selectable_cards[i + pos]->code)
+					if(selectable_cards[i + pos]->code) {
 						mainGame->btnCardSelect[i]->setImage(imageManager.GetTexture(selectable_cards[i + pos]->code));
-					else if(conti_selecting)
+					} else if(conti_selecting) {
 						mainGame->btnCardSelect[i]->setImage(imageManager.GetTexture(selectable_cards[i + pos]->chain_code));
-					else
+					} else {
 						mainGame->btnCardSelect[i]->setImage(imageManager.tCover[selectable_cards[i + pos]->controler + 2]);
+}
 					mainGame->btnCardSelect[i]->setRelativePosition(rect<s32>(30 + i * 125, 55, 30 + 120 + i * 125, 225));
 					// text
 					wchar_t formatBuffer[2048];
 					if(mainGame->dInfo.curMsg == MSG_SORT_CARD) {
-						if(sort_list[pos + i])
+						if(sort_list[pos + i]) {
 							myswprintf(formatBuffer, L"%d", sort_list[pos + i]);
-						else
+						} else {
 							myswprintf(formatBuffer, L"");
+}
 					} else {
-						if(conti_selecting)
+						if(conti_selecting) {
 							myswprintf(formatBuffer, L"%ls", DataManager::unknown_string);
-						else if(cant_check_grave && selectable_cards[i]->location == LOCATION_GRAVE)
+						} else if(cant_check_grave && selectable_cards[i]->location == LOCATION_GRAVE) {
 							myswprintf(formatBuffer, L"%ls", dataManager.FormatLocation(selectable_cards[i]->location, 0));
-						else if(selectable_cards[i + pos]->location == LOCATION_OVERLAY)
+						} else if(selectable_cards[i + pos]->location == LOCATION_OVERLAY) {
 							myswprintf(formatBuffer, L"%ls[%d](%d)",
 								dataManager.FormatLocation(selectable_cards[i + pos]->overlayTarget->location, selectable_cards[i + pos]->overlayTarget->sequence),
 								selectable_cards[i + pos]->overlayTarget->sequence + 1, selectable_cards[i + pos]->sequence + 1);
-						else
+						} else {
 							myswprintf(formatBuffer, L"%ls[%d]", dataManager.FormatLocation(selectable_cards[i + pos]->location, selectable_cards[i + pos]->sequence),
 								selectable_cards[i + pos]->sequence + 1);
+}
 					}
 					mainGame->stCardPos[i]->setText(formatBuffer);
 					// color
-					if(conti_selecting)
+					if(conti_selecting) {
 						mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
-					else if(selectable_cards[i + pos]->location == LOCATION_OVERLAY) {
-						if(selectable_cards[i + pos]->owner != selectable_cards[i + pos]->overlayTarget->controler)
+					} else if(selectable_cards[i + pos]->location == LOCATION_OVERLAY) {
+						if(selectable_cards[i + pos]->owner != selectable_cards[i + pos]->overlayTarget->controler) {
 							mainGame->stCardPos[i]->setOverrideColor(0xff0000ff);
-						if(selectable_cards[i + pos]->is_selected)
+}
+						if(selectable_cards[i + pos]->is_selected) {
 							mainGame->stCardPos[i]->setBackgroundColor(0xffffff00);
-						else if(selectable_cards[i + pos]->overlayTarget->controler)
+						} else if(selectable_cards[i + pos]->overlayTarget->controler) {
 							mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
-						else
+						} else {
 							mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
+}
 					} else if(selectable_cards[i + pos]->location == LOCATION_DECK || selectable_cards[i + pos]->location == LOCATION_EXTRA || selectable_cards[i + pos]->location == LOCATION_REMOVED) {
-						if(selectable_cards[i + pos]->position & POS_FACEDOWN)
+						if(selectable_cards[i + pos]->position & POS_FACEDOWN) {
 							mainGame->stCardPos[i]->setOverrideColor(0xff0000ff);
-						if(selectable_cards[i + pos]->is_selected)
+}
+						if(selectable_cards[i + pos]->is_selected) {
 							mainGame->stCardPos[i]->setBackgroundColor(0xffffff00);
-						else if(selectable_cards[i + pos]->controler)
+						} else if(selectable_cards[i + pos]->controler) {
 							mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
-						else
+						} else {
 							mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
+}
 					} else {
-						if(selectable_cards[i + pos]->is_selected)
+						if(selectable_cards[i + pos]->is_selected) {
 							mainGame->stCardPos[i]->setBackgroundColor(0xffffff00);
-						else if(selectable_cards[i + pos]->controler)
+						} else if(selectable_cards[i + pos]->controler) {
 							mainGame->stCardPos[i]->setBackgroundColor(0xffd0d0d0);
-						else
+						} else {
 							mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
+}
 					}
 				}
 				break;
@@ -957,40 +1023,47 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				for(int i = 0; i < 5; ++i) {
 					// draw display_cards[i + pos] in btnCardDisplay[i]
 					mainGame->stDisplayPos[i]->enableOverrideColor(false);
-					if(display_cards[i + pos]->code)
+					if(display_cards[i + pos]->code) {
 						mainGame->btnCardDisplay[i]->setImage(imageManager.GetTexture(display_cards[i + pos]->code));
-					else
+					} else {
 						mainGame->btnCardDisplay[i]->setImage(imageManager.tCover[display_cards[i + pos]->controler + 2]);
+}
 					mainGame->btnCardDisplay[i]->setRelativePosition(rect<s32>(30 + i * 125, 55, 30 + 120 + i * 125, 225));
 					wchar_t formatBuffer[2048];
 					if(display_cards[i + pos]->location == LOCATION_OVERLAY) {
 							myswprintf(formatBuffer, L"%ls[%d](%d)",
 								dataManager.FormatLocation(display_cards[i + pos]->overlayTarget->location, display_cards[i + pos]->overlayTarget->sequence),
 								display_cards[i + pos]->overlayTarget->sequence + 1, display_cards[i + pos]->sequence + 1);
-					} else
+					} else {
 						myswprintf(formatBuffer, L"%ls[%d]", dataManager.FormatLocation(display_cards[i + pos]->location, display_cards[i + pos]->sequence),
 							display_cards[i + pos]->sequence + 1);
+}
 					mainGame->stDisplayPos[i]->setText(formatBuffer);
 					if(display_cards[i + pos]->location == LOCATION_OVERLAY) {
-						if(display_cards[i + pos]->owner != display_cards[i + pos]->overlayTarget->controler)
+						if(display_cards[i + pos]->owner != display_cards[i + pos]->overlayTarget->controler) {
 							mainGame->stDisplayPos[i]->setOverrideColor(0xff0000ff);
+}
 						// BackgroundColor: controller of the xyz monster
-						if(display_cards[i + pos]->overlayTarget->controler)
+						if(display_cards[i + pos]->overlayTarget->controler) {
 							mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
-						else
+						} else {
 							mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
+}
 					} else if(display_cards[i + pos]->location == LOCATION_EXTRA || display_cards[i + pos]->location == LOCATION_REMOVED) {
-						if(display_cards[i + pos]->position & POS_FACEDOWN)
+						if(display_cards[i + pos]->position & POS_FACEDOWN) {
 							mainGame->stDisplayPos[i]->setOverrideColor(0xff0000ff);
-						if(display_cards[i + pos]->controler)
+}
+						if(display_cards[i + pos]->controler) {
 							mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
-						else
+						} else {
 							mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
+}
 					} else {
-						if(display_cards[i + pos]->controler)
+						if(display_cards[i + pos]->controler) {
 							mainGame->stDisplayPos[i]->setBackgroundColor(0xffd0d0d0);
-						else
+						} else {
 							mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
+}
 					}
 				}
 				break;
@@ -1070,124 +1143,144 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 	case irr::EET_MOUSE_INPUT_EVENT: {
 		switch(event.MouseInput.Event) {
 		case irr::EMIE_LMOUSE_LEFT_UP: {
-			if(!mainGame->dInfo.isStarted)
+			if(!mainGame->dInfo.isStarted) {
 				break;
+}
 			hovered_location = 0;
 			position2di pos = mainGame->ResizeReverse(event.MouseInput.X, event.MouseInput.Y);
 			position2di mousepos(event.MouseInput.X, event.MouseInput.Y);
 			s32 x = pos.X;
 			s32 y = pos.Y;
-			if(x < 300)
+			if(x < 300) {
 				break;
+}
 			if(mainGame->gameConf.control_mode == 1) {
 				mainGame->always_chain = event.MouseInput.isLeftPressed();
 				mainGame->ignore_chain = false;
 				mainGame->chain_when_avail = false;
 				UpdateChainButtons();
 			}
-			if(mainGame->wCmdMenu->isVisible() && !mainGame->wCmdMenu->getRelativePosition().isPointInside(mousepos))
+			if(mainGame->wCmdMenu->isVisible() && !mainGame->wCmdMenu->getRelativePosition().isPointInside(mousepos)) {
 				HideMenu();
-			if(mainGame->btnBP->isVisible() && mainGame->btnBP->getAbsolutePosition().isPointInside(mousepos))
+}
+			if(mainGame->btnBP->isVisible() && mainGame->btnBP->getAbsolutePosition().isPointInside(mousepos)) {
 				break;
-			if(mainGame->btnM2->isVisible() && mainGame->btnM2->getAbsolutePosition().isPointInside(mousepos))
+}
+			if(mainGame->btnM2->isVisible() && mainGame->btnM2->getAbsolutePosition().isPointInside(mousepos)) {
 				break;
-			if(panel && panel->isVisible())
+}
+			if(panel && panel->isVisible()) {
 				break;
+}
 			GetHoverField(x, y);
-			if(hovered_location & 0xe)
+			if(hovered_location & 0xe) {
 				clicked_card = GetCard(hovered_controler, hovered_location, hovered_sequence);
-			else clicked_card = nullptr;
+			} else { clicked_card = nullptr;
+}
 			wchar_t formatBuffer[2048];
 			if(mainGame->dInfo.isReplay) {
-				if(mainGame->wCardSelect->isVisible())
+				if(mainGame->wCardSelect->isVisible()) {
 					break;
+}
 				selectable_cards.clear();
 				switch(hovered_location) {
 				case LOCATION_DECK: {
-					if(deck[hovered_controler].size() == 0)
+					if(deck[hovered_controler].size() == 0) {
 						break;
+}
 					selectable_cards.assign(deck[hovered_controler].rbegin(), deck[hovered_controler].rend());
 					myswprintf(formatBuffer, L"%ls(%d)", dataManager.GetSysString(1000), deck[hovered_controler].size());
 					mainGame->wCardSelect->setText(formatBuffer);
 					break;
 				}
 				case LOCATION_MZONE: {
-					if(!clicked_card || clicked_card->overlayed.size() == 0)
+					if(!clicked_card || clicked_card->overlayed.size() == 0) {
 						break;
+}
 					selectable_cards.assign(clicked_card->overlayed.begin(), clicked_card->overlayed.end());
 					myswprintf(formatBuffer, L"%ls(%d)", dataManager.GetSysString(1007), clicked_card->overlayed.size());
 					mainGame->wCardSelect->setText(formatBuffer);
 					break;
 				}
 				case LOCATION_GRAVE: {
-					if(grave[hovered_controler].size() == 0)
+					if(grave[hovered_controler].size() == 0) {
 						break;
+}
 					selectable_cards.assign(grave[hovered_controler].rbegin(), grave[hovered_controler].rend());
 					myswprintf(formatBuffer, L"%ls(%d)", dataManager.GetSysString(1004), grave[hovered_controler].size());
 					mainGame->wCardSelect->setText(formatBuffer);
 					break;
 				}
 				case LOCATION_REMOVED: {
-					if(remove[hovered_controler].size() == 0)
+					if(remove[hovered_controler].size() == 0) {
 						break;
+}
 					selectable_cards.assign(remove[hovered_controler].rbegin(), remove[hovered_controler].rend());
 					myswprintf(formatBuffer, L"%ls(%d)", dataManager.GetSysString(1005), remove[hovered_controler].size());
 					mainGame->wCardSelect->setText(formatBuffer);
 					break;
 				}
 				case LOCATION_EXTRA: {
-					if(extra[hovered_controler].size() == 0)
+					if(extra[hovered_controler].size() == 0) {
 						break;
+}
 					selectable_cards.assign(extra[hovered_controler].rbegin(), extra[hovered_controler].rend());
 					myswprintf(formatBuffer, L"%ls(%d)", dataManager.GetSysString(1006), extra[hovered_controler].size());
 					mainGame->wCardSelect->setText(formatBuffer);
 					break;
 				}
 				}
-				if(selectable_cards.size())
+				if(selectable_cards.size()) {
 					ShowSelectCard(true);
+}
 				break;
 			}
 			if(mainGame->dInfo.player_type == 7) {
-				if(mainGame->wCardSelect->isVisible())
+				if(mainGame->wCardSelect->isVisible()) {
 					break;
+}
 				selectable_cards.clear();
 				switch(hovered_location) {
 				case LOCATION_MZONE: {
-					if(!clicked_card || clicked_card->overlayed.size() == 0)
+					if(!clicked_card || clicked_card->overlayed.size() == 0) {
 						break;
+}
 					selectable_cards.assign(clicked_card->overlayed.begin(), clicked_card->overlayed.end());
 					myswprintf(formatBuffer, L"%ls(%d)", dataManager.GetSysString(1007), clicked_card->overlayed.size());
 					mainGame->wCardSelect->setText(formatBuffer);
 					break;
 				}
 				case LOCATION_GRAVE: {
-					if(grave[hovered_controler].size() == 0)
+					if(grave[hovered_controler].size() == 0) {
 						break;
+}
 					selectable_cards.assign(grave[hovered_controler].rbegin(), grave[hovered_controler].rend());
 					myswprintf(formatBuffer, L"%ls(%d)", dataManager.GetSysString(1004), grave[hovered_controler].size());
 					mainGame->wCardSelect->setText(formatBuffer);
 					break;
 				}
 				case LOCATION_REMOVED: {
-					if (remove[hovered_controler].size() == 0)
+					if (remove[hovered_controler].size() == 0) {
 						break;
+}
 					selectable_cards.assign(remove[hovered_controler].rbegin(), remove[hovered_controler].rend());
 					myswprintf(formatBuffer, L"%ls(%d)", dataManager.GetSysString(1005), remove[hovered_controler].size());
 					mainGame->wCardSelect->setText(formatBuffer);
 					break;
 				}
 				case LOCATION_EXTRA: {
-					if (extra[hovered_controler].size() == 0)
+					if (extra[hovered_controler].size() == 0) {
 						break;
+}
 					selectable_cards.assign(extra[hovered_controler].rbegin(), extra[hovered_controler].rend());
 					myswprintf(formatBuffer, L"%ls(%d)", dataManager.GetSysString(1006), extra[hovered_controler].size());
 					mainGame->wCardSelect->setText(formatBuffer);
 					break;
 				}
 				}
-				if(selectable_cards.size())
+				if(selectable_cards.size()) {
 					ShowSelectCard(true);
+}
 				break;
 			}
 			command_controler = hovered_controler;
@@ -1198,28 +1291,33 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				switch(hovered_location) {
 				case LOCATION_MZONE:
 				case LOCATION_SZONE: {
-					if(!clicked_card || clicked_card->overlayed.size() == 0)
+					if(!clicked_card || clicked_card->overlayed.size() == 0) {
 						break;
+}
 					ShowMenu(COMMAND_LIST, x, y);
 					break;
 				}
 				case LOCATION_GRAVE: {
-					if(grave[hovered_controler].size() == 0)
+					if(grave[hovered_controler].size() == 0) {
 						break;
-					if(cant_check_grave)
+}
+					if(cant_check_grave) {
 						break;
+}
 					ShowMenu(COMMAND_LIST, x, y);
 					break;
 				}
 				case LOCATION_REMOVED: {
-					if(remove[hovered_controler].size() == 0)
+					if(remove[hovered_controler].size() == 0) {
 						break;
+}
 					ShowMenu(COMMAND_LIST, x, y);
 					break;
 				}
 				case LOCATION_EXTRA: {
-					if(extra[hovered_controler].size() == 0)
+					if(extra[hovered_controler].size() == 0) {
 						break;
+}
 					ShowMenu(COMMAND_LIST, x, y);
 					break;
 				}
@@ -1232,12 +1330,15 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				switch(hovered_location) {
 				case LOCATION_DECK: {
 					int command_flag = 0;
-					if(deck[hovered_controler].size() == 0)
+					if(deck[hovered_controler].size() == 0) {
 						break;
-					for(size_t i = 0; i < deck[hovered_controler].size(); ++i)
+}
+					for(size_t i = 0; i < deck[hovered_controler].size(); ++i) {
 						command_flag |= deck[hovered_controler][i]->cmdFlag;
-					if(mainGame->dInfo.isSingleMode)
+}
+					if(mainGame->dInfo.isSingleMode) {
 						command_flag |= COMMAND_LIST;
+}
 					list_command = 1;
 					ShowMenu(command_flag, x, y);
 					break;
@@ -1245,23 +1346,28 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				case LOCATION_HAND:
 				case LOCATION_MZONE:
 				case LOCATION_SZONE: {
-					if(!clicked_card)
+					if(!clicked_card) {
 						break;
+}
 					int command_flag = clicked_card->cmdFlag;
-					if(clicked_card->overlayed.size())
+					if(clicked_card->overlayed.size()) {
 						command_flag |= COMMAND_LIST;
+}
 					list_command = 0;
 					ShowMenu(command_flag, x, y);
 					break;
 				}
 				case LOCATION_GRAVE: {
 					int command_flag = 0;
-					if(grave[hovered_controler].size() == 0)
+					if(grave[hovered_controler].size() == 0) {
 						break;
-					if(cant_check_grave)
+}
+					if(cant_check_grave) {
 						break;
-					for(size_t i = 0; i < grave[hovered_controler].size(); ++i)
+}
+					for(size_t i = 0; i < grave[hovered_controler].size(); ++i) {
 						command_flag |= grave[hovered_controler][i]->cmdFlag;
+}
 					command_flag |= COMMAND_LIST;
 					list_command = 1;
 					ShowMenu(command_flag, x, y);
@@ -1269,10 +1375,12 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				}
 				case LOCATION_REMOVED: {
 					int command_flag = 0;
-					if(remove[hovered_controler].size() == 0)
+					if(remove[hovered_controler].size() == 0) {
 						break;
-					for(size_t i = 0; i < remove[hovered_controler].size(); ++i)
+}
+					for(size_t i = 0; i < remove[hovered_controler].size(); ++i) {
 						command_flag |= remove[hovered_controler][i]->cmdFlag;
+}
 					command_flag |= COMMAND_LIST;
 					list_command = 1;
 					ShowMenu(command_flag, x, y);
@@ -1280,10 +1388,12 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				}
 				case LOCATION_EXTRA: {
 					int command_flag = 0;
-					if(extra[hovered_controler].size() == 0)
+					if(extra[hovered_controler].size() == 0) {
 						break;
-					for(size_t i = 0; i < extra[hovered_controler].size(); ++i)
+}
+					for(size_t i = 0; i < extra[hovered_controler].size(); ++i) {
 						command_flag |= extra[hovered_controler][i]->cmdFlag;
+}
 					command_flag |= COMMAND_LIST;
 					list_command = 1;
 					ShowMenu(command_flag, x, y);
@@ -1291,8 +1401,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				}
 				case POSITION_HINT: {
 					int command_flag = 0;
-					if(conti_cards.size() == 0)
+					if(conti_cards.size() == 0) {
 						break;
+}
 					command_flag |= COMMAND_OPERATION;
 					list_command = 1;
 					ShowMenu(command_flag, x, y);
@@ -1303,8 +1414,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			}
 			case MSG_SELECT_PLACE:
 			case MSG_SELECT_DISFIELD: {
-				if (!(hovered_location & LOCATION_ONFIELD))
+				if (!(hovered_location & LOCATION_ONFIELD)) {
 					break;
+}
 				unsigned int flag = 1 << (hovered_sequence + (hovered_controler << 4) + ((hovered_location == LOCATION_MZONE) ? 0 : 8));
 				if (flag & selectable_field) {
 					if (flag & selected_field) {
@@ -1363,12 +1475,14 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case MSG_SELECT_CARD: {
-				if(!(hovered_location & 0xe) || !clicked_card || !clicked_card->is_selectable)
+				if(!(hovered_location & 0xe) || !clicked_card || !clicked_card->is_selectable) {
 					break;
+}
 				if(clicked_card->is_selected) {
 					clicked_card->is_selected = false;
 					int i = 0;
-					while(selected_cards[i] != clicked_card) i++;
+					while(selected_cards[i] != clicked_card) { i++;
+}
 					selected_cards.erase(selected_cards.begin() + i);
 				} else {
 					clicked_card->is_selected = true;
@@ -1389,16 +1503,18 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					}
 				} else {
 					select_ready = false;
-					if(select_cancelable && selected_cards.size() == 0)
+					if(select_cancelable && selected_cards.size() == 0) {
 						ShowCancelOrFinishButton(1);
-					else
+					} else {
 						ShowCancelOrFinishButton(0);
+}
 				}
 				break;
 			}
 			case MSG_SELECT_TRIBUTE: {
-				if (!(hovered_location & 0xe) || !clicked_card || !clicked_card->is_selectable)
+				if (!(hovered_location & 0xe) || !clicked_card || !clicked_card->is_selectable) {
 					break;
+}
 				if(clicked_card->is_selected) {
 					auto it = std::find(selected_cards.begin(), selected_cards.end(), clicked_card);
 					selected_cards.erase(it);
@@ -1416,16 +1532,18 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					}
 				} else {
 					select_ready = false;
-					if (select_cancelable && selected_cards.size() == 0)
+					if (select_cancelable && selected_cards.size() == 0) {
 						ShowCancelOrFinishButton(1);
-					else
+					} else {
 						ShowCancelOrFinishButton(0);
+}
 				}
 				break;
 			}
 			case MSG_SELECT_UNSELECT_CARD: {
-				if (!(hovered_location & 0xe) || !clicked_card || !clicked_card->is_selectable)
+				if (!(hovered_location & 0xe) || !clicked_card || !clicked_card->is_selectable) {
 					break;
+}
 				if (clicked_card->is_selected) {
 					clicked_card->is_selected = false;
 				} else {
@@ -1440,16 +1558,19 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case MSG_SELECT_COUNTER: {
-				if (!clicked_card || !clicked_card->is_selectable)
+				if (!clicked_card || !clicked_card->is_selectable) {
 					break;
+}
 				clicked_card->opParam--;
-				if ((clicked_card->opParam & 0xffff) == 0)
+				if ((clicked_card->opParam & 0xffff) == 0) {
 					clicked_card->is_selectable = false;
+}
 				select_counter_count--;
 				if (select_counter_count == 0) {
 					unsigned short int respbuf[32];
-					for(size_t i = 0; i < selectable_cards.size(); ++i)
+					for(size_t i = 0; i < selectable_cards.size(); ++i) {
 						respbuf[i] = (selectable_cards[i]->opParam >> 16) - (selectable_cards[i]->opParam & 0xffff);
+}
 					mainGame->stHintMsg->setVisible(false);
 					ClearSelect();
 					DuelClient::SetResponseB(respbuf, selectable_cards.size() * 2);
@@ -1461,13 +1582,15 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case MSG_SELECT_SUM: {
-				if (!clicked_card || !clicked_card->is_selectable)
+				if (!clicked_card || !clicked_card->is_selectable) {
 					break;
+}
 				if (clicked_card->is_selected) {
 					auto it = std::find(selected_cards.begin(), selected_cards.end(), clicked_card);
 					selected_cards.erase(it);
-				} else
+				} else {
 					selected_cards.push_back(clicked_card);
+}
 				ShowSelectSum(false);
 				break;
 			}
@@ -1475,10 +1598,12 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			break;
 		}
 		case irr::EMIE_RMOUSE_LEFT_UP: {
-			if(mainGame->dInfo.isReplay)
+			if(mainGame->dInfo.isReplay) {
 				break;
-			if(event.MouseInput.isLeftPressed())
+}
+			if(event.MouseInput.isLeftPressed()) {
 				break;
+}
 			if(mainGame->gameConf.control_mode == 1 && event.MouseInput.X > 300 * mainGame->xScale) {
 				mainGame->ignore_chain = event.MouseInput.isRightPressed();
 				mainGame->always_chain = false;
@@ -1487,14 +1612,16 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			}
 			mainGame->HideElement(mainGame->wSurrender);
 			HideMenu();
-			if(mainGame->fadingList.size())
+			if(mainGame->fadingList.size()) {
 				break;
+}
 			CancelOrFinish();
 			break;
 		}
 		case irr::EMIE_MOUSE_MOVED: {
-			if(!mainGame->dInfo.isStarted)
+			if(!mainGame->dInfo.isStarted) {
 				break;
+}
 			bool should_show_tip = false;
 			position2di pos = mainGame->ResizeReverse(event.MouseInput.X, event.MouseInput.Y);
 			position2di mousepos = position2di(event.MouseInput.X, event.MouseInput.Y);
@@ -1519,38 +1646,44 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			int mplayer = -1;
 			if(!panel || !panel->isVisible() || !panel->getRelativePosition().isPointInside(mousepos)) {
 				GetHoverField(x, y);
-				if(hovered_location & 0xe)
+				if(hovered_location & 0xe) {
 					mcard = GetCard(hovered_controler, hovered_location, hovered_sequence);
-				else if(hovered_location == LOCATION_GRAVE) {
-					if(grave[hovered_controler].size())
+				} else if(hovered_location == LOCATION_GRAVE) {
+					if(grave[hovered_controler].size()) {
 						mcard = grave[hovered_controler].back();
+}
 				} else if(hovered_location == LOCATION_REMOVED) {
 					if(remove[hovered_controler].size()) {
 						mcard = remove[hovered_controler].back();
-						if(mcard->position & POS_FACEDOWN)
+						if(mcard->position & POS_FACEDOWN) {
 							mcard = nullptr;
+}
 					}
 				} else if(hovered_location == LOCATION_EXTRA) {
 					if(extra[hovered_controler].size()) {
 						mcard = extra[hovered_controler].back();
-						if(mcard->position & POS_FACEDOWN)
+						if(mcard->position & POS_FACEDOWN) {
 							mcard = nullptr;
+}
 					}
 				} else if(hovered_location == LOCATION_DECK) {
-					if(deck[hovered_controler].size())
+					if(deck[hovered_controler].size()) {
 						mcard = deck[hovered_controler].back();
+}
 				} else {
-					if(mainGame->Resize(327, 8, 630, 51).isPointInside(mousepos))
+					if(mainGame->Resize(327, 8, 630, 51).isPointInside(mousepos)) {
 						mplayer = 0;
-					else if(mainGame->Resize(689, 8, 991, 51).isPointInside(mousepos))
+					} else if(mainGame->Resize(689, 8, 991, 51).isPointInside(mousepos)) {
 						mplayer = 1;
+}
 				}
 			}
-			if(hovered_location == LOCATION_HAND && (mainGame->dInfo.is_shuffling || mainGame->dInfo.curMsg == MSG_SHUFFLE_HAND))
+			if(hovered_location == LOCATION_HAND && (mainGame->dInfo.is_shuffling || mainGame->dInfo.curMsg == MSG_SHUFFLE_HAND)) {
 				mcard = nullptr;
-			if(mcard == nullptr && mplayer < 0)
+}
+			if(mcard == nullptr && mplayer < 0) {
 				should_show_tip = false;
-			else if(mcard == hovered_card && mplayer == hovered_player) {
+			} else if(mcard == hovered_card && mplayer == hovered_player) {
 				if(mainGame->stTip->isVisible()) {
 					should_show_tip = true;
 					irr::core::recti tpos = mainGame->stTip->getRelativePosition();
@@ -1562,19 +1695,22 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					if(hovered_card->location == LOCATION_HAND && !mainGame->dInfo.is_shuffling && mainGame->dInfo.curMsg != MSG_SHUFFLE_HAND) {
 						hovered_card->is_hovered = false;
 						MoveCard(hovered_card, 5);
-						if(hovered_controler == 0)
+						if(hovered_controler == 0) {
 							mainGame->hideChat = false;
+}
 					}
 					SetShowMark(hovered_card, false);
 				}
 				if(mcard) {
-					if(mcard != menu_card)
+					if(mcard != menu_card) {
 						HideMenu();
+}
 					if(hovered_location == LOCATION_HAND) {
 						mcard->is_hovered = true;
 						MoveCard(mcard, 5);
-						if(hovered_controler == 0)
+						if(hovered_controler == 0) {
 							mainGame->hideChat = true;
+}
 					}
 					SetShowMark(mcard, true);
 					if(mcard->code) {
@@ -1592,7 +1728,8 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 								str.append(formatBuffer);
 								if(!(mcard->type & TYPE_LINK)) {
 									const wchar_t* form = L"\u2605";
-									if (mcard->rank) form = L"\u2606";
+									if (mcard->rank) { form = L"\u2606";
+}
 									myswprintf(formatBuffer, L"\n%ls%d", form, (mcard->level ? mcard->level : mcard->rank));
 									str.append(formatBuffer);
 								} else {
@@ -1620,16 +1757,17 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 								str.append(formatBuffer);
 							}
 							if(mcard->cHint && mcard->chValue && (mcard->location & LOCATION_ONFIELD)) {
-								if(mcard->cHint == CHINT_TURN)
+								if(mcard->cHint == CHINT_TURN) {
 									myswprintf(formatBuffer, L"\n%ls%d", dataManager.GetSysString(211), mcard->chValue);
-								else if(mcard->cHint == CHINT_CARD)
+								} else if(mcard->cHint == CHINT_CARD) {
 									myswprintf(formatBuffer, L"\n%ls%ls", dataManager.GetSysString(212), dataManager.GetName(mcard->chValue));
-								else if(mcard->cHint == CHINT_RACE)
+								} else if(mcard->cHint == CHINT_RACE) {
 									myswprintf(formatBuffer, L"\n%ls%ls", dataManager.GetSysString(213), dataManager.FormatRace(mcard->chValue).c_str());
-								else if(mcard->cHint == CHINT_ATTRIBUTE)
+								} else if(mcard->cHint == CHINT_ATTRIBUTE) {
 									myswprintf(formatBuffer, L"\n%ls%ls", dataManager.GetSysString(214), dataManager.FormatAttribute(mcard->chValue).c_str());
-								else if(mcard->cHint == CHINT_NUMBER)
+								} else if(mcard->cHint == CHINT_NUMBER) {
 									myswprintf(formatBuffer, L"\n%ls%d", dataManager.GetSysString(215), mcard->chValue);
+}
 								str.append(formatBuffer);
 							}
 							for(auto iter = mcard->desc_hints.begin(); iter != mcard->desc_hints.end(); ++iter) {
@@ -1652,15 +1790,17 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				if(mplayer >= 0) {
 					const wchar_t* player_name = nullptr;
 					if(mplayer == 0) {
-						if(!mainGame->dInfo.isTag || !mainGame->dInfo.tag_player[0])
+						if(!mainGame->dInfo.isTag || !mainGame->dInfo.tag_player[0]) {
 							player_name = mainGame->dInfo.hostname;
-						else
+						} else {
 							player_name = mainGame->dInfo.hostname_tag;
+}
 					} else {
-						if(!mainGame->dInfo.isTag || !mainGame->dInfo.tag_player[1])
+						if(!mainGame->dInfo.isTag || !mainGame->dInfo.tag_player[1]) {
 							player_name = mainGame->dInfo.clientname;
-						else
+						} else {
 							player_name = mainGame->dInfo.clientname_tag;
+}
 					}
 					std::wstring str(player_name);
 					const auto& mplayer_hints = mainGame->dField.player_desc_hints[mplayer];
@@ -1669,10 +1809,11 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						str.append(formatBuffer);
 					}
 					if(mainGame->dInfo.turn == 1) {
-						if(mplayer == 0 && mainGame->dInfo.isFirst || mplayer != 0 && !mainGame->dInfo.isFirst)
+						if(mplayer == 0 && mainGame->dInfo.isFirst || mplayer != 0 && !mainGame->dInfo.isFirst) {
 							myswprintf(formatBuffer, L"\n*%ls", dataManager.GetSysString(100));
-						else
+						} else {
 							myswprintf(formatBuffer, L"\n*%ls", dataManager.GetSysString(101));
+}
 						str.append(formatBuffer);
 					}
 					should_show_tip = true;
@@ -1689,8 +1830,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			break;
 		}
 		case irr::EMIE_LMOUSE_PRESSED_DOWN: {
-			if(!mainGame->dInfo.isStarted)
+			if(!mainGame->dInfo.isStarted) {
 				break;
+}
 			if(mainGame->gameConf.control_mode == 1 && event.MouseInput.X > 300 * mainGame->xScale) {
 				mainGame->always_chain = event.MouseInput.isLeftPressed();
 				mainGame->ignore_chain = false;
@@ -1700,8 +1842,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			break;
 		}
 		case irr::EMIE_RMOUSE_PRESSED_DOWN: {
-			if(!mainGame->dInfo.isStarted)
+			if(!mainGame->dInfo.isStarted) {
 				break;
+}
 			if(mainGame->gameConf.control_mode == 1 && event.MouseInput.X > 300 * mainGame->xScale) {
 				mainGame->ignore_chain = event.MouseInput.isRightPressed();
 				mainGame->always_chain = false;
@@ -1758,54 +1901,64 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				display_cards.clear();
 				switch(event.KeyInput.Key) {
 					case irr::KEY_F1:
-						if(cant_check_grave)
+						if(cant_check_grave) {
 							break;
+}
 						loc_id = 1004;
-						for(auto it = grave[0].rbegin(); it != grave[0].rend(); ++it)
+						for(auto it = grave[0].rbegin(); it != grave[0].rend(); ++it) {
 							display_cards.push_back(*it);
+}
 						break;
 					case irr::KEY_F2:
 						loc_id = 1005;
-						for(auto it = remove[0].rbegin(); it != remove[0].rend(); ++it)
+						for(auto it = remove[0].rbegin(); it != remove[0].rend(); ++it) {
 							display_cards.push_back(*it);
+}
 						break;
 					case irr::KEY_F3:
 						loc_id = 1006;
-						for(auto it = extra[0].rbegin(); it != extra[0].rend(); ++it)
+						for(auto it = extra[0].rbegin(); it != extra[0].rend(); ++it) {
 							display_cards.push_back(*it);
+}
 						break;
 					case irr::KEY_F4:
 						loc_id = 1007;
 						for(auto it = mzone[0].begin(); it != mzone[0].end(); ++it) {
 							if(*it) {
-								for(auto oit = (*it)->overlayed.begin(); oit != (*it)->overlayed.end(); ++oit)
+								for(auto oit = (*it)->overlayed.begin(); oit != (*it)->overlayed.end(); ++oit) {
 									display_cards.push_back(*oit);
+}
 							}
 						}
 						break;
 					case irr::KEY_F5:
-						if(cant_check_grave)
+						if(cant_check_grave) {
 							break;
+}
 						loc_id = 1004;
-						for(auto it = grave[1].rbegin(); it != grave[1].rend(); ++it)
+						for(auto it = grave[1].rbegin(); it != grave[1].rend(); ++it) {
 							display_cards.push_back(*it);
+}
 						break;
 					case irr::KEY_F6:
 						loc_id = 1005;
-						for(auto it = remove[1].rbegin(); it != remove[1].rend(); ++it)
+						for(auto it = remove[1].rbegin(); it != remove[1].rend(); ++it) {
 							display_cards.push_back(*it);
+}
 						break;
 					case irr::KEY_F7:
 						loc_id = 1006;
-						for(auto it = extra[1].rbegin(); it != extra[1].rend(); ++it)
+						for(auto it = extra[1].rbegin(); it != extra[1].rend(); ++it) {
 							display_cards.push_back(*it);
+}
 						break;
 					case irr::KEY_F8:
 						loc_id = 1007;
 						for(auto it = mzone[1].begin(); it != mzone[1].end(); ++it) {
 							if(*it) {
-								for(auto oit = (*it)->overlayed.begin(); oit != (*it)->overlayed.end(); ++oit)
+								for(auto oit = (*it)->overlayed.begin(); oit != (*it)->overlayed.end(); ++oit) {
 									display_cards.push_back(*oit);
+}
 							}
 						}
 						break;
@@ -1886,29 +2039,33 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 			switch(id) {
 			case CHECKBOX_AUTO_SEARCH: {
 				mainGame->gameConf.auto_search_limit = mainGame->chkAutoSearch->isChecked() ? 0 : -1;
-				if(mainGame->is_building && !mainGame->is_siding)
+				if(mainGame->is_building && !mainGame->is_siding) {
 					mainGame->deckBuilder.InstantSearch();
+}
 				return true;
 				break;
 			}
 			case CHECKBOX_MULTI_KEYWORDS: {
 				mainGame->gameConf.search_multiple_keywords = mainGame->chkMultiKeywords->isChecked() ? 1 : 0;
-				if(mainGame->is_building && !mainGame->is_siding)
+				if(mainGame->is_building && !mainGame->is_siding) {
 					mainGame->deckBuilder.InstantSearch();
+}
 				return true;
 				break;
 			}
 			case CHECKBOX_ENABLE_MUSIC: {
-				if(!mainGame->chkEnableMusic->isChecked())
+				if(!mainGame->chkEnableMusic->isChecked()) {
 					soundManager.StopBGM();
+}
 				return true;
 				break;
 			}
 			case CHECKBOX_DISABLE_CHAT: {
 				bool show = (mainGame->is_building && !mainGame->is_siding) ? false : !mainGame->chkIgnore1->isChecked();
 				mainGame->wChat->setVisible(show);
-				if(!show)
+				if(!show) {
 					mainGame->ClearChatMsg();
+}
 				return true;
 				break;
 			}
@@ -1924,8 +2081,9 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 			}
 			case CHECKBOX_HIDE_PLAYER_NAME: {
 				mainGame->gameConf.hide_player_name = mainGame->chkHidePlayerName->isChecked() ? 1 : 0;
-				if(mainGame->gameConf.hide_player_name)
+				if(mainGame->gameConf.hide_player_name) {
 					mainGame->ClearChatMsg();
+}
 				return true;
 				break;
 			}
@@ -2022,8 +2180,9 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 		case irr::gui::EGET_EDITBOX_ENTER: {
 			switch(id) {
 			case EDITBOX_CHAT: {
-				if(mainGame->dInfo.isReplay)
+				if(mainGame->dInfo.isReplay) {
 					break;
+}
 				const wchar_t* input = mainGame->ebChatInput->getText();
 				if(input[0]) {
 					uint16_t msgbuf[LEN_CHAT_MSG];
@@ -2062,8 +2221,9 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 			break;
 		}
 		case irr::KEY_ESCAPE: {
-			if(!mainGame->HasFocus(EGUIET_EDIT_BOX))
+			if(!mainGame->HasFocus(EGUIET_EDIT_BOX)) {
 				mainGame->device->minimizeWindow();
+}
 			return true;
 			break;
 		}
@@ -2084,55 +2244,61 @@ void ClientField::GetHoverField(int x, int y) {
 		int hc = hand[0].size();
 		int cardSize = 66;
 		int cardSpace = 10;
-		if(hc == 0)
+		if(hc == 0) {
 			hovered_location = 0;
-		else if(hc < 7) {
+		} else if(hc < 7) {
 			int left = sfRect.UpperLeftCorner.X + (cardSize + cardSpace) * (6 - hc) / 2;
-			if(x < left)
+			if(x < left) {
 				hovered_location = 0;
-			else {
+			} else {
 				int seq = (x - left) / (cardSize + cardSpace);
-				if(seq >= hc) seq = hc - 1;
+				if(seq >= hc) { seq = hc - 1;
+}
 				if(x - left - (cardSize + cardSpace) * seq < cardSize) {
 					hovered_controler = 0;
 					hovered_location = LOCATION_HAND;
 					hovered_sequence = seq;
-				} else hovered_location = 0;
+				} else { hovered_location = 0;
+}
 			}
 		} else {
 			hovered_controler = 0;
 			hovered_location = LOCATION_HAND;
-			if(x >= sfRect.UpperLeftCorner.X + (cardSize + cardSpace) * 5)
+			if(x >= sfRect.UpperLeftCorner.X + (cardSize + cardSpace) * 5) {
 				hovered_sequence = hc - 1;
-			else
+			} else {
 				hovered_sequence = (x - sfRect.UpperLeftCorner.X) * (hc - 1) / ((cardSize + cardSpace) * 5);
+}
 		}
 	} else if(ofRect.isPointInside(pos)) {
 		int hc = hand[1].size();
 		int cardSize = 39;
 		int cardSpace = 7;
-		if(hc == 0)
+		if(hc == 0) {
 			hovered_location = 0;
-		else if(hc < 7) {
+		} else if(hc < 7) {
 			int left = ofRect.UpperLeftCorner.X + (cardSize + cardSpace) * (6 - hc) / 2;
-			if(x < left)
+			if(x < left) {
 				hovered_location = 0;
-			else {
+			} else {
 				int seq = (x - left) / (cardSize + cardSpace);
-				if(seq >= hc) seq = hc - 1;
+				if(seq >= hc) { seq = hc - 1;
+}
 				if(x - left - (cardSize + cardSpace) * seq < cardSize) {
 					hovered_controler = 1;
 					hovered_location = LOCATION_HAND;
 					hovered_sequence = hc - 1 - seq;
-				} else hovered_location = 0;
+				} else { hovered_location = 0;
+}
 			}
 		} else {
 			hovered_controler = 1;
 			hovered_location = LOCATION_HAND;
-			if(x >= ofRect.UpperLeftCorner.X + (cardSize + cardSpace) * 5)
+			if(x >= ofRect.UpperLeftCorner.X + (cardSize + cardSpace) * 5) {
 				hovered_sequence = 0;
-			else
+			} else {
 				hovered_sequence = hc - 1 - (x - ofRect.UpperLeftCorner.X) * (hc - 1) / ((cardSize + cardSpace) * 5);
+}
 		}
 	} else {
 		double screenx = x / 1024.0 * 1.35 - 0.90;
@@ -2224,8 +2390,9 @@ void ClientField::GetHoverField(int x, int y) {
 			}
 		} else if(boardx >= matManager.vFieldMzone[0][0][0].Pos.X && boardx <= matManager.vFieldMzone[0][4][1].Pos.X) {
 			int sequence = (boardx - matManager.vFieldMzone[0][0][0].Pos.X) / (matManager.vFieldMzone[0][0][1].Pos.X - matManager.vFieldMzone[0][0][0].Pos.X);
-			if(sequence > 4)
+			if(sequence > 4) {
 				sequence = 4;
+}
 			if(boardy > matManager.vFieldSzone[0][0][rule][0].Pos.Y && boardy <= matManager.vFieldSzone[0][0][rule][2].Pos.Y) {
 				hovered_controler = 0;
 				hovered_location = LOCATION_SZONE;
@@ -2317,71 +2484,84 @@ void ClientField::ShowMenu(int flag, int x, int y) {
 		mainGame->btnActivate->setVisible(true);
 		mainGame->btnActivate->setRelativePosition(position2di(1, height));
 		height += offset;
-	} else mainGame->btnActivate->setVisible(false);
+	} else { mainGame->btnActivate->setVisible(false);
+}
 	if(flag & COMMAND_SUMMON) {
 		mainGame->btnSummon->setVisible(true);
 		mainGame->btnSummon->setRelativePosition(position2di(1, height));
 		height += offset;
-	} else mainGame->btnSummon->setVisible(false);
+	} else { mainGame->btnSummon->setVisible(false);
+}
 	if(flag & COMMAND_SPSUMMON) {
 		mainGame->btnSPSummon->setVisible(true);
 		mainGame->btnSPSummon->setRelativePosition(position2di(1, height));
 		height += offset;
-	} else mainGame->btnSPSummon->setVisible(false);
+	} else { mainGame->btnSPSummon->setVisible(false);
+}
 	if(flag & COMMAND_MSET) {
 		mainGame->btnMSet->setVisible(true);
 		mainGame->btnMSet->setRelativePosition(position2di(1, height));
 		height += offset;
-	} else mainGame->btnMSet->setVisible(false);
+	} else { mainGame->btnMSet->setVisible(false);
+}
 	if(flag & COMMAND_SSET) {
-		if(!(clicked_card->type & TYPE_MONSTER))
+		if(!(clicked_card->type & TYPE_MONSTER)) {
 			mainGame->btnSSet->setText(dataManager.GetSysString(1153));
-		else
+		} else {
 			mainGame->btnSSet->setText(dataManager.GetSysString(1159));
+}
 		mainGame->btnSSet->setVisible(true);
 		mainGame->btnSSet->setRelativePosition(position2di(1, height));
 		height += offset;
-	} else mainGame->btnSSet->setVisible(false);
+	} else { mainGame->btnSSet->setVisible(false);
+}
 	if(flag & COMMAND_REPOS) {
-		if(clicked_card->position & POS_FACEDOWN)
+		if(clicked_card->position & POS_FACEDOWN) {
 			mainGame->btnRepos->setText(dataManager.GetSysString(1154));
-		else if(clicked_card->position & POS_ATTACK)
+		} else if(clicked_card->position & POS_ATTACK) {
 			mainGame->btnRepos->setText(dataManager.GetSysString(1155));
-		else
+		} else {
 			mainGame->btnRepos->setText(dataManager.GetSysString(1156));
+}
 		mainGame->btnRepos->setVisible(true);
 		mainGame->btnRepos->setRelativePosition(position2di(1, height));
 		height += offset;
-	} else mainGame->btnRepos->setVisible(false);
+	} else { mainGame->btnRepos->setVisible(false);
+}
 	if(flag & COMMAND_ATTACK) {
 		mainGame->btnAttack->setVisible(true);
 		mainGame->btnAttack->setRelativePosition(position2di(1, height));
 		height += offset;
-	} else mainGame->btnAttack->setVisible(false);
+	} else { mainGame->btnAttack->setVisible(false);
+}
 	if(flag & COMMAND_LIST) {
 		mainGame->btnShowList->setVisible(true);
 		mainGame->btnShowList->setRelativePosition(position2di(1, height));
 		height += offset;
-	} else mainGame->btnShowList->setVisible(false);
+	} else { mainGame->btnShowList->setVisible(false);
+}
 	if(flag & COMMAND_OPERATION) {
 		mainGame->btnOperation->setVisible(true);
 		mainGame->btnOperation->setRelativePosition(position2di(1, height));
 		height += offset;
-	} else mainGame->btnOperation->setVisible(false);
+	} else { mainGame->btnOperation->setVisible(false);
+}
 	if(flag & COMMAND_RESET) {
 		mainGame->btnReset->setVisible(true);
 		mainGame->btnReset->setRelativePosition(position2di(1, height));
 		height += offset;
-	} else mainGame->btnReset->setVisible(false);
+	} else { mainGame->btnReset->setVisible(false);
+}
 	panel = mainGame->wCmdMenu;
 	mainGame->wCmdMenu->setVisible(true);
 	mainGame->btnBP->setEnabled(false);
 	mainGame->btnM2->setEnabled(false);
 	mainGame->btnEP->setEnabled(false);
-	if(mainGame->gameConf.resize_popup_menu)
+	if(mainGame->gameConf.resize_popup_menu) {
 		mainGame->wCmdMenu->setRelativePosition(mainGame->Resize(x - 20, y - 20, x + 80, y - 20, 0, -height, 0, 0));
-	else
+	} else {
 		mainGame->wCmdMenu->setRelativePosition(mainGame->Resize(x, y, x, y, -20, -(20 + height), 80, -20));
+}
 }
 void ClientField::HideMenu() {
 	mainGame->wCmdMenu->setVisible(false);
@@ -2417,21 +2597,27 @@ void ClientField::ShowCancelOrFinishButton(int buttonOp) {
 	}
 }
 void ClientField::SetShowMark(ClientCard* pcard, bool enable) {
-	if(pcard->equipTarget)
+	if(pcard->equipTarget) {
 		pcard->equipTarget->is_showequip = enable;
-	for (const auto& card : pcard->equipped)
+}
+	for (const auto& card : pcard->equipped) {
 		card->is_showequip = enable;
-	for (const auto& card : pcard->cardTarget)
+}
+	for (const auto& card : pcard->cardTarget) {
 		card->is_showtarget = enable;
-	for (const auto& card : pcard->ownerTarget)
+}
+	for (const auto& card : pcard->ownerTarget) {
 		card->is_showtarget = enable;
+}
 	for (auto& ch : chains) {
 		if (pcard == ch.chain_card) {
-			for (const auto& tg : ch.target)
+			for (const auto& tg : ch.target) {
 				tg->is_showchaintarget = enable;
+}
 		}
-		if (ch.target.find(pcard) != ch.target.end())
+		if (ch.target.find(pcard) != ch.target.end()) {
 			ch.chain_card->is_showchaintarget = enable;
+}
 	}
 }
 void ClientField::ShowCardInfoInList(ClientCard* pcard, irr::gui::IGUIElement* element, irr::gui::IGUIElement* parent) {
@@ -2446,8 +2632,9 @@ void ClientField::ShowCardInfoInList(ClientCard* pcard, irr::gui::IGUIElement* e
 			str.append(L"\n").append(formatBuffer);
 		}
 		if ((pcard->status & STATUS_PROC_COMPLETE)
-			&& (pcard->type & (TYPE_RITUAL | TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK | TYPE_SPSUMMON)))
+			&& (pcard->type & (TYPE_RITUAL | TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK | TYPE_SPSUMMON))) {
 			str.append(L"\n").append(dataManager.GetSysString(224));
+}
 		for (auto iter = pcard->desc_hints.begin(); iter != pcard->desc_hints.end(); ++iter) {
 			myswprintf(formatBuffer, L"\n*%ls", dataManager.GetDesc(iter->first));
 			str.append(formatBuffer);
@@ -2472,10 +2659,12 @@ void ClientField::ShowCardInfoInList(ClientCard* pcard, irr::gui::IGUIElement* e
 		mainGame->SetStaticText(mainGame->stCardListTip, 320, mainGame->guiFont, str.c_str());
 		irr::core::dimension2d<unsigned int> dTip = mainGame->guiFont->getDimension(mainGame->stCardListTip->getText()) + irr::core::dimension2d<unsigned int>(10, 10);
 		s32 w = dTip.Width / 2;
-		if(x - w < 10)
+		if(x - w < 10) {
 			x = w + 10;
-		if(x + w > 670)
+}
+		if(x + w > 670) {
 			x = 670 - w;
+}
 		mainGame->stCardListTip->setRelativePosition(recti(x - w, y - 10, x + w, y - 10 + dTip.Height));
 		mainGame->stCardListTip->setVisible(true);
 	}
@@ -2483,11 +2672,13 @@ void ClientField::ShowCardInfoInList(ClientCard* pcard, irr::gui::IGUIElement* e
 void ClientField::SetResponseSelectedCards() const {
 	unsigned char respbuf[SIZE_RETURN_VALUE]{};
 	int len = (int)selected_cards.size();
-	if (len > UINT8_MAX)
+	if (len > UINT8_MAX) {
 		len = UINT8_MAX;
+}
 	respbuf[0] = (unsigned char)len;
-	for (int i = 0; i < len; ++i)
+	for (int i = 0; i < len; ++i) {
 		respbuf[i + 1] = selected_cards[i]->select_seq;
+}
 	DuelClient::SetResponseB(respbuf, len + 1);
 }
 void ClientField::SetResponseSelectedOption() const {
@@ -2538,8 +2729,9 @@ void ClientField::CancelOrFinish() {
 	}
 	case MSG_SELECT_YESNO:
 	case MSG_SELECT_EFFECTYN: {
-		if(highlighting_card)
+		if(highlighting_card) {
 			highlighting_card->is_highlighting = false;
+}
 		highlighting_card = nullptr;
 		DuelClient::SetResponseI(0);
 		mainGame->HideElement(mainGame->wQuery, true);
@@ -2550,10 +2742,11 @@ void ClientField::CancelOrFinish() {
 			if(select_cancelable) {
 				DuelClient::SetResponseI(-1);
 				ShowCancelOrFinishButton(0);
-				if(mainGame->wCardSelect->isVisible())
+				if(mainGame->wCardSelect->isVisible()) {
 					mainGame->HideElement(mainGame->wCardSelect, true);
-				else
+				} else {
 					DuelClient::SendResponse();
+}
 			}
 		}
 		if(mainGame->wQuery->isVisible()) {
@@ -2565,10 +2758,11 @@ void ClientField::CancelOrFinish() {
 		if(select_ready) {
 			SetResponseSelectedCards();
 			ShowCancelOrFinishButton(0);
-			if(mainGame->wCardSelect->isVisible())
+			if(mainGame->wCardSelect->isVisible()) {
 				mainGame->HideElement(mainGame->wCardSelect, true);
-			else
+			} else {
 				DuelClient::SendResponse();
+}
 		}
 		break;
 	}
@@ -2576,10 +2770,11 @@ void ClientField::CancelOrFinish() {
         if (select_cancelable) {
             DuelClient::SetResponseI(-1);
             ShowCancelOrFinishButton(0);
-            if (mainGame->wCardSelect->isVisible())
+            if (mainGame->wCardSelect->isVisible()) {
                 mainGame->HideElement(mainGame->wCardSelect, true);
-            else
+            } else {
                 DuelClient::SendResponse();
+}
         }
         break;
     }
@@ -2588,10 +2783,11 @@ void ClientField::CancelOrFinish() {
 			if(select_cancelable) {
 				DuelClient::SetResponseI(-1);
 				ShowCancelOrFinishButton(0);
-				if(mainGame->wCardSelect->isVisible())
+				if(mainGame->wCardSelect->isVisible()) {
 					mainGame->HideElement(mainGame->wCardSelect, true);
-				else
+				} else {
 					DuelClient::SendResponse();
+}
 			}
 			break;
 		}
@@ -2613,16 +2809,18 @@ void ClientField::CancelOrFinish() {
 			SetResponseSelectedCards();
 			ShowCancelOrFinishButton(0);
 
-			if(mainGame->wCardSelect->isVisible())
+			if(mainGame->wCardSelect->isVisible()) {
 				mainGame->HideElement(mainGame->wCardSelect, true);
-			else
+			} else {
 				DuelClient::SendResponse();
+}
 		}
 		break;
 	}
 	case MSG_SELECT_CHAIN: {
-		if(chain_forced)
+		if(chain_forced) {
 			break;
+}
 		if(mainGame->wCardSelect->isVisible()) {
 			mainGame->HideElement(mainGame->wCardSelect);
 			break;

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -1650,7 +1650,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			}
 			if(mplayer != hovered_player) {
 				if(mplayer >= 0) {
-					const wchar_t* player_name;
+					const wchar_t* player_name = nullptr;
 					if(mplayer == 0) {
 						if(!mainGame->dInfo.isTag || !mainGame->dInfo.tag_player[0])
 							player_name = mainGame->dInfo.hostname;

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -204,7 +204,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				case MSG_SELECT_EFFECTYN: {
 					if(highlighting_card)
 						highlighting_card->is_highlighting = false;
-					highlighting_card = 0;
+					highlighting_card = nullptr;
 					DuelClient::SetResponseI(1);
 					mainGame->HideElement(mainGame->wQuery, true);
 					break;
@@ -238,7 +238,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				case MSG_SELECT_EFFECTYN: {
 					if(highlighting_card)
 						highlighting_card->is_highlighting = false;
-					highlighting_card = 0;
+					highlighting_card = nullptr;
 					DuelClient::SetResponseI(0);
 					mainGame->HideElement(mainGame->wQuery, true);
 					break;
@@ -1096,7 +1096,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			GetHoverField(x, y);
 			if(hovered_location & 0xe)
 				clicked_card = GetCard(hovered_controler, hovered_location, hovered_sequence);
-			else clicked_card = 0;
+			else clicked_card = nullptr;
 			wchar_t formatBuffer[2048];
 			if(mainGame->dInfo.isReplay) {
 				if(mainGame->wCardSelect->isVisible())
@@ -1515,7 +1515,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			hovered_location = 0;
-			ClientCard* mcard = 0;
+			ClientCard* mcard = nullptr;
 			int mplayer = -1;
 			if(!panel || !panel->isVisible() || !panel->getRelativePosition().isPointInside(mousepos)) {
 				GetHoverField(x, y);
@@ -1528,13 +1528,13 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					if(remove[hovered_controler].size()) {
 						mcard = remove[hovered_controler].back();
 						if(mcard->position & POS_FACEDOWN)
-							mcard = 0;
+							mcard = nullptr;
 					}
 				} else if(hovered_location == LOCATION_EXTRA) {
 					if(extra[hovered_controler].size()) {
 						mcard = extra[hovered_controler].back();
 						if(mcard->position & POS_FACEDOWN)
-							mcard = 0;
+							mcard = nullptr;
 					}
 				} else if(hovered_location == LOCATION_DECK) {
 					if(deck[hovered_controler].size())
@@ -1547,8 +1547,8 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				}
 			}
 			if(hovered_location == LOCATION_HAND && (mainGame->dInfo.is_shuffling || mainGame->dInfo.curMsg == MSG_SHUFFLE_HAND))
-				mcard = 0;
-			if(mcard == 0 && mplayer < 0)
+				mcard = nullptr;
+			if(mcard == nullptr && mplayer < 0)
 				should_show_tip = false;
 			else if(mcard == hovered_card && mplayer == hovered_player) {
 				if(mainGame->stTip->isVisible()) {
@@ -2540,7 +2540,7 @@ void ClientField::CancelOrFinish() {
 	case MSG_SELECT_EFFECTYN: {
 		if(highlighting_card)
 			highlighting_card->is_highlighting = false;
-		highlighting_card = 0;
+		highlighting_card = nullptr;
 		DuelClient::SetResponseI(0);
 		mainGame->HideElement(mainGame->wQuery, true);
 		break;

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -2419,15 +2419,15 @@ void ClientField::ShowCancelOrFinishButton(int buttonOp) {
 void ClientField::SetShowMark(ClientCard* pcard, bool enable) {
 	if(pcard->equipTarget)
 		pcard->equipTarget->is_showequip = enable;
-	for (auto& card : pcard->equipped)
+	for (const auto& card : pcard->equipped)
 		card->is_showequip = enable;
-	for (auto& card : pcard->cardTarget)
+	for (const auto& card : pcard->cardTarget)
 		card->is_showtarget = enable;
-	for (auto& card : pcard->ownerTarget)
+	for (const auto& card : pcard->ownerTarget)
 		card->is_showtarget = enable;
 	for (auto& ch : chains) {
 		if (pcard == ch.chain_card) {
-			for (auto& tg : ch.target)
+			for (const auto& tg : ch.target)
 				tg->is_showchaintarget = enable;
 		}
 		if (ch.target.find(pcard) != ch.target.end())

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -53,8 +53,9 @@ void DuelInfo::Clear() {
 bool IsExtension(const wchar_t* filename, const wchar_t* extension) {
 	auto flen = std::wcslen(filename);
 	auto elen = std::wcslen(extension);
-	if (!elen || flen < elen)
+	if (!elen || flen < elen) {
 		return false;
+}
 	return !mywcsncasecmp(filename + (flen - elen), extension, elen);
 }
 
@@ -62,10 +63,11 @@ bool Game::Initialize() {
 	LoadConfig();
 	irr::SIrrlichtCreationParameters params = irr::SIrrlichtCreationParameters();
 	params.AntiAlias = gameConf.antialias;
-	if(gameConf.use_d3d)
+	if(gameConf.use_d3d) {
 		params.DriverType = irr::video::EDT_DIRECT3D9;
-	else
+	} else {
 		params.DriverType = irr::video::EDT_OPENGL;
+}
 	params.WindowSize = irr::core::dimension2d<u32>(gameConf.window_width, gameConf.window_height);
 	device = irr::createDeviceEx(params);
 	if(!device) {
@@ -127,8 +129,9 @@ bool Game::Initialize() {
 		for(const wchar_t* path : numFontPaths) {
 			BufferIO::CopyWideString(path, gameConf.numfont);
 			numFont = irr::gui::CGUITTFont::createTTFont(env, gameConf.numfont, 16);
-			if(numFont)
+			if(numFont) {
 				break;
+}
 		}
 	}
 	textFont = irr::gui::CGUITTFont::createTTFont(env, gameConf.textfont, gameConf.textfontsize);
@@ -152,8 +155,9 @@ bool Game::Initialize() {
 		for(const wchar_t* path : textFontPaths) {
 			BufferIO::CopyWideString(path, gameConf.textfont);
 			textFont = irr::gui::CGUITTFont::createTTFont(env, gameConf.textfont, gameConf.textfontsize);
-			if(textFont)
+			if(textFont) {
 				break;
+}
 		}
 	}
 	if(!numFont || !textFont) {
@@ -183,14 +187,16 @@ bool Game::Initialize() {
 	smgr = device->getSceneManager();
 	device->setWindowCaption(L"YGOPro");
 	device->setResizable(true);
-	if(gameConf.window_maximized)
+	if(gameConf.window_maximized) {
 		device->maximizeWindow();
+}
 #ifdef _WIN32
 	irr::video::SExposedVideoData exposedData = driver->getExposedVideoData();
-	if(gameConf.use_d3d)
+	if(gameConf.use_d3d) {
 		hWnd = reinterpret_cast<HWND>(exposedData.D3D9.HWnd);
-	else
+	} else {
 		hWnd = reinterpret_cast<HWND>(exposedData.OpenGLWin32.HWnd);
+}
 #endif
 	SetWindowsIcon();
 	//main menu
@@ -231,8 +237,9 @@ bool Game::Initialize() {
 	wCreateHost->setVisible(false);
 	env->addStaticText(dataManager.GetSysString(1226), rect<s32>(20, 30, 220, 50), false, false, wCreateHost);
 	cbHostLFlist = env->addComboBox(rect<s32>(140, 25, 300, 50), wCreateHost);
-	for(unsigned int i = 0; i < deckManager._lfList.size(); ++i)
+	for(unsigned int i = 0; i < deckManager._lfList.size(); ++i) {
 		cbHostLFlist->addItem(deckManager._lfList[i].listName.c_str(), deckManager._lfList[i].hash);
+}
 	cbHostLFlist->setSelected(gameConf.use_lflist ? gameConf.default_lflist : cbHostLFlist->getItemCount() - 1);
 	env->addStaticText(dataManager.GetSysString(1225), rect<s32>(20, 60, 220, 80), false, false, wCreateHost);
 	cbRule = env->addComboBox(rect<s32>(140, 55, 300, 80), wCreateHost);
@@ -462,8 +469,9 @@ bool Game::Initialize() {
 	chkLFlist->setChecked(gameConf.use_lflist);
 	cbLFlist = env->addComboBox(rect<s32>(posX + 115, posY, posX + 250, posY + 25), tabSystem, COMBOBOX_LFLIST);
 	cbLFlist->setMaxSelectionRows(6);
-	for(unsigned int i = 0; i < deckManager._lfList.size(); ++i)
+	for(unsigned int i = 0; i < deckManager._lfList.size(); ++i) {
 		cbLFlist->addItem(deckManager._lfList[i].listName.c_str());
+}
 	cbLFlist->setEnabled(gameConf.use_lflist);
 	cbLFlist->setSelected(gameConf.use_lflist ? gameConf.default_lflist : cbLFlist->getItemCount() - 1);
 	posY += 30;
@@ -617,16 +625,18 @@ bool Game::Initialize() {
 	wANAttribute = env->addWindow(rect<s32>(500, 200, 830, 285), false, dataManager.GetSysString(562));
 	wANAttribute->getCloseButton()->setVisible(false);
 	wANAttribute->setVisible(false);
-	for(int filter = 0x1, i = 0; i < 7; filter <<= 1, ++i)
+	for(int filter = 0x1, i = 0; i < 7; filter <<= 1, ++i) {
 		chkAttribute[i] = env->addCheckBox(false, rect<s32>(10 + (i % 4) * 80, 25 + (i / 4) * 25, 90 + (i % 4) * 80, 50 + (i / 4) * 25),
 		                                   wANAttribute, CHECK_ATTRIBUTE, dataManager.FormatAttribute(filter).c_str());
+}
 	//announce race
 	wANRace = env->addWindow(rect<s32>(480, 200, 850, 410), false, dataManager.GetSysString(563));
 	wANRace->getCloseButton()->setVisible(false);
 	wANRace->setVisible(false);
-	for(int filter = 0x1, i = 0; i < RACES_COUNT; filter <<= 1, ++i)
+	for(int filter = 0x1, i = 0; i < RACES_COUNT; filter <<= 1, ++i) {
 		chkRace[i] = env->addCheckBox(false, rect<s32>(10 + (i % 4) * 90, 25 + (i / 4) * 25, 100 + (i % 4) * 90, 50 + (i / 4) * 25),
 		                              wANRace, CHECK_RACE, dataManager.FormatRace(filter).c_str());
+}
 	//selection hint
 	stHintMsg = env->addStaticText(L"", rect<s32>(500, 60, 820, 90), true, false, nullptr, -1, false);
 	stHintMsg->setBackgroundColor(0xc0ffffff);
@@ -724,8 +734,9 @@ bool Game::Initialize() {
 	wSort = env->addStaticText(L"", rect<s32>(930, 132, 1020, 156), true, false, nullptr, -1, true);
 	cbSortType = env->addComboBox(rect<s32>(10, 2, 85, 22), wSort, COMBOBOX_SORTTYPE);
 	cbSortType->setMaxSelectionRows(10);
-	for(int i = 1370; i <= 1373; i++)
+	for(int i = 1370; i <= 1373; i++) {
 		cbSortType->addItem(dataManager.GetSysString(i));
+}
 	wSort->setVisible(false);
 	//filters
 	wFilter = env->addStaticText(L"", rect<s32>(610, 5, 1020, 130), true, false, nullptr, -1, true);
@@ -755,14 +766,16 @@ bool Game::Initialize() {
 	cbAttribute = env->addComboBox(rect<s32>(60, 20 + 50 / 6, 195, 40 + 50 / 6), wFilter, COMBOBOX_ATTRIBUTE);
 	cbAttribute->setMaxSelectionRows(10);
 	cbAttribute->addItem(dataManager.GetSysString(1310), 0);
-	for(int filter = 0x1; filter != 0x80; filter <<= 1)
+	for(int filter = 0x1; filter != 0x80; filter <<= 1) {
 		cbAttribute->addItem(dataManager.FormatAttribute(filter).c_str(), filter);
+}
 	stRace = env->addStaticText(dataManager.GetSysString(1321), rect<s32>(10, 42 + 75 / 6, 70, 62 + 75 / 6), false, false, wFilter);
 	cbRace = env->addComboBox(rect<s32>(60, 40 + 75 / 6, 195, 60 + 75 / 6), wFilter, COMBOBOX_RACE);
 	cbRace->setMaxSelectionRows(10);
 	cbRace->addItem(dataManager.GetSysString(1310), 0);
-	for(int filter = 0x1; filter < (1 << RACES_COUNT); filter <<= 1)
+	for(int filter = 0x1; filter < (1 << RACES_COUNT); filter <<= 1) {
 		cbRace->addItem(dataManager.FormatRace(filter).c_str(), filter);
+}
 	stAttack = env->addStaticText(dataManager.GetSysString(1322), rect<s32>(205, 22 + 50 / 6, 280, 42 + 50 / 6), false, false, wFilter);
 	ebAttack = env->addEditBox(L"", rect<s32>(260, 20 + 50 / 6, 340, 40 + 50 / 6), true, wFilter, EDITBOX_INPUTS);
 	ebAttack->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
@@ -793,11 +806,13 @@ bool Game::Initialize() {
 	int catewidth = 0;
 	for(int i = 0; i < 32; ++i) {
 		irr::core::dimension2d<unsigned int> dtxt = guiFont->getDimension(dataManager.GetSysString(1100 + i));
-		if((int)dtxt.Width + 40 > catewidth)
+		if((int)dtxt.Width + 40 > catewidth) {
 			catewidth = dtxt.Width + 40;
+}
 	}
-	for(int i = 0; i < 32; ++i)
+	for(int i = 0; i < 32; ++i) {
 		chkCategory[i] = env->addCheckBox(false, recti(10 + (i % 4) * catewidth, 5 + (i / 4) * 25, 10 + (i % 4 + 1) * catewidth, 5 + (i / 4 + 1) * 25), wCategories, -1, dataManager.GetSysString(1100 + i));
+}
 	int wcatewidth = catewidth * 4 + 16;
 	wCategories->setRelativePosition(rect<s32>(1000 - wcatewidth, 60, 1000, 305));
 	btnCategoryOK->setRelativePosition(recti(wcatewidth / 2 - 50, 210, wcatewidth / 2 + 50, 235));
@@ -816,8 +831,9 @@ bool Game::Initialize() {
 	btnMark[5] = env->addButton(recti(10, 80, 40, 110), wLinkMarks, -1, L"\u2199");
 	btnMark[6] = env->addButton(recti(45, 80, 75, 110), wLinkMarks, -1, L"\u2193");
 	btnMark[7] = env->addButton(recti(80, 80, 110, 110), wLinkMarks, -1, L"\u2198");
-	for(int i=0;i<8;i++)
+	for(int i=0;i<8;i++) {
 		btnMark[i]->setIsPushButton(true);
+}
 	//replay window
 	wReplay = env->addWindow(rect<s32>(220, 100, 800, 520), false, dataManager.GetSysString(1202));
 	wReplay->getCloseButton()->setVisible(false);
@@ -1010,16 +1026,17 @@ void Game::MainLoop() {
 		driver->beginScene(true, true, SColor(0, 0, 0, 0));
 		gMutex.lock();
 		if(dInfo.isStarted) {
-			if(dInfo.isFinished && showcardcode == 1)
+			if(dInfo.isFinished && showcardcode == 1) {
 				soundManager.PlayBGM(BGM_WIN);
-			else if(dInfo.isFinished && (showcardcode == 2 || showcardcode == 3))
+			} else if(dInfo.isFinished && (showcardcode == 2 || showcardcode == 3)) {
 				soundManager.PlayBGM(BGM_LOSE);
-			else if(dInfo.lp[0] > 0 && dInfo.lp[0] <= dInfo.lp[1] / 2)
+			} else if(dInfo.lp[0] > 0 && dInfo.lp[0] <= dInfo.lp[1] / 2) {
 				soundManager.PlayBGM(BGM_DISADVANTAGE);
-			else if(dInfo.lp[0] > 0 && dInfo.lp[0] >= dInfo.lp[1] * 2)
+			} else if(dInfo.lp[0] > 0 && dInfo.lp[0] >= dInfo.lp[1] * 2) {
 				soundManager.PlayBGM(BGM_ADVANTAGE);
-			else
+			} else {
 				soundManager.PlayBGM(BGM_DUEL);
+}
 			DrawBackImage(imageManager.tBackGround);
 			DrawBackGround();
 			DrawCards();
@@ -1040,8 +1057,9 @@ void Game::MainLoop() {
 		gMutex.unlock();
 		if(signalFrame > 0) {
 			signalFrame--;
-			if(!signalFrame)
+			if(!signalFrame) {
 				frameSignal.Set();
+}
 		}
 		if(waitFrame >= 0) {
 			waitFrame++;
@@ -1054,33 +1072,39 @@ void Game::MainLoop() {
 			}
 		}
 		driver->endScene();
-		if(closeSignal.Wait(1))
+		if(closeSignal.Wait(1)) {
 			CloseDuelWindow();
+}
 		fps++;
 		cur_time = timer->getTime();
-		if(cur_time < fps * 17 - 20)
+		if(cur_time < fps * 17 - 20) {
 			std::this_thread::sleep_for(std::chrono::milliseconds(20));
+}
 		if(cur_time >= 1000) {
 			myswprintf(cap, L"YGOPro FPS: %d", fps);
 			device->setWindowCaption(cap);
 			fps = 0;
 			cur_time -= 1000;
 			timer->setTime(0);
-			if(dInfo.time_player == 0 || dInfo.time_player == 1)
-				if(dInfo.time_left[dInfo.time_player])
+			if(dInfo.time_player == 0 || dInfo.time_player == 1) {
+				if(dInfo.time_left[dInfo.time_player]) {
 					dInfo.time_left[dInfo.time_player]--;
+}
+}
 		}
 	}
 	DuelClient::StopClient(true);
-	if(dInfo.isSingleMode)
+	if(dInfo.isSingleMode) {
 		SingleMode::StopPlay(true);
+}
 	std::this_thread::sleep_for(std::chrono::milliseconds(500));
 	SaveConfig();
 	device->drop();
 }
 void Game::BuildProjectionMatrix(irr::core::matrix4& mProjection, f32 left, f32 right, f32 bottom, f32 top, f32 znear, f32 zfar) {
-	for(int i = 0; i < 16; ++i)
+	for(int i = 0; i < 16; ++i) {
 		mProjection[i] = 0;
+}
 	mProjection[0] = 2.0f * znear / (right - left);
 	mProjection[5] = 2.0f * znear / (top - bottom);
 	mProjection[8] = (left + right) / (left - right);
@@ -1094,8 +1118,9 @@ void Game::InitStaticText(irr::gui::IGUIStaticText* pControl, u32 cWidth, u32 cH
 	format_text = SetStaticText(pControl, cWidth, font, text);
 	if(font->getDimension(format_text.c_str()).Height <= cHeight) {
 		scrCardText->setVisible(false);
-		if(env->hasFocus(scrCardText))
+		if(env->hasFocus(scrCardText)) {
 			env->removeFocus(scrCardText);
+}
 		return;
 	}
 	format_text = SetStaticText(pControl, cWidth-25, font, text);
@@ -1124,22 +1149,25 @@ std::wstring Game::SetStaticText(irr::gui::IGUIStaticText* pControl, u32 cWidth,
 			_width = 0;
 			_height++;
 			prev = 0;
-			if(_height == pos)
+			if(_height == pos) {
 				pbuffer = 0;
+}
 			continue;
 		} else if(_width > 0 && _width + w > cWidth) {
 			strBuffer[pbuffer++] = L'\n';
 			_width = 0;
 			_height++;
 			prev = 0;
-			if(_height == pos)
+			if(_height == pos) {
 				pbuffer = 0;
+}
 		}
 		_width += w;
 		strBuffer[pbuffer++] = c;
 	}
 	strBuffer[pbuffer] = 0;
-	if(pControl) pControl->setText(strBuffer);
+	if(pControl) { pControl->setText(strBuffer);
+}
 	ret.assign(strBuffer);
 	return ret;
 }
@@ -1260,46 +1288,56 @@ void Game::RefreshDeck(const wchar_t* deckpath, const std::function<void(const w
 void Game::RefreshReplay() {
 	lstReplayList->clear();
 	FileSystem::TraversalDir(L"./replay", [this](const wchar_t* name, bool isdir) {
-		if (!isdir && IsExtension(name, L".yrp") && Replay::CheckReplay(name))
+		if (!isdir && IsExtension(name, L".yrp") && Replay::CheckReplay(name)) {
 			lstReplayList->addItem(name);
+}
 	});
 }
 void Game::RefreshSingleplay() {
 	lstSinglePlayList->clear();
 	stSinglePlayInfo->setText(L"");
 	FileSystem::TraversalDir(L"./single", [this](const wchar_t* name, bool isdir) {
-		if(!isdir && IsExtension(name, L".lua"))
+		if(!isdir && IsExtension(name, L".lua")) {
 			lstSinglePlayList->addItem(name);
+}
 	});
 }
 void Game::RefreshBot() {
-	if(!gameConf.enable_bot_mode)
+	if(!gameConf.enable_bot_mode) {
 		return;
+}
 	botInfo.clear();
 	FILE* fp = fopen("bot.conf", "r");
 	char linebuf[256]{};
 	char strbuf[256]{};
 	if(fp) {
 		while(fgets(linebuf, 256, fp)) {
-			if(linebuf[0] == '#')
+			if(linebuf[0] == '#') {
 				continue;
+}
 			if(linebuf[0] == '!') {
 				BotInfo newinfo;
-				if (sscanf(linebuf, "!%240[^\n]", strbuf) != 1)
+				if (sscanf(linebuf, "!%240[^\n]", strbuf) != 1) {
 					continue;
+}
 				BufferIO::DecodeUTF8(strbuf, newinfo.name);
-				if (!fgets(linebuf, 256, fp))
+				if (!fgets(linebuf, 256, fp)) {
 					break;
-				if (sscanf(linebuf, "%240[^\n]", strbuf) != 1)
+}
+				if (sscanf(linebuf, "%240[^\n]", strbuf) != 1) {
 					continue;
+}
 				BufferIO::DecodeUTF8(strbuf, newinfo.command);
-				if (!fgets(linebuf, 256, fp))
+				if (!fgets(linebuf, 256, fp)) {
 					break;
-				if (sscanf(linebuf, "%240[^\n]", strbuf) != 1)
+}
+				if (sscanf(linebuf, "%240[^\n]", strbuf) != 1) {
 					continue;
+}
 				BufferIO::DecodeUTF8(strbuf, newinfo.desc);
-				if (!fgets(linebuf, 256, fp))
+				if (!fgets(linebuf, 256, fp)) {
 					break;
+}
 				newinfo.support_master_rule_3 = !!std::strstr(linebuf, "SUPPORT_MASTER_RULE_3");
 				newinfo.support_new_master_rule = !!std::strstr(linebuf, "SUPPORT_NEW_MASTER_RULE");
 				newinfo.support_master_rule_2020 = !!std::strstr(linebuf, "SUPPORT_MASTER_RULE_2020");
@@ -1307,8 +1345,9 @@ void Game::RefreshBot() {
 				int rule = cbBotRule->getSelected() + 3;
 				if((rule == 3 && newinfo.support_master_rule_3)
 					|| (rule == 4 && newinfo.support_new_master_rule)
-					|| (rule == 5 && newinfo.support_master_rule_2020))
+					|| (rule == 5 && newinfo.support_master_rule_2020)) {
 					botInfo.push_back(newinfo);
+}
 				continue;
 			}
 		}
@@ -1330,14 +1369,16 @@ void Game::RefreshBot() {
 }
 void Game::LoadConfig() {
 	FILE* fp = fopen("system.conf", "r");
-	if(!fp)
+	if(!fp) {
 		return;
+}
 	char linebuf[CONFIG_LINE_SIZE]{};
 	char strbuf[64]{};
 	char valbuf[960]{};
 	while(fgets(linebuf, sizeof linebuf, fp)) {
-		if (sscanf(linebuf, "%63s = %959s", strbuf, valbuf) != 2)
+		if (sscanf(linebuf, "%63s = %959s", strbuf, valbuf) != 2) {
 			continue;
+}
 		if(!std::strcmp(strbuf, "antialias")) {
 			gameConf.antialias = strtol(valbuf, nullptr, 10);
 		} else if(!std::strcmp(strbuf, "use_d3d")) {
@@ -1349,8 +1390,9 @@ void Game::LoadConfig() {
 			enable_log = val & 0xff;
 		} else if(!std::strcmp(strbuf, "textfont")) {
 			int textfontsize = 0;
-			if (sscanf(linebuf, "%63s = %959s %d", strbuf, valbuf, &textfontsize) != 3)
+			if (sscanf(linebuf, "%63s = %959s %d", strbuf, valbuf, &textfontsize) != 3) {
 				continue;
+}
 			gameConf.textfontsize = textfontsize;
 			BufferIO::DecodeUTF8(valbuf, gameConf.textfont);
 		} else if(!std::strcmp(strbuf, "numfont")) {
@@ -1383,8 +1425,9 @@ void Game::LoadConfig() {
 			gameConf.default_lflist = strtol(valbuf, nullptr, 10);
 		} else if(!std::strcmp(strbuf, "default_rule")) {
 			gameConf.default_rule = strtol(valbuf, nullptr, 10);
-			if(gameConf.default_rule <= 0)
+			if(gameConf.default_rule <= 0) {
 				gameConf.default_rule = DEFAULT_DUEL_RULE;
+}
 		} else if(!std::strcmp(strbuf, "hide_setname")) {
 			gameConf.hide_setname = strtol(valbuf, nullptr, 10);
 		} else if(!std::strcmp(strbuf, "hide_hint_button")) {
@@ -1447,8 +1490,9 @@ void Game::LoadConfig() {
 #endif
 		} else {
 			// options allowing multiple words
-			if (sscanf(linebuf, "%63s = %959[^\n]", strbuf, valbuf) != 2)
+			if (sscanf(linebuf, "%63s = %959[^\n]", strbuf, valbuf) != 2) {
 				continue;
+}
 			if (!std::strcmp(strbuf, "nickname")) {
 				BufferIO::DecodeUTF8(valbuf, gameConf.nickname);
 			} else if (!std::strcmp(strbuf, "gamename")) {
@@ -1541,18 +1585,20 @@ void Game::SaveConfig() {
 	fclose(fp);
 }
 void Game::ShowCardInfo(int code, bool resize) {
-	if(showingcode == code && !resize)
+	if(showingcode == code && !resize) {
 		return;
+}
 	wchar_t formatBuffer[256];
 	auto cit = dataManager.GetCodePointer(code);
 	bool is_valid = (cit != dataManager.datas_end());
 	imgCard->setImage(imageManager.GetTexture(code, true));
 	if (is_valid) {
 		const auto& cd = cit->second;
-		if (cd.is_alternative())
+		if (cd.is_alternative()) {
 			myswprintf(formatBuffer, L"%ls[%08d]", dataManager.GetName(cd.alias), cd.alias);
-		else
+		} else {
 			myswprintf(formatBuffer, L"%ls[%08d]", dataManager.GetName(code), code);
+}
 	}
 	else {
 		myswprintf(formatBuffer, L"%ls[%08d]", dataManager.GetName(code), code);
@@ -1570,8 +1616,9 @@ void Game::ShowCardInfo(int code, bool resize) {
 			myswprintf(formatBuffer, L"%ls%ls", dataManager.GetSysString(1329), dataManager.FormatSetName(target->second.setcode).c_str());
 			stSetName->setText(formatBuffer);
 		}
-		else
+		else {
 			stSetName->setText(L"");
+}
 	}
 	else {
 		stSetName->setText(L"");
@@ -1582,28 +1629,32 @@ void Game::ShowCardInfo(int code, bool resize) {
 		stInfo->setText(formatBuffer);
 		int offset_info = 0;
 		irr::core::dimension2d<unsigned int> dtxt = guiFont->getDimension(formatBuffer);
-		if(dtxt.Width > (300 * xScale - 13) - 15)
+		if(dtxt.Width > (300 * xScale - 13) - 15) {
 			offset_info = 15;
+}
 		const wchar_t* form = L"\u2605";
 		wchar_t adBuffer[64]{};
 		wchar_t scaleBuffer[16]{};
 		if(!(cd.type & TYPE_LINK)) {
-			if(cd.type & TYPE_XYZ)
+			if(cd.type & TYPE_XYZ) {
 				form = L"\u2606";
-			if(cd.attack < 0 && cd.defense < 0)
+}
+			if(cd.attack < 0 && cd.defense < 0) {
 				myswprintf(adBuffer, L"?/?");
-			else if(cd.attack < 0)
+			} else if(cd.attack < 0) {
 				myswprintf(adBuffer, L"?/%d", cd.defense);
-			else if(cd.defense < 0)
+			} else if(cd.defense < 0) {
 				myswprintf(adBuffer, L"%d/?", cd.attack);
-			else
+			} else {
 				myswprintf(adBuffer, L"%d/%d", cd.attack, cd.defense);
+}
 		} else {
 			form = L"LINK-";
-			if(cd.attack < 0)
+			if(cd.attack < 0) {
 				myswprintf(adBuffer, L"?/-   %ls", dataManager.FormatLinkMarker(cd.link_marker).c_str());
-			else
+			} else {
 				myswprintf(adBuffer, L"%d/-   %ls", cd.attack, dataManager.FormatLinkMarker(cd.link_marker).c_str());
+}
 		}
 		if(cd.type & TYPE_PENDULUM) {
 			myswprintf(scaleBuffer, L"   %d/%d", cd.lscale, cd.rscale);
@@ -1612,8 +1663,9 @@ void Game::ShowCardInfo(int code, bool resize) {
 		stDataInfo->setText(formatBuffer);
 		int offset_arrows = offset_info;
 		dtxt = guiFont->getDimension(formatBuffer);
-		if(dtxt.Width > (300 * xScale - 13) - 15)
+		if(dtxt.Width > (300 * xScale - 13) - 15) {
 			offset_arrows += 15;
+}
 		stInfo->setRelativePosition(rect<s32>(15, 37, 300 * xScale - 13, (60 + offset_info)));
 		stDataInfo->setRelativePosition(rect<s32>(15, (60 + offset_info), 300 * xScale - 13, (83 + offset_arrows)));
 		stSetName->setRelativePosition(rect<s32>(15, (83 + offset_arrows), 296 * xScale, (83 + offset_arrows) + offset));
@@ -1621,10 +1673,11 @@ void Game::ShowCardInfo(int code, bool resize) {
 		scrCardText->setRelativePosition(rect<s32>(287 * xScale - 20, (83 + offset_arrows) + offset, 287 * xScale, 324 * yScale));
 	}
 	else {
-		if (is_valid)
+		if (is_valid) {
 			myswprintf(formatBuffer, L"[%ls]", dataManager.FormatType(cit->second.type).c_str());
-		else
+		} else {
 			myswprintf(formatBuffer, L"[%ls]", dataManager.unknown_string);
+}
 		stInfo->setText(formatBuffer);
 		stDataInfo->setText(L"");
 		stSetName->setRelativePosition(rect<s32>(15, 60, 296 * xScale, 60 + offset));
@@ -1662,10 +1715,12 @@ void Game::AddChatMsg(const wchar_t* msg, int player, bool play_sound) {
 	chatMsg[0].clear();
 	chatTiming[0] = 1200;
 	chatType[0] = player;
-	if(gameConf.hide_player_name && player < 4)
+	if(gameConf.hide_player_name && player < 4) {
 		player = 10;
-	if(play_sound)
+}
+	if(play_sound) {
 		soundManager.PlaySoundEffect(SOUND_CHAT);
+}
 	switch(player) {
 	case 0: //from host
 		chatMsg[0].append(dInfo.hostname);
@@ -1697,8 +1752,9 @@ void Game::AddChatMsg(const wchar_t* msg, int player, bool play_sound) {
 		chatMsg[0].append(L"[********]: ");
 		break;
 	default: //from watcher or unknown
-		if(player < 11 || player > 19)
+		if(player < 11 || player > 19) {
 			chatMsg[0].append(L"[---]: ");
+}
 	}
 	chatMsg[0].append(msg);
 }
@@ -1721,8 +1777,9 @@ void Game::AddDebugMsg(const char* msg) {
 }
 void Game::ErrorLog(const char* msg) {
 	FILE* fp = fopen("error.log", "at");
-	if(!fp)
+	if(!fp) {
 		return;
+}
 	time_t nowtime = std::time(nullptr);
 	char timebuf[40];
 	std::strftime(timebuf, sizeof timebuf, "%Y-%m-%d %H:%M:%S", std::localtime(&nowtime));
@@ -1752,8 +1809,9 @@ void Game::CloseGameButtons() {
 void Game::CloseGameWindow() {
 	CloseGameButtons();
 	for(auto wit = fadingList.begin(); wit != fadingList.end(); ++wit) {
-		if(wit->isFadein)
+		if(wit->isFadein) {
 			wit->autoFadeoutFrame = 1;
+}
 	}
 	wACMessage->setVisible(false);
 	wANAttribute->setVisible(false);
@@ -1803,18 +1861,20 @@ int Game::OppositePlayer(int player) {
 	return player ^ player_side_bit;
 }
 int Game::ChatLocalPlayer(int player) {
-	if(player > 3)
+	if(player > 3) {
 		return player;
+}
 	bool is_self = false;
 	if(dInfo.isStarted || is_siding) {
-		if(dInfo.isInDuel)
+		if(dInfo.isInDuel) {
 			// when in duel
 			player = mainGame->dInfo.isFirst ? player : OppositePlayer(player);
-		else {
+		} else {
 			// when changing side or waiting tp result
 			auto selftype_boundary = dInfo.isTag ? 2 : 1;
-			if(DuelClient::selftype >= selftype_boundary && DuelClient::selftype < 4)
+			if(DuelClient::selftype >= selftype_boundary && DuelClient::selftype < 4) {
 				player = OppositePlayer(player);
+}
 		}
 		if (DuelClient::selftype >= 4) {
 			is_self = false;
@@ -1839,8 +1899,9 @@ void Game::OnResize() {
 #ifdef _WIN32
 	WINDOWPLACEMENT plc;
 	plc.length = sizeof(WINDOWPLACEMENT);
-	if(GetWindowPlacement(hWnd, &plc))
+	if(GetWindowPlacement(hWnd, &plc)) {
 		gameConf.window_maximized = (plc.showCmd == SW_SHOWMAXIMIZED);
+}
 #endif // _WIN32
 	if(!gameConf.window_maximized) {
 		gameConf.window_width = window_size.Width;
@@ -1893,8 +1954,9 @@ void Game::OnResize() {
 	ebCardName->setRelativePosition(Resize(260, 60 + 100 / 6, 390, 80 + 100 / 6));
 	btnEffectFilter->setRelativePosition(Resize(345, 20 + 50 / 6, 390, 60 + 75 / 6));
 	btnStartFilter->setRelativePosition(Resize(260, 80 + 125 / 6, 390, 100 + 125 / 6));
-	if(btnClearFilter)
+	if(btnClearFilter) {
 		btnClearFilter->setRelativePosition(Resize(205, 80 + 125 / 6, 255, 100 + 125 / 6));
+}
 	btnMarksFilter->setRelativePosition(Resize(60, 80 + 125 / 6, 195, 100 + 125 / 6));
 
 	recti btncatepos = btnEffectFilter->getAbsolutePosition();
@@ -1959,8 +2021,9 @@ void Game::OnResize() {
 		scrTabHelper->setPos(0);
 		scrTabHelper->setVisible(true);
 	}
-	else
+	else {
 		scrTabHelper->setVisible(false);
+}
 
 	recti tabSystemPos = recti(0, 0, 300 * xScale - 50, 365 * yScale - 65);
 	tabSystem->setRelativePosition(tabSystemPos);
@@ -1970,8 +2033,9 @@ void Game::OnResize() {
 		scrTabSystem->setMax(tabSystemLastY - tabSystemPos.LowerRightCorner.Y + 5);
 		scrTabSystem->setPos(0);
 		scrTabSystem->setVisible(true);
-	} else
+	} else {
 		scrTabSystem->setVisible(false);
+}
 
 	if(gameConf.resize_popup_menu) {
 		int width = 100 * xScale;
@@ -1995,10 +2059,11 @@ void Game::OnResize() {
 	wInfos->setRelativePosition(Resize(1, 275, 301, 639));
 	stName->setRelativePosition(recti(10, 10, 300 * xScale - 13, 10 + 22));
 	lstLog->setRelativePosition(Resize(10, 10, 290, 290));
-	if(showingcode)
+	if(showingcode) {
 		ShowCardInfo(showingcode, true);
-	else
+	} else {
 		ClearCardInfo();
+}
 	btnClearLog->setRelativePosition(Resize(160, 300, 260, 325));
 
 	wPhase->setRelativePosition(Resize(480, 310, 855, 330));
@@ -2032,7 +2097,8 @@ void Game::OnResize() {
 }
 void Game::ResizeChatInputWindow() {
 	s32 x = wInfos->getRelativePosition().LowerRightCorner.X + 6;
-	if(is_building) x = 802 * xScale;
+	if(is_building) { x = 802 * xScale;
+}
 	wChat->setRelativePosition(recti(x, window_size.Height - 25, window_size.Width, window_size.Height));
 	ebChatInput->setRelativePosition(recti(3, 2, window_size.Width - wChat->getRelativePosition().UpperLeftCorner.X - 6, 22));
 }
@@ -2078,8 +2144,9 @@ recti Game::ResizePhaseHint(s32 x, s32 y, s32 x2, s32 y2, s32 width) {
 }
 recti Game::ResizeCardImgWin(s32 x, s32 y, s32 mx, s32 my) {
 	float mul = xScale;
-	if(xScale > yScale)
+	if(xScale > yScale) {
 		mul = yScale;
+}
 	s32 w = CARD_IMG_WIDTH * mul + mx * xScale;
 	s32 h = CARD_IMG_HEIGHT * mul + my * yScale;
 	x = x * xScale;
@@ -2094,8 +2161,9 @@ position2di Game::ResizeCardHint(s32 x, s32 y) {
 }
 recti Game::ResizeCardMid(s32 x, s32 y, s32 x2, s32 y2, s32 midx, s32 midy) {
 	float mul = xScale;
-	if(xScale > yScale)
+	if(xScale > yScale) {
 		mul = yScale;
+}
 	s32 cx = midx * xScale;
 	s32 cy = midy * yScale;
 	x = cx + (x - midx) * mul;
@@ -2106,8 +2174,9 @@ recti Game::ResizeCardMid(s32 x, s32 y, s32 x2, s32 y2, s32 midx, s32 midy) {
 }
 position2di Game::ResizeCardMid(s32 x, s32 y, s32 midx, s32 midy) {
 	float mul = xScale;
-	if(xScale > yScale)
+	if(xScale > yScale) {
 		mul = yScale;
+}
 	s32 cx = midx * xScale;
 	s32 cy = midy * yScale;
 	x = cx + (x - midx) * mul;
@@ -2116,8 +2185,9 @@ position2di Game::ResizeCardMid(s32 x, s32 y, s32 midx, s32 midy) {
 }
 recti Game::ResizeFit(s32 x, s32 y, s32 x2, s32 y2) {
 	float mul = xScale;
-	if(xScale > yScale)
+	if(xScale > yScale) {
 		mul = yScale;
+}
 	x = x * mul;
 	y = y * mul;
 	x2 = x2 * mul;
@@ -2137,8 +2207,9 @@ void Game::SetWindowsScale(float scale) {
 #ifdef _WIN32
 	WINDOWPLACEMENT plc;
 	plc.length = sizeof(WINDOWPLACEMENT);
-	if(GetWindowPlacement(hWnd, &plc) && (plc.showCmd == SW_SHOWMAXIMIZED))
+	if(GetWindowPlacement(hWnd, &plc) && (plc.showCmd == SW_SHOWMAXIMIZED)) {
 		ShowWindow(hWnd, SW_RESTORE);
+}
 	RECT rcWindow, rcClient;
 	GetWindowRect(hWnd, &rcWindow);
 	GetClientRect(hWnd, &rcClient);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -332,7 +332,7 @@ bool Game::Initialize() {
 	btnHostPrepStart = env->addButton(rect<s32>(230, 280, 340, 305), wHostPrepare, BUTTON_HP_START, dataManager.GetSysString(1215));
 	btnHostPrepCancel = env->addButton(rect<s32>(350, 280, 460, 305), wHostPrepare, BUTTON_HP_CANCEL, dataManager.GetSysString(1210));
 	//img
-	wCardImg = env->addStaticText(L"", rect<s32>(1, 1, 1 + CARD_IMG_WIDTH + 20, 1 + CARD_IMG_HEIGHT + 18), true, false, 0, -1, true);
+	wCardImg = env->addStaticText(L"", rect<s32>(1, 1, 1 + CARD_IMG_WIDTH + 20, 1 + CARD_IMG_HEIGHT + 18), true, false, nullptr, -1, true);
 	wCardImg->setBackgroundColor(0xc0c0c0c0);
 	wCardImg->setVisible(false);
 	imgCard = env->addImage(rect<s32>(10, 9, 10 + CARD_IMG_WIDTH, 9 + CARD_IMG_HEIGHT), wCardImg);
@@ -354,7 +354,7 @@ bool Game::Initialize() {
 	btnEP = env->addButton(rect<s32>(320, 0, 370, 20), wPhase, BUTTON_EP, L"\xff25\xff30");
 	btnEP->setVisible(false);
 	//tab
-	wInfos = env->addTabControl(rect<s32>(1, 275, 301, 639), 0, true);
+	wInfos = env->addTabControl(rect<s32>(1, 275, 301, 639), nullptr, true);
 	wInfos->setTabExtraWidth(16);
 	wInfos->setVisible(false);
 	//info
@@ -628,7 +628,7 @@ bool Game::Initialize() {
 		chkRace[i] = env->addCheckBox(false, rect<s32>(10 + (i % 4) * 90, 25 + (i / 4) * 25, 100 + (i % 4) * 90, 50 + (i / 4) * 25),
 		                              wANRace, CHECK_RACE, dataManager.FormatRace(filter).c_str());
 	//selection hint
-	stHintMsg = env->addStaticText(L"", rect<s32>(500, 60, 820, 90), true, false, 0, -1, false);
+	stHintMsg = env->addStaticText(L"", rect<s32>(500, 60, 820, 90), true, false, nullptr, -1, false);
 	stHintMsg->setBackgroundColor(0xc0ffffff);
 	stHintMsg->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
 	stHintMsg->setVisible(false);
@@ -648,11 +648,11 @@ bool Game::Initialize() {
 	btnOperation = env->addButton(rect<s32>(1, 169, 99, 189), wCmdMenu, BUTTON_CMD_ACTIVATE, dataManager.GetSysString(1161));
 	btnReset = env->addButton(rect<s32>(1, 190, 99, 210), wCmdMenu, BUTTON_CMD_RESET, dataManager.GetSysString(1162));
 	//deck edit
-	wDeckEdit = env->addStaticText(L"", rect<s32>(309, 5, 605, 130), true, false, 0, -1, true);
+	wDeckEdit = env->addStaticText(L"", rect<s32>(309, 5, 605, 130), true, false, nullptr, -1, true);
 	wDeckEdit->setVisible(false);
 	btnManageDeck = env->addButton(rect<s32>(225, 5, 290, 30), wDeckEdit, BUTTON_MANAGE_DECK, dataManager.GetSysString(1328));
 	//deck manage
-	wDeckManage = env->addWindow(rect<s32>(310, 135, 800, 465), false, dataManager.GetSysString(1460), 0, WINDOW_DECK_MANAGE);
+	wDeckManage = env->addWindow(rect<s32>(310, 135, 800, 465), false, dataManager.GetSysString(1460), nullptr, WINDOW_DECK_MANAGE);
 	wDeckManage->setVisible(false);
 	lstCategories = env->addListBox(rect<s32>(10, 30, 140, 320), wDeckManage, LISTBOX_CATEGORIES, true);
 	lstDecks = env->addListBox(rect<s32>(150, 30, 340, 320), wDeckManage, LISTBOX_DECKS, true);
@@ -688,7 +688,7 @@ bool Game::Initialize() {
 	cbDMCategory->setMaxSelectionRows(10);
 	btnDMOK = env->addButton(rect<s32>(70, 80, 140, 105), wDMQuery, BUTTON_DM_OK, dataManager.GetSysString(1211));
 	btnDMCancel = env->addButton(rect<s32>(170, 80, 240, 105), wDMQuery, BUTTON_DM_CANCEL, dataManager.GetSysString(1212));
-	scrPackCards = env->addScrollBar(false, recti(775, 161, 795, 629), 0, SCROLL_FILTER);
+	scrPackCards = env->addScrollBar(false, recti(775, 161, 795, 629), nullptr, SCROLL_FILTER);
 	scrPackCards->setLargeStep(1);
 	scrPackCards->setSmallStep(1);
 	scrPackCards->setVisible(false);
@@ -707,28 +707,28 @@ bool Game::Initialize() {
 	btnShuffleDeck = env->addButton(rect<s32>(5, 99, 55, 120), wDeckEdit, BUTTON_SHUFFLE_DECK, dataManager.GetSysString(1307));
 	btnSortDeck = env->addButton(rect<s32>(60, 99, 110, 120), wDeckEdit, BUTTON_SORT_DECK, dataManager.GetSysString(1305));
 	btnClearDeck = env->addButton(rect<s32>(115, 99, 165, 120), wDeckEdit, BUTTON_CLEAR_DECK, dataManager.GetSysString(1304));
-	btnSideOK = env->addButton(rect<s32>(400, 40, 710, 80), 0, BUTTON_SIDE_OK, dataManager.GetSysString(1334));
+	btnSideOK = env->addButton(rect<s32>(400, 40, 710, 80), nullptr, BUTTON_SIDE_OK, dataManager.GetSysString(1334));
 	btnSideOK->setVisible(false);
-	btnSideShuffle = env->addButton(rect<s32>(310, 100, 370, 130), 0, BUTTON_SHUFFLE_DECK, dataManager.GetSysString(1307));
+	btnSideShuffle = env->addButton(rect<s32>(310, 100, 370, 130), nullptr, BUTTON_SHUFFLE_DECK, dataManager.GetSysString(1307));
 	btnSideShuffle->setVisible(false);
-	btnSideSort = env->addButton(rect<s32>(375, 100, 435, 130), 0, BUTTON_SORT_DECK, dataManager.GetSysString(1305));
+	btnSideSort = env->addButton(rect<s32>(375, 100, 435, 130), nullptr, BUTTON_SORT_DECK, dataManager.GetSysString(1305));
 	btnSideSort->setVisible(false);
-	btnSideReload = env->addButton(rect<s32>(440, 100, 500, 130), 0, BUTTON_SIDE_RELOAD, dataManager.GetSysString(1309));
+	btnSideReload = env->addButton(rect<s32>(440, 100, 500, 130), nullptr, BUTTON_SIDE_RELOAD, dataManager.GetSysString(1309));
 	btnSideReload->setVisible(false);
 	//
-	scrFilter = env->addScrollBar(false, recti(999, 161, 1019, 629), 0, SCROLL_FILTER);
+	scrFilter = env->addScrollBar(false, recti(999, 161, 1019, 629), nullptr, SCROLL_FILTER);
 	scrFilter->setLargeStep(10);
 	scrFilter->setSmallStep(1);
 	scrFilter->setVisible(false);
 	//sort type
-	wSort = env->addStaticText(L"", rect<s32>(930, 132, 1020, 156), true, false, 0, -1, true);
+	wSort = env->addStaticText(L"", rect<s32>(930, 132, 1020, 156), true, false, nullptr, -1, true);
 	cbSortType = env->addComboBox(rect<s32>(10, 2, 85, 22), wSort, COMBOBOX_SORTTYPE);
 	cbSortType->setMaxSelectionRows(10);
 	for(int i = 1370; i <= 1373; i++)
 		cbSortType->addItem(dataManager.GetSysString(i));
 	wSort->setVisible(false);
 	//filters
-	wFilter = env->addStaticText(L"", rect<s32>(610, 5, 1020, 130), true, false, 0, -1, true);
+	wFilter = env->addStaticText(L"", rect<s32>(610, 5, 1020, 130), true, false, nullptr, -1, true);
 	wFilter->setVisible(false);
 	stCategory = env->addStaticText(dataManager.GetSysString(1311), rect<s32>(10, 2 + 25 / 6, 70, 22 + 25 / 6), false, false, wFilter);
 	cbCardType = env->addComboBox(rect<s32>(60, 25 / 6, 120, 20 + 25 / 6), wFilter, COMBOBOX_MAINTYPE);
@@ -885,7 +885,7 @@ bool Game::Initialize() {
 	btnRSYes = env->addButton(rect<s32>(70, 80, 140, 105), wReplaySave, BUTTON_REPLAY_SAVE, dataManager.GetSysString(1341));
 	btnRSNo = env->addButton(rect<s32>(170, 80, 240, 105), wReplaySave, BUTTON_REPLAY_CANCEL, dataManager.GetSysString(1212));
 	//replay control
-	wReplayControl = env->addStaticText(L"", rect<s32>(205, 118, 295, 273), true, false, 0, -1, true);
+	wReplayControl = env->addStaticText(L"", rect<s32>(205, 118, 295, 273), true, false, nullptr, -1, true);
 	wReplayControl->setVisible(false);
 	btnReplayStart = env->addButton(rect<s32>(5, 5, 85, 25), wReplayControl, BUTTON_REPLAY_START, dataManager.GetSysString(1343));
 	btnReplayPause = env->addButton(rect<s32>(5, 30, 85, 50), wReplayControl, BUTTON_REPLAY_PAUSE, dataManager.GetSysString(1344));
@@ -901,12 +901,12 @@ bool Game::Initialize() {
 	wChat->setVisible(false);
 	ebChatInput = env->addEditBox(L"", rect<s32>(3, 2, 710, 22), true, wChat, EDITBOX_CHAT);
 	//swap
-	btnSpectatorSwap = env->addButton(rect<s32>(205, 100, 295, 135), 0, BUTTON_REPLAY_SWAP, dataManager.GetSysString(1346));
+	btnSpectatorSwap = env->addButton(rect<s32>(205, 100, 295, 135), nullptr, BUTTON_REPLAY_SWAP, dataManager.GetSysString(1346));
 	btnSpectatorSwap->setVisible(false);
 	//chain buttons
-	btnChainIgnore = env->addButton(rect<s32>(205, 100, 295, 135), 0, BUTTON_CHAIN_IGNORE, dataManager.GetSysString(1292));
-	btnChainAlways = env->addButton(rect<s32>(205, 140, 295, 175), 0, BUTTON_CHAIN_ALWAYS, dataManager.GetSysString(1293));
-	btnChainWhenAvail = env->addButton(rect<s32>(205, 180, 295, 215), 0, BUTTON_CHAIN_WHENAVAIL, dataManager.GetSysString(1294));
+	btnChainIgnore = env->addButton(rect<s32>(205, 100, 295, 135), nullptr, BUTTON_CHAIN_IGNORE, dataManager.GetSysString(1292));
+	btnChainAlways = env->addButton(rect<s32>(205, 140, 295, 175), nullptr, BUTTON_CHAIN_ALWAYS, dataManager.GetSysString(1293));
+	btnChainWhenAvail = env->addButton(rect<s32>(205, 180, 295, 215), nullptr, BUTTON_CHAIN_WHENAVAIL, dataManager.GetSysString(1294));
 	btnChainIgnore->setIsPushButton(true);
 	btnChainAlways->setIsPushButton(true);
 	btnChainWhenAvail->setIsPushButton(true);
@@ -914,10 +914,10 @@ bool Game::Initialize() {
 	btnChainAlways->setVisible(false);
 	btnChainWhenAvail->setVisible(false);
 	//shuffle
-	btnShuffle = env->addButton(rect<s32>(205, 230, 295, 265), 0, BUTTON_CMD_SHUFFLE, dataManager.GetSysString(1297));
+	btnShuffle = env->addButton(rect<s32>(205, 230, 295, 265), nullptr, BUTTON_CMD_SHUFFLE, dataManager.GetSysString(1297));
 	btnShuffle->setVisible(false);
 	//cancel or finish
-	btnCancelOrFinish = env->addButton(rect<s32>(205, 230, 295, 265), 0, BUTTON_CANCEL_OR_FINISH, dataManager.GetSysString(1295));
+	btnCancelOrFinish = env->addButton(rect<s32>(205, 230, 295, 265), nullptr, BUTTON_CANCEL_OR_FINISH, dataManager.GetSysString(1295));
 	btnCancelOrFinish->setVisible(false);
 	//big picture
 	wBigCard = env->addWindow(rect<s32>(0, 0, 0, 0), false, L"");
@@ -928,19 +928,19 @@ bool Game::Initialize() {
 	imgBigCard = env->addImage(rect<s32>(0, 0, 0, 0), wBigCard);
 	imgBigCard->setScaleImage(false);
 	imgBigCard->setUseAlphaChannel(true);
-	btnBigCardOriginalSize = env->addButton(rect<s32>(205, 100, 295, 135), 0, BUTTON_BIG_CARD_ORIG_SIZE, dataManager.GetSysString(1443));
-	btnBigCardZoomIn = env->addButton(rect<s32>(205, 140, 295, 175), 0, BUTTON_BIG_CARD_ZOOM_IN, dataManager.GetSysString(1441));
-	btnBigCardZoomOut = env->addButton(rect<s32>(205, 180, 295, 215), 0, BUTTON_BIG_CARD_ZOOM_OUT, dataManager.GetSysString(1442));
-	btnBigCardClose = env->addButton(rect<s32>(205, 230, 295, 265), 0, BUTTON_BIG_CARD_CLOSE, dataManager.GetSysString(1440));
+	btnBigCardOriginalSize = env->addButton(rect<s32>(205, 100, 295, 135), nullptr, BUTTON_BIG_CARD_ORIG_SIZE, dataManager.GetSysString(1443));
+	btnBigCardZoomIn = env->addButton(rect<s32>(205, 140, 295, 175), nullptr, BUTTON_BIG_CARD_ZOOM_IN, dataManager.GetSysString(1441));
+	btnBigCardZoomOut = env->addButton(rect<s32>(205, 180, 295, 215), nullptr, BUTTON_BIG_CARD_ZOOM_OUT, dataManager.GetSysString(1442));
+	btnBigCardClose = env->addButton(rect<s32>(205, 230, 295, 265), nullptr, BUTTON_BIG_CARD_CLOSE, dataManager.GetSysString(1440));
 	btnBigCardOriginalSize->setVisible(false);
 	btnBigCardZoomIn->setVisible(false);
 	btnBigCardZoomOut->setVisible(false);
 	btnBigCardClose->setVisible(false);
 	//leave/surrender/exit
-	btnLeaveGame = env->addButton(rect<s32>(205, 5, 295, 80), 0, BUTTON_LEAVE_GAME, L"");
+	btnLeaveGame = env->addButton(rect<s32>(205, 5, 295, 80), nullptr, BUTTON_LEAVE_GAME, L"");
 	btnLeaveGame->setVisible(false);
 	//tip
-	stTip = env->addStaticText(L"", rect<s32>(0, 0, 150, 150), false, true, 0, -1, true);
+	stTip = env->addStaticText(L"", rect<s32>(0, 0, 150, 150), false, true, nullptr, -1, true);
 	stTip->setBackgroundColor(0xc0ffffff);
 	stTip->setTextAlignment(irr::gui::EGUIA_CENTER, irr::gui::EGUIA_CENTER);
 	stTip->setVisible(false);
@@ -982,7 +982,7 @@ bool Game::Initialize() {
 }
 void Game::MainLoop() {
 	wchar_t cap[256];
-	camera = smgr->addCameraSceneNode(0);
+	camera = smgr->addCameraSceneNode(nullptr);
 	irr::core::matrix4 mProjection;
 	BuildProjectionMatrix(mProjection, -0.90f, 0.45f, -0.42f, 0.42f, 1.0f, 100.0f);
 	camera->setProjectionMatrix(mProjection);
@@ -1730,7 +1730,7 @@ void Game::ErrorLog(const char* msg) {
 	fclose(fp);
 }
 void Game::ClearTextures() {
-	matManager.mCard.setTexture(0, 0);
+	matManager.mCard.setTexture(0, nullptr);
 	ClearCardInfo(0);
 	btnPSAU->setImage();
 	btnPSDU->setImage();

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1548,7 +1548,7 @@ void Game::ShowCardInfo(int code, bool resize) {
 	bool is_valid = (cit != dataManager.datas_end());
 	imgCard->setImage(imageManager.GetTexture(code, true));
 	if (is_valid) {
-		auto& cd = cit->second;
+		const auto& cd = cit->second;
 		if (cd.is_alternative())
 			myswprintf(formatBuffer, L"%ls[%08d]", dataManager.GetName(cd.alias), cd.alias);
 		else
@@ -1560,7 +1560,7 @@ void Game::ShowCardInfo(int code, bool resize) {
 	stName->setText(formatBuffer);
 	int offset = 0;
 	if (is_valid && !gameConf.hide_setname) {
-		auto& cd = cit->second;
+		const auto& cd = cit->second;
 		auto target = cit;
 		if (cd.alias && dataManager.GetCodePointer(cd.alias) != dataManager.datas_end()) {
 			target = dataManager.GetCodePointer(cd.alias);
@@ -1577,7 +1577,7 @@ void Game::ShowCardInfo(int code, bool resize) {
 		stSetName->setText(L"");
 	}
 	if(is_valid && cit->second.type & TYPE_MONSTER) {
-		auto& cd = cit->second;
+		const auto& cd = cit->second;
 		myswprintf(formatBuffer, L"[%ls] %ls/%ls", dataManager.FormatType(cd.type).c_str(), dataManager.FormatRace(cd.race).c_str(), dataManager.FormatAttribute(cd.attribute).c_str());
 		stInfo->setText(formatBuffer);
 		int offset_info = 0;

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1805,7 +1805,7 @@ int Game::OppositePlayer(int player) {
 int Game::ChatLocalPlayer(int player) {
 	if(player > 3)
 		return player;
-	bool is_self;
+	bool is_self = false;
 	if(dInfo.isStarted || is_siding) {
 		if(dInfo.isInDuel)
 			// when in duel

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -59,8 +59,9 @@ int main(int argc, char* argv[]) {
 #endif //_WIN32
 	ygo::Game _game;
 	ygo::mainGame = &_game;
-	if(!ygo::mainGame->Initialize())
+	if(!ygo::mainGame->Initialize()) {
 		return 0;
+}
 
 #ifdef _WIN32
 	int wargc = 0;
@@ -90,23 +91,27 @@ int main(int argc, char* argv[]) {
 			continue;
 		} else if(!std::wcscmp(wargv[i], L"-n")) { // nickName
 			++i;
-			if(i < wargc)
+			if(i < wargc) {
 				ygo::mainGame->ebNickName->setText(wargv[i]);
+}
 			continue;
 		} else if(!std::wcscmp(wargv[i], L"-h")) { // Host address
 			++i;
-			if(i < wargc)
+			if(i < wargc) {
 				ygo::mainGame->ebJoinHost->setText(wargv[i]);
+}
 			continue;
 		} else if(!std::wcscmp(wargv[i], L"-p")) { // host Port
 			++i;
-			if(i < wargc)
+			if(i < wargc) {
 				ygo::mainGame->ebJoinPort->setText(wargv[i]);
+}
 			continue;
 		} else if(!std::wcscmp(wargv[i], L"-w")) { // host passWord
 			++i;
-			if(i < wargc)
+			if(i < wargc) {
 				ygo::mainGame->ebJoinPass->setText(wargv[i]);
+}
 			continue;
 		} else if(!std::wcscmp(wargv[i], L"-k")) { // Keep on return
 			exit_on_return = false;
@@ -119,8 +124,9 @@ int main(int argc, char* argv[]) {
 			}
 		} else if(!std::wcscmp(wargv[i], L"-d")) { // Deck
 			++i;
-			if(!deckCategorySpecified)
+			if(!deckCategorySpecified) {
 				ygo::mainGame->gameConf.lastcategory[0] = 0;
+}
 			if(i + 1 < wargc) { // select deck
 				BufferIO::CopyWideString(wargv[i], ygo::mainGame->gameConf.lastdeck);
 				continue;
@@ -159,8 +165,9 @@ int main(int argc, char* argv[]) {
 				BufferIO::CopyWideString(wargv[i], open_file_name);
 			}
 			ClickButton(ygo::mainGame->btnReplayMode);
-			if(open_file)
+			if(open_file) {
 				ClickButton(ygo::mainGame->btnLoadReplay);
+}
 			break;
 		} else if(!std::wcscmp(wargv[i], L"-s")) { // Single
 			exit_on_return = !keep_on_return;
@@ -170,8 +177,9 @@ int main(int argc, char* argv[]) {
 				BufferIO::CopyWideString(wargv[i], open_file_name);
 			}
 			ClickButton(ygo::mainGame->btnSingleMode);
-			if(open_file)
+			if(open_file) {
 				ClickButton(ygo::mainGame->btnLoadSinglePlay);
+}
 			break;
 		} else if(wargc == 2 && std::wcslen(wargv[1]) >= 4) {
 			wchar_t* pstrext = wargv[1] + std::wcslen(wargv[1]) - 4;

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -37,7 +37,7 @@ int main(int argc, char* argv[]) {
 #endif //__APPLE__
 #ifdef _WIN32
 #ifndef _DEBUG
-	char* pstrext;
+	char* pstrext = nullptr;
 	if(argc == 2 && (pstrext = std::strrchr(argv[1], '.'))
 		&& (!mystrncasecmp(pstrext, ".ydk", 4) || !mystrncasecmp(pstrext, ".yrp", 4))) {
 		wchar_t exepath[MAX_PATH];
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
 #endif //_DEBUG
 #endif //_WIN32
 #ifdef _WIN32
-	WORD wVersionRequested;
+	WORD wVersionRequested = 0;
 	WSADATA wsaData;
 	wVersionRequested = MAKEWORD(2, 2);
 	WSAStartup(wVersionRequested, &wsaData);
@@ -63,7 +63,7 @@ int main(int argc, char* argv[]) {
 		return 0;
 
 #ifdef _WIN32
-	int wargc;
+	int wargc = 0;
 	std::unique_ptr<wchar_t*[], void(*)(wchar_t**)> wargv(CommandLineToArgvW(GetCommandLineW(), &wargc), [](wchar_t** wargv) {
 		LocalFree(wargv);
 	});

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -13,8 +13,9 @@ bool ImageManager::Initial() {
 	tCover[1] = nullptr;
 	tCover[2] = GetTextureFromFile("textures/cover.jpg", CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
 	tCover[3] = GetTextureFromFile("textures/cover2.jpg", CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
-	if(!tCover[3])
+	if(!tCover[3]) {
 		tCover[3] = tCover[2];
+}
 	tUnknown = nullptr;
 	tUnknownFit = nullptr;
 	tUnknownThumb = nullptr;
@@ -53,16 +54,19 @@ void ImageManager::SetDevice(irr::IrrlichtDevice* dev) {
 }
 void ImageManager::ClearTexture() {
 	for(auto tit = tMap[0].begin(); tit != tMap[0].end(); ++tit) {
-		if(tit->second)
+		if(tit->second) {
 			driver->removeTexture(tit->second);
+}
 	}
 	for(auto tit = tMap[1].begin(); tit != tMap[1].end(); ++tit) {
-		if(tit->second)
+		if(tit->second) {
 			driver->removeTexture(tit->second);
+}
 	}
 	for(auto tit = tThumb.begin(); tit != tThumb.end(); ++tit) {
-		if(tit->second && tit->second != tLoading)
+		if(tit->second && tit->second != tLoading) {
 			driver->removeTexture(tit->second);
+}
 	}
 	if(tBigPicture != nullptr) {
 		driver->removeTexture(tBigPicture);
@@ -73,8 +77,9 @@ void ImageManager::ClearTexture() {
 	tThumb.clear();
 	tThumbLoadingMutex.lock();
 	tThumbLoading.clear();
-	while(!tThumbLoadingCodes.empty())
+	while(!tThumbLoadingCodes.empty()) {
 		tThumbLoadingCodes.pop();
+}
 	tThumbLoadingThreadRunning = false;
 	tThumbLoadingMutex.unlock();
 	tFields.clear();
@@ -82,14 +87,16 @@ void ImageManager::ClearTexture() {
 void ImageManager::RemoveTexture(int code) {
 	auto tit = tMap[0].find(code);
 	if(tit != tMap[0].end()) {
-		if(tit->second)
+		if(tit->second) {
 			driver->removeTexture(tit->second);
+}
 		tMap[0].erase(tit);
 	}
 	tit = tMap[1].find(code);
 	if(tit != tMap[1].end()) {
-		if(tit->second)
+		if(tit->second) {
 			driver->removeTexture(tit->second);
+}
 		tMap[1].erase(tit);
 	}
 }
@@ -107,8 +114,9 @@ void ImageManager::ResizeTexture() {
 	driver->removeTexture(tCover[1]);
 	tCover[0] = GetTextureFromFile("textures/cover.jpg", imgWidth, imgHeight);
 	tCover[1] = GetTextureFromFile("textures/cover2.jpg", imgWidth, imgHeight);
-	if(!tCover[1])
+	if(!tCover[1]) {
 		tCover[1] = tCover[0];
+}
 	driver->removeTexture(tUnknown);
 	driver->removeTexture(tUnknownFit);
 	driver->removeTexture(tUnknownThumb);
@@ -121,12 +129,14 @@ void ImageManager::ResizeTexture() {
 	tBackGround = GetTextureFromFile("textures/bg.jpg", bgWidth, bgHeight);
 	driver->removeTexture(tBackGround_menu);
 	tBackGround_menu = GetTextureFromFile("textures/bg_menu.jpg", bgWidth, bgHeight);
-	if(!tBackGround_menu)
+	if(!tBackGround_menu) {
 		tBackGround_menu = tBackGround;
+}
 	driver->removeTexture(tBackGround_deck);
 	tBackGround_deck = GetTextureFromFile("textures/bg_deck.jpg", bgWidth, bgHeight);
-	if(!tBackGround_deck)
+	if(!tBackGround_deck) {
 		tBackGround_deck = tBackGround;
+}
 }
 // function by Warr1024, from https://github.com/minetest/minetest/issues/2419 , modified
 void imageScaleNNAA(irr::video::IImage *src, irr::video::IImage *dest) {
@@ -141,7 +151,7 @@ void imageScaleNNAA(irr::video::IImage *src, irr::video::IImage *dest) {
 	// Walk each destination image pixel.
 	// Note: loop y around x for better cache locality.
 	irr::core::dimension2d<u32> dim = dest->getDimension();
-	for(dy = 0; dy < dim.Height; dy++)
+	for(dy = 0; dy < dim.Height; dy++) {
 		for(dx = 0; dx < dim.Width; dx++) {
 
 			// Calculate floating-point source rectangle bounds.
@@ -159,21 +169,25 @@ void imageScaleNNAA(irr::video::IImage *src, irr::video::IImage *dest) {
 			aa = 0;
 
 			// Loop over the integral pixel positions described by those bounds.
-			for(sy = floor(minsy); sy < maxsy; sy++)
+			for(sy = floor(minsy); sy < maxsy; sy++) {
 				for(sx = floor(minsx); sx < maxsx; sx++) {
 
 					// Calculate width, height, then area of dest pixel
 					// that's covered by this source pixel.
 					pw = 1;
-					if(minsx > sx)
+					if(minsx > sx) {
 						pw += sx - minsx;
-					if(maxsx < (sx + 1))
+}
+					if(maxsx < (sx + 1)) {
 						pw += maxsx - sx - 1;
+}
 					ph = 1;
-					if(minsy > sy)
+					if(minsy > sy) {
 						ph += sy - minsy;
-					if(maxsy < (sy + 1))
+}
+					if(maxsy < (sy + 1)) {
 						ph += maxsy - sy - 1;
+}
 					pa = pw * ph;
 
 					// Get source pixel and add it to totals, weighted
@@ -185,6 +199,7 @@ void imageScaleNNAA(irr::video::IImage *src, irr::video::IImage *dest) {
 					ba += pa * pxl.getBlue();
 					aa += pa * pxl.getAlpha();
 				}
+}
 
 			// Set the destination image pixel to the average color.
 			if(area > 0) {
@@ -201,12 +216,14 @@ void imageScaleNNAA(irr::video::IImage *src, irr::video::IImage *dest) {
 			dest->setPixel(dx, dy, pxl);
 		}
 }
+}
 irr::video::ITexture* ImageManager::GetTextureFromFile(const char* file, s32 width, s32 height) {
 	if(mainGame->gameConf.use_image_scale) {
 		irr::video::ITexture* texture = nullptr;
 		irr::video::IImage* srcimg = driver->createImageFromFile(file);
-		if(srcimg == nullptr)
+		if(srcimg == nullptr) {
 			return nullptr;
+}
 		if(srcimg->getDimension() == irr::core::dimension2d<u32>(width, height)) {
 			texture = driver->addTexture(file, srcimg);
 		} else {
@@ -222,14 +239,16 @@ irr::video::ITexture* ImageManager::GetTextureFromFile(const char* file, s32 wid
 	}
 }
 irr::video::ITexture* ImageManager::GetTexture(int code, bool fit) {
-	if(code == 0)
+	if(code == 0) {
 		return fit ? tUnknownFit : tUnknown;
+}
 	int width = CARD_IMG_WIDTH;
 	int height = CARD_IMG_HEIGHT;
 	if(fit) {
 		float mul = mainGame->xScale;
-		if(mainGame->xScale > mainGame->yScale)
+		if(mainGame->xScale > mainGame->yScale) {
 			mul = mainGame->yScale;
+}
 		width = width * mul;
 		height = height * mul;
 	}
@@ -249,14 +268,16 @@ irr::video::ITexture* ImageManager::GetTexture(int code, bool fit) {
 		tMap[fit ? 1 : 0][code] = img;
 		return (img == nullptr) ? (fit ? tUnknownFit : tUnknown) : img;
 	}
-	if(tit->second)
+	if(tit->second) {
 		return tit->second;
-	else
+	} else {
 		return mainGame->gameConf.use_image_scale ? (fit ? tUnknownFit : tUnknown) : GetTextureThumb(code);
 }
+}
 irr::video::ITexture* ImageManager::GetBigPicture(int code, float zoom) {
-	if(code == 0)
+	if(code == 0) {
 		return tUnknown;
+}
 	if(tBigPicture != nullptr) {
 		driver->removeTexture(tBigPicture);
 		tBigPicture = nullptr;
@@ -312,8 +333,9 @@ int ImageManager::LoadThumbThread() {
 			if(img->getDimension() == irr::core::dimension2d<u32>(width, height)) {
 				img->grab();
 				imageManager.tThumbLoadingMutex.lock();
-				if(imageManager.tThumbLoadingThreadRunning)
+				if(imageManager.tThumbLoadingThreadRunning) {
 					imageManager.tThumbLoading[code] = img;
+}
 				imageManager.tThumbLoadingMutex.unlock();
 			} else {
 				irr::video::IImage *destimg = imageManager.driver->createImage(img->getColorFormat(), irr::core::dimension2d<u32>(width, height));
@@ -321,28 +343,32 @@ int ImageManager::LoadThumbThread() {
 				img->drop();
 				destimg->grab();
 				imageManager.tThumbLoadingMutex.lock();
-				if(imageManager.tThumbLoadingThreadRunning)
+				if(imageManager.tThumbLoadingThreadRunning) {
 					imageManager.tThumbLoading[code] = destimg;
+}
 				imageManager.tThumbLoadingMutex.unlock();
 			}
 		} else {
 			imageManager.tThumbLoadingMutex.lock();
-			if(imageManager.tThumbLoadingThreadRunning)
+			if(imageManager.tThumbLoadingThreadRunning) {
 				imageManager.tThumbLoading[code] = nullptr;
+}
 			imageManager.tThumbLoadingMutex.unlock();
 		}
 		imageManager.tThumbLoadingMutex.lock();
 		imageManager.tThumbLoadingThreadRunning = !imageManager.tThumbLoadingCodes.empty();
-		if(!imageManager.tThumbLoadingThreadRunning)
+		if(!imageManager.tThumbLoadingThreadRunning) {
 			break;
+}
 		imageManager.tThumbLoadingMutex.unlock();
 	}
 	imageManager.tThumbLoadingMutex.unlock();
 	return 0;
 }
 irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
-	if(code == 0)
+	if(code == 0) {
 		return tUnknownThumb;
+}
 	imageManager.tThumbLoadingMutex.lock();
 	auto lit = tThumbLoading.find(code);
 	if(lit != tThumbLoading.end()) {
@@ -370,14 +396,16 @@ irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 		imageManager.tThumbLoadingMutex.unlock();
 		return tLoading;
 	}
-	if(tit->second)
+	if(tit->second) {
 		return tit->second;
-	else
+	} else {
 		return tUnknownThumb;
 }
+}
 irr::video::ITexture* ImageManager::GetTextureField(int code) {
-	if(code == 0)
+	if(code == 0) {
 		return nullptr;
+}
 	auto tit = tFields.find(code);
 	if(tit == tFields.end()) {
 		char file[256];
@@ -406,9 +434,10 @@ irr::video::ITexture* ImageManager::GetTextureField(int code) {
 			return img;
 		}
 	}
-	if(tit->second)
+	if(tit->second) {
 		return tit->second;
-	else
+	} else {
 		return nullptr;
+}
 }
 }

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -1,4 +1,6 @@
 #include "image_manager.h"
+
+#include <math.h>
 #include "game.h"
 #include <thread>
 
@@ -128,8 +130,8 @@ void ImageManager::ResizeTexture() {
 }
 // function by Warr1024, from https://github.com/minetest/minetest/issues/2419 , modified
 void imageScaleNNAA(irr::video::IImage *src, irr::video::IImage *dest) {
-	double sx, sy, minsx, maxsx, minsy, maxsy, area, ra, ga, ba, aa, pw, ph, pa;
-	u32 dy, dx;
+	double sx = NAN, sy = NAN, minsx = NAN, maxsx = NAN, minsy = NAN, maxsy = NAN, area = NAN, ra = NAN, ga = NAN, ba = NAN, aa = NAN, pw = NAN, ph = NAN, pa = NAN;
+	u32 dy = 0, dx = 0;
 	irr::video::SColor pxl;
 
 	// Cache rectsngle boundaries.
@@ -201,7 +203,7 @@ void imageScaleNNAA(irr::video::IImage *src, irr::video::IImage *dest) {
 }
 irr::video::ITexture* ImageManager::GetTextureFromFile(const char* file, s32 width, s32 height) {
 	if(mainGame->gameConf.use_image_scale) {
-		irr::video::ITexture* texture;
+		irr::video::ITexture* texture = nullptr;
 		irr::video::IImage* srcimg = driver->createImageFromFile(file);
 		if(srcimg == nullptr)
 			return nullptr;
@@ -259,7 +261,7 @@ irr::video::ITexture* ImageManager::GetBigPicture(int code, float zoom) {
 		driver->removeTexture(tBigPicture);
 		tBigPicture = nullptr;
 	}
-	irr::video::ITexture* texture;
+	irr::video::ITexture* texture = nullptr;
 	char file[256];
 	snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
 	irr::video::IImage* srcimg = driver->createImageFromFile(file);

--- a/gframe/materials.cpp
+++ b/gframe/materials.cpp
@@ -191,8 +191,9 @@ Materials::Materials() {
 	//remove
 	SetS3DVertex(vFieldRemove[0][0], 7.9f, 0.1f, 8.7f, 1.3f, 0, 1, 0, 0, 0, 0);
 	SetS3DVertex(vFieldRemove[0][1], 6.9f, 0.1f, 7.7f, 1.3f, 0, 1, 0, 0, 0, 0);
-	for(int i = 0; i < 5; ++i)
+	for(int i = 0; i < 5; ++i) {
 		SetS3DVertex(vFieldMzone[0][i], 1.2f + i * 1.1f, 0.8f, 2.3f + i * 1.1f, 2.0f, 0, 1, 0, 0, 0, 0);
+}
 	SetS3DVertex(vFieldMzone[0][5], 2.3f, -0.6f, 3.4f, 0.6f, 0, 1, 0, 0, 0, 0);
 	SetS3DVertex(vFieldMzone[0][6], 4.5f, -0.6f, 5.6f, 0.6f, 0, 1, 0, 0, 0, 0);
 	for (int i = 0; i < 5; ++i) {
@@ -218,8 +219,9 @@ Materials::Materials() {
 	//remove
 	SetS3DVertex(vFieldRemove[1][0], 0.0f, -0.1f, -0.8f, -1.3f, 0, 1, 0, 0, 0, 0);
 	SetS3DVertex(vFieldRemove[1][1], 1.0f, -0.1f, 0.2f, -1.3f, 0, 1, 0, 0, 0, 0);
-	for(int i = 0; i < 5; ++i)
+	for(int i = 0; i < 5; ++i) {
 		SetS3DVertex(vFieldMzone[1][i], 6.7f - i * 1.1f, -0.8f, 5.6f - i * 1.1f, -2.0f, 0, 1, 0, 0, 0, 0);
+}
 	SetS3DVertex(vFieldMzone[1][5], 5.6f, 0.6f, 4.5f, -0.6f, 0, 1, 0, 0, 0, 0);
 	SetS3DVertex(vFieldMzone[1][6], 3.4f, 0.6f, 2.3f, -0.6f, 0, 1, 0, 0, 0, 0);
 	for (int i = 0; i < 5; ++i) {
@@ -243,8 +245,9 @@ Materials::Materials() {
 	vFieldContiAct[3] = vector3df(4.4f, 0.6f, 0.0f);
 
 
-	for(int i = 0; i < 40; ++i)
+	for(int i = 0; i < 40; ++i) {
 		iArrow[i] = i;
+}
 
 	mCard.AmbientColor = 0xffffffff;
 	mCard.DiffuseColor = 0xff000000;

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -19,17 +19,21 @@ void UpdateDeck() {
 	auto *pdeck = deckbuf;
 	BufferIO::WriteInt32(pdeck, deckManager.current_deck.main.size() + deckManager.current_deck.extra.size());
 	BufferIO::WriteInt32(pdeck, deckManager.current_deck.side.size());
-	for(size_t i = 0; i < deckManager.current_deck.main.size(); ++i)
+	for(size_t i = 0; i < deckManager.current_deck.main.size(); ++i) {
 		BufferIO::WriteInt32(pdeck, deckManager.current_deck.main[i]->first);
-	for(size_t i = 0; i < deckManager.current_deck.extra.size(); ++i)
+}
+	for(size_t i = 0; i < deckManager.current_deck.extra.size(); ++i) {
 		BufferIO::WriteInt32(pdeck, deckManager.current_deck.extra[i]->first);
-	for(size_t i = 0; i < deckManager.current_deck.side.size(); ++i)
+}
+	for(size_t i = 0; i < deckManager.current_deck.side.size(); ++i) {
 		BufferIO::WriteInt32(pdeck, deckManager.current_deck.side[i]->first);
+}
 	DuelClient::SendBufferToServer(CTOS_UPDATE_DECK, deckbuf, pdeck - deckbuf);
 }
 bool MenuHandler::OnEvent(const irr::SEvent& event) {
-	if(mainGame->dField.OnCommonEvent(event))
+	if(mainGame->dField.OnCommonEvent(event)) {
 		return false;
+}
 	switch(event.EventType) {
 	case irr::EET_GUI_EVENT: {
 		irr::gui::IGUIElement* caller = event.GUIEvent.Caller;
@@ -44,10 +48,11 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 		}
 		switch(event.GUIEvent.EventType) {
 		case irr::gui::EGET_BUTTON_CLICKED: {
-			if(id < 110)
+			if(id < 110) {
 				soundManager.PlaySoundEffect(SOUND_MENU);
-			else
+			} else {
 				soundManager.PlaySoundEffect(SOUND_BUTTON);
+}
 			switch(id) {
 			case BUTTON_MODE_EXIT: {
 				mainGame->device->closeDevice();
@@ -111,8 +116,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			case BUTTON_JOIN_CANCEL: {
 				mainGame->HideElement(mainGame->wLanWindow);
 				mainGame->ShowElement(mainGame->wMainMenu);
-				if(exit_on_return)
+				if(exit_on_return) {
 					mainGame->device->closeDevice();
+}
 				break;
 			}
 			case BUTTON_LAN_REFRESH: {
@@ -165,8 +171,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			case BUTTON_HP_KICK: {
 				int index = 0;
 				while(index < 4) {
-					if(mainGame->btnHostPrepKick[index] == caller)
+					if(mainGame->btnHostPrepKick[index] == caller) {
 						break;
+}
 					++index;
 				}
 				CTOS_Kick csk;
@@ -207,13 +214,15 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				mainGame->btnStartBot->setEnabled(true);
 				mainGame->btnBotCancel->setEnabled(true);
 				mainGame->HideElement(mainGame->wHostPrepare);
-				if(bot_mode)
+				if(bot_mode) {
 					mainGame->ShowElement(mainGame->wSinglePlay);
-				else
+				} else {
 					mainGame->ShowElement(mainGame->wLanWindow);
+}
 				mainGame->wChat->setVisible(false);
-				if(exit_on_return)
+				if(exit_on_return) {
 					mainGame->device->closeDevice();
+}
 				break;
 			}
 			case BUTTON_REPLAY_MODE: {
@@ -237,12 +246,14 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					open_file = false;
 				} else {
 					auto selected = mainGame->lstReplayList->getSelected();
-					if(selected == -1)
+					if(selected == -1) {
 						break;
+}
 					wchar_t replay_path[256]{};
 					myswprintf(replay_path, L"./replay/%ls", mainGame->lstReplayList->getListItem(selected));
-					if (!ReplayMode::cur_replay.OpenReplay(replay_path))
+					if (!ReplayMode::cur_replay.OpenReplay(replay_path)) {
 						break;
+}
 				}
 				mainGame->ClearCardInfo();
 				mainGame->wCardImg->setVisible(true);
@@ -258,15 +269,17 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				mainGame->HideElement(mainGame->wReplay);
 				mainGame->device->setEventReceiver(&mainGame->dField);
 				unsigned int start_turn = std::wcstol(mainGame->ebRepStartTurn->getText(), nullptr, 10);
-				if(start_turn == 1)
+				if(start_turn == 1) {
 					start_turn = 0;
+}
 				ReplayMode::StartReplay(start_turn);
 				break;
 			}
 			case BUTTON_DELETE_REPLAY: {
 				int sel = mainGame->lstReplayList->getSelected();
-				if(sel == -1)
+				if(sel == -1) {
 					break;
+}
 				mainGame->gMutex.lock();
 				wchar_t textBuffer[256];
 				myswprintf(textBuffer, L"%ls\n%ls", mainGame->lstReplayList->getListItem(sel), dataManager.GetSysString(1363));
@@ -279,8 +292,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_RENAME_REPLAY: {
 				int sel = mainGame->lstReplayList->getSelected();
-				if(sel == -1)
+				if(sel == -1) {
 					break;
+}
 				mainGame->gMutex.lock();
 				mainGame->wReplaySave->setText(dataManager.GetSysString(1364));
 				mainGame->ebRSName->setText(mainGame->lstReplayList->getListItem(sel));
@@ -297,8 +311,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_EXPORT_DECK: {
 				auto selected = mainGame->lstReplayList->getSelected();
-				if(selected == -1)
+				if(selected == -1) {
 					break;
+}
 				Replay replay;
 				wchar_t ex_filename[256]{};
 				wchar_t namebuf[4][20]{};
@@ -306,18 +321,22 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				wchar_t replay_path[256]{};
 				BufferIO::CopyWideString(mainGame->lstReplayList->getListItem(selected), ex_filename);
 				myswprintf(replay_path, L"./replay/%ls", ex_filename);
-				if (!replay.OpenReplay(replay_path))
+				if (!replay.OpenReplay(replay_path)) {
 					break;
+}
 				const ReplayHeader& rh = replay.pheader;
-				if(rh.flag & REPLAY_SINGLE_MODE)
+				if(rh.flag & REPLAY_SINGLE_MODE) {
 					break;
+}
 				int player_count = (rh.flag & REPLAY_TAG) ? 4 : 2;
 				//player name
-				for(int i = 0; i < player_count; ++i)
+				for(int i = 0; i < player_count; ++i) {
 					replay.ReadName(namebuf[i]);
+}
 				//skip pre infos
-				for(int i = 0; i < 4; ++i)
+				for(int i = 0; i < 4; ++i) {
 					replay.ReadInt32();
+}
 				//deck
 				std::vector<int> deckbuf;
 				for(int i = 0; i < player_count; ++i) {
@@ -343,8 +362,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_BOT_START: {
 				int sel = mainGame->lstBotList->getSelected();
-				if(sel == -1)
+				if(sel == -1) {
 					break;
+}
 				bot_mode = true;
 #ifdef _WIN32
 				if(!NetServer::StartServer(mainGame->gameConf.serverport)) {
@@ -370,8 +390,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					deckManager.GetDeckFile(botdeck, mainGame->cbBotDeckCategory, mainGame->cbBotDeck);
 					myswprintf(arg1, L"%ls DeckFile='%ls'", mainGame->botInfo[sel].command, botdeck);
 				}
-				else
+				else {
 					myswprintf(arg1, L"%ls", mainGame->botInfo[sel].command);
+}
 				int flag = 0;
 				flag += (mainGame->chkBotHand->isChecked() ? 0x1 : 0);
 				myswprintf(cmd, L"Bot.exe \"%ls\" %d %d", arg1, flag, mainGame->gameConf.serverport);
@@ -420,8 +441,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_LOAD_SINGLEPLAY: {
-				if(!open_file && mainGame->lstSinglePlayList->getSelected() == -1)
+				if(!open_file && mainGame->lstSinglePlayList->getSelected() == -1) {
 					break;
+}
 				mainGame->singleSignal.SetNoWait(false);
 				SingleMode::StartPlay();
 				break;
@@ -528,8 +550,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			switch(id) {
 			case LISTBOX_LAN_HOST: {
 				int sel = mainGame->lstHostList->getSelected();
-				if(sel == -1)
+				if(sel == -1) {
 					break;
+}
 				int addr = DuelClient::hosts[sel].ipaddr;
 				int port = DuelClient::hosts[sel].port;
 				wchar_t buf[20];
@@ -541,8 +564,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case LISTBOX_REPLAY_LIST: {
 				int sel = mainGame->lstReplayList->getSelected();
-				if(sel == -1)
+				if(sel == -1) {
 					break;
+}
 				wchar_t replay_path[256]{};
 				myswprintf(replay_path, L"./replay/%ls", mainGame->lstReplayList->getListItem(sel));
 				if (!ReplayMode::cur_replay.OpenReplay(replay_path)) {
@@ -552,10 +576,11 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				wchar_t infobuf[256]{};
 				std::wstring repinfo;
 				time_t curtime = 0;
-				if(ReplayMode::cur_replay.pheader.flag & REPLAY_UNIFORM)
+				if(ReplayMode::cur_replay.pheader.flag & REPLAY_UNIFORM) {
 					curtime = ReplayMode::cur_replay.pheader.start_time;
-				else
+				} else {
 					curtime = ReplayMode::cur_replay.pheader.seed;
+}
 				std::wcsftime(infobuf, sizeof infobuf / sizeof infobuf[0], L"%Y/%m/%d %H:%M:%S\n", std::localtime(&curtime));
 				repinfo.append(infobuf);
 				wchar_t namebuf[4][20]{};
@@ -565,10 +590,11 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					ReplayMode::cur_replay.ReadName(namebuf[2]);
 					ReplayMode::cur_replay.ReadName(namebuf[3]);
 				}
-				if(ReplayMode::cur_replay.pheader.flag & REPLAY_TAG)
+				if(ReplayMode::cur_replay.pheader.flag & REPLAY_TAG) {
 					myswprintf(infobuf, L"%ls\n%ls\n===VS===\n%ls\n%ls\n", namebuf[0], namebuf[1], namebuf[2], namebuf[3]);
-				else
+				} else {
 					myswprintf(infobuf, L"%ls\n===VS===\n%ls\n", namebuf[0], namebuf[1]);
+}
 				repinfo.append(infobuf);
 				mainGame->ebRepStartTurn->setText(L"1");
 				mainGame->SetStaticText(mainGame->stReplayInfo, 180, mainGame->guiFont, repinfo.c_str());
@@ -576,8 +602,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case LISTBOX_SINGLEPLAY_LIST: {
 				int sel = mainGame->lstSinglePlayList->getSelected();
-				if(sel == -1)
+				if(sel == -1) {
 					break;
+}
 				const wchar_t* name = mainGame->lstSinglePlayList->getListItem(sel);
 				wchar_t fname[256];
 				myswprintf(fname, L"./single/%ls", name);
@@ -619,8 +646,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case LISTBOX_BOT_LIST: {
 				int sel = mainGame->lstBotList->getSelected();
-				if(sel == -1)
+				if(sel == -1) {
 					break;
+}
 				mainGame->SetStaticText(mainGame->stBotInfo, 200, mainGame->guiFont, mainGame->botInfo[sel].desc);
 				mainGame->cbBotDeckCategory->setVisible(mainGame->botInfo[sel].select_deckfile);
 				mainGame->cbBotDeck->setVisible(mainGame->botInfo[sel].select_deckfile);
@@ -632,8 +660,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 		case irr::gui::EGET_CHECKBOX_CHANGED: {
 			switch(id) {
 			case CHECKBOX_HP_READY: {
-				if(!caller->isEnabled())
+				if(!caller->isEnabled()) {
 					break;
+}
 				mainGame->env->setFocus(mainGame->wHostPrepare);
 				if(static_cast<irr::gui::IGUICheckBox*>(caller)->isChecked()) {
 					if(mainGame->cbCategorySelect->getSelected() == -1 || mainGame->cbDeckSelect->getSelected() == -1 ||

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -16,7 +16,7 @@ void UpdateDeck() {
 	BufferIO::CopyWideString(mainGame->cbCategorySelect->getText(), mainGame->gameConf.lastcategory);
 	BufferIO::CopyWideString(mainGame->cbDeckSelect->getText(), mainGame->gameConf.lastdeck);
 	unsigned char deckbuf[1024]{};
-	auto pdeck = deckbuf;
+	auto *pdeck = deckbuf;
 	BufferIO::WriteInt32(pdeck, deckManager.current_deck.main.size() + deckManager.current_deck.extra.size());
 	BufferIO::WriteInt32(pdeck, deckManager.current_deck.side.size());
 	for(size_t i = 0; i < deckManager.current_deck.main.size(); ++i)

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -551,7 +551,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				}
 				wchar_t infobuf[256]{};
 				std::wstring repinfo;
-				time_t curtime;
+				time_t curtime = 0;
 				if(ReplayMode::cur_replay.pheader.flag & REPLAY_UNIFORM)
 					curtime = ReplayMode::cur_replay.pheader.start_time;
 				else

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -69,7 +69,7 @@ void NetServer::StopBroadcast() {
 	if(!net_evbase || !broadcast_ev)
 		return;
 	event_del(broadcast_ev);
-	evutil_socket_t fd;
+	evutil_socket_t fd = 0;
 	event_get_assignment(broadcast_ev, nullptr, &fd, nullptr, nullptr, nullptr);
 	evutil_closesocket(fd);
 	event_free(broadcast_ev);
@@ -159,7 +159,7 @@ int NetServer::ServerThread() {
 	evconnlistener_free(listener);
 	listener = nullptr;
 	if(broadcast_ev) {
-		evutil_socket_t fd;
+		evutil_socket_t fd = 0;
 		event_get_assignment(broadcast_ev, nullptr, &fd, nullptr, nullptr, nullptr);
 		evutil_closesocket(fd);
 		event_free(broadcast_ev);

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -184,7 +184,7 @@ void NetServer::DisconnectPlayer(DuelPlayer* dp) {
 	}
 }
 void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
-	auto pdata = data;
+	auto *pdata = data;
 	unsigned char pktType = BufferIO::ReadUInt8(pdata);
 	if((pktType != CTOS_SURRENDER) && (pktType != CTOS_CHAT) && (dp->state == 0xff || (dp->state && dp->state != pktType)))
 		return;
@@ -248,7 +248,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 			return;
 		CTOS_PlayerInfo packet;
 		std::memcpy(&packet, pdata, sizeof packet);
-		auto pkt = &packet;
+		auto *pkt = &packet;
 		BufferIO::NullTerminate(pkt->name);
 		BufferIO::CopyCharArray(pkt->name, dp->name);
 		break;
@@ -260,7 +260,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 			return;
 		CTOS_CreateGame packet;
 		std::memcpy(&packet, pdata, sizeof packet);
-		auto pkt = &packet;
+		auto *pkt = &packet;
 		if(pkt->info.rule > CURRENT_RULE)
 			pkt->info.rule = CURRENT_RULE;
 		if(pkt->info.mode > MODE_TAG)
@@ -368,7 +368,7 @@ size_t NetServer::CreateChatPacket(unsigned char* src, int src_size, unsigned ch
 	if (src_msg[src_len - 1] != 0)
 		return 0;
 	// STOC_Chat packet
-	auto pdst = dst;
+	auto *pdst = dst;
 	buffer_write<uint16_t>(pdst, dst_player_type);
 	buffer_write_block(pdst, src_msg, src_size);
 	return sizeof(dst_player_type) + src_size;

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -8,10 +8,10 @@
 namespace ygo {
 std::unordered_map<bufferevent*, DuelPlayer> NetServer::users;
 unsigned short NetServer::server_port = 0;
-event_base* NetServer::net_evbase = 0;
-event* NetServer::broadcast_ev = 0;
-evconnlistener* NetServer::listener = 0;
-DuelMode* NetServer::duel_mode = 0;
+event_base* NetServer::net_evbase = nullptr;
+event* NetServer::broadcast_ev = nullptr;
+evconnlistener* NetServer::listener = nullptr;
+DuelMode* NetServer::duel_mode = nullptr;
 unsigned char NetServer::net_server_write[SIZE_NETWORK_BUFFER];
 size_t NetServer::last_sent = 0;
 
@@ -31,7 +31,7 @@ bool NetServer::StartServer(unsigned short port) {
 	                                   LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, -1, (sockaddr*)&sin, sizeof(sin));
 	if(!listener) {
 		event_base_free(net_evbase);
-		net_evbase = 0;
+		net_evbase = nullptr;
 		return false;
 	}
 	evconnlistener_set_error_cb(listener, ServerAcceptError);
@@ -63,17 +63,17 @@ void NetServer::StopServer() {
 		return;
 	if(duel_mode)
 		duel_mode->EndDuel();
-	event_base_loopexit(net_evbase, 0);
+	event_base_loopexit(net_evbase, nullptr);
 }
 void NetServer::StopBroadcast() {
 	if(!net_evbase || !broadcast_ev)
 		return;
 	event_del(broadcast_ev);
 	evutil_socket_t fd;
-	event_get_assignment(broadcast_ev, 0, &fd, 0, 0, 0);
+	event_get_assignment(broadcast_ev, nullptr, &fd, nullptr, nullptr, nullptr);
 	evutil_closesocket(fd);
 	event_free(broadcast_ev);
-	broadcast_ev = 0;
+	broadcast_ev = nullptr;
 }
 void NetServer::StopListen() {
 	evconnlistener_disable(listener);
@@ -114,7 +114,7 @@ void NetServer::ServerAccept(evconnlistener* listener, evutil_socket_t fd, socka
 	bufferevent_enable(bev, EV_READ);
 }
 void NetServer::ServerAcceptError(evconnlistener* listener, void* ctx) {
-	event_base_loopexit(net_evbase, 0);
+	event_base_loopexit(net_evbase, nullptr);
 }
 /*
 * packet_len: 2 bytes
@@ -157,21 +157,21 @@ int NetServer::ServerThread() {
 	}
 	users.clear();
 	evconnlistener_free(listener);
-	listener = 0;
+	listener = nullptr;
 	if(broadcast_ev) {
 		evutil_socket_t fd;
-		event_get_assignment(broadcast_ev, 0, &fd, 0, 0, 0);
+		event_get_assignment(broadcast_ev, nullptr, &fd, nullptr, nullptr, nullptr);
 		evutil_closesocket(fd);
 		event_free(broadcast_ev);
-		broadcast_ev = 0;
+		broadcast_ev = nullptr;
 	}
 	if(duel_mode) {
 		event_free(duel_mode->etimer);
 		delete duel_mode;
 	}
-	duel_mode = 0;
+	duel_mode = nullptr;
 	event_base_free(net_evbase);
-	net_evbase = 0;
+	net_evbase = nullptr;
 	return 0;
 }
 void NetServer::DisconnectPlayer(DuelPlayer* dp) {
@@ -297,7 +297,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 		BufferIO::NullTerminate(pkt->pass);
 		BufferIO::CopyCharArray(pkt->name, duel_mode->name);
 		BufferIO::CopyCharArray(pkt->pass, duel_mode->pass);
-		duel_mode->JoinGame(dp, 0, true);
+		duel_mode->JoinGame(dp, nullptr, true);
 		StartBroadcast();
 		break;
 	}

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -36,7 +36,7 @@ void Replay::BeginRecord() {
 void Replay::WriteHeader(ReplayHeader& header) {
 	pheader = header;
 #ifdef _WIN32
-	DWORD size;
+	DWORD size = 0;
 	WriteFile(recording_fp, &header, sizeof(header), &size, nullptr);
 #else
 	fwrite(&header, sizeof(header), 1, fp);
@@ -51,7 +51,7 @@ void Replay::WriteData(const void* data, size_t length, bool flush) {
 	std::memcpy(replay_data + replay_size, data, length);
 	replay_size += length;
 #ifdef _WIN32
-	DWORD size;
+	DWORD size = 0;
 	WriteFile(recording_fp, data, length, &size, nullptr);
 #else
 	fwrite(data, length, 1, fp);

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -13,14 +13,17 @@ Replay::~Replay() {
 	delete[] comp_data;
 }
 void Replay::BeginRecord() {
-	if(!FileSystem::IsDirExists(L"./replay") && !FileSystem::MakeDir(L"./replay"))
+	if(!FileSystem::IsDirExists(L"./replay") && !FileSystem::MakeDir(L"./replay")) {
 		return;
+}
 #ifdef _WIN32
-	if(is_recording)
+	if(is_recording) {
 		CloseHandle(recording_fp);
+}
 	recording_fp = CreateFileW(L"./replay/_LastReplay.yrp", GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_FLAG_WRITE_THROUGH, nullptr);
-	if(recording_fp == INVALID_HANDLE_VALUE)
+	if(recording_fp == INVALID_HANDLE_VALUE) {
 		return;
+}
 #else
 	if(is_recording)
 		fclose(fp);
@@ -44,10 +47,12 @@ void Replay::WriteHeader(ReplayHeader& header) {
 #endif
 }
 void Replay::WriteData(const void* data, size_t length, bool flush) {
-	if(!is_recording)
+	if(!is_recording) {
 		return;
-	if (replay_size + length > MAX_REPLAY_SIZE)
+}
+	if (replay_size + length > MAX_REPLAY_SIZE) {
 		return;
+}
 	std::memcpy(replay_data + replay_size, data, length);
 	replay_size += length;
 #ifdef _WIN32
@@ -63,16 +68,18 @@ void Replay::WriteInt32(int32_t data, bool flush) {
 	Write<int32_t>(data, flush);
 }
 void Replay::Flush() {
-	if(!is_recording)
+	if(!is_recording) {
 		return;
+}
 #ifdef _WIN32
 #else
 	fflush(fp);
 #endif
 }
 void Replay::EndRecord() {
-	if(!is_recording)
+	if(!is_recording) {
 		return;
+}
 #ifdef _WIN32
 	CloseHandle(recording_fp);
 #else
@@ -90,13 +97,15 @@ void Replay::EndRecord() {
 	is_recording = false;
 }
 void Replay::SaveReplay(const wchar_t* name) {
-	if(!FileSystem::IsDirExists(L"./replay") && !FileSystem::MakeDir(L"./replay"))
+	if(!FileSystem::IsDirExists(L"./replay") && !FileSystem::MakeDir(L"./replay")) {
 		return;
+}
 	wchar_t fname[256];
 	myswprintf(fname, L"./replay/%ls.yrp", name);
 	FILE* rfp = myfopen(fname, "wb");
-	if(!rfp)
+	if(!rfp) {
 		return;
+}
 	fwrite(&pheader, sizeof pheader, 1, rfp);
 	fwrite(comp_data, comp_size, 1, rfp);
 	fclose(rfp);
@@ -108,8 +117,9 @@ bool Replay::OpenReplay(const wchar_t* name) {
 		myswprintf(fname, L"./replay/%ls", name);
 		rfp = myfopen(fname, "rb");
 	}
-	if(!rfp)
+	if(!rfp) {
 		return false;
+}
 
 	data_position = 0;
 	is_recording = false;
@@ -123,11 +133,13 @@ bool Replay::OpenReplay(const wchar_t* name) {
 	if(pheader.flag & REPLAY_COMPRESSED) {
 		comp_size = fread(comp_data, 1, MAX_COMP_SIZE, rfp);
 		fclose(rfp);
-		if (pheader.datasize > MAX_REPLAY_SIZE)
+		if (pheader.datasize > MAX_REPLAY_SIZE) {
 			return false;
+}
 		replay_size = pheader.datasize;
-		if (LzmaUncompress(replay_data, &replay_size, comp_data, &comp_size, pheader.props, 5) != SZ_OK)
+		if (LzmaUncompress(replay_data, &replay_size, comp_data, &comp_size, pheader.props, 5) != SZ_OK) {
 			return false;
+}
 		if (replay_size != pheader.datasize) {
 			replay_size = 0;
 			return false;
@@ -144,8 +156,9 @@ bool Replay::CheckReplay(const wchar_t* name) {
 	wchar_t fname[256];
 	myswprintf(fname, L"./replay/%ls", name);
 	FILE* rfp = myfopen(fname, "rb");
-	if(!rfp)
+	if(!rfp) {
 		return false;
+}
 	ReplayHeader rheader;
 	size_t count = fread(&rheader, sizeof rheader, 1, rfp);
 	fclose(rfp);
@@ -183,14 +196,16 @@ bool Replay::RenameReplay(const wchar_t* oldname, const wchar_t* newname) {
 }
 bool Replay::ReadNextResponse(unsigned char resp[]) {
 	unsigned char len{};
-	if (!ReadData(&len, sizeof len))
+	if (!ReadData(&len, sizeof len)) {
 		return false;
+}
 	if (len > SIZE_RETURN_VALUE) {
 		is_replaying = false;
 		return false;
 	}
-	if (!ReadData(resp, len))
+	if (!ReadData(resp, len)) {
 		return false;
+}
 	return true;
 }
 bool Replay::ReadName(wchar_t* data) {
@@ -205,14 +220,16 @@ void Replay::ReadHeader(ReplayHeader& header) {
 	header = pheader;
 }
 bool Replay::ReadData(void* data, size_t length) {
-	if(!is_replaying)
+	if(!is_replaying) {
 		return false;
+}
 	if (data_position + length > replay_size) {
 		is_replaying = false;
 		return false;
 	}
-	if (length)
+	if (length) {
 		std::memcpy(data, &replay_data[data_position], length);
+}
 	data_position += length;
 	return true;
 }

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -321,7 +321,7 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			mainGame->gMutex.unlock();
 			is_swaping = false;
 		}
-		auto offset = pbuf;
+		auto *offset = pbuf;
 		bool pauseable = true;
 		mainGame->dInfo.curMsg = BufferIO::ReadUInt8(pbuf);
 		switch (mainGame->dInfo.curMsg) {

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -22,8 +22,9 @@ int ReplayMode::skip_step = 0;
 
 bool ReplayMode::StartReplay(int skipturn) {
 	skip_turn = skipturn;
-	if(skip_turn < 0)
+	if(skip_turn < 0) {
 		skip_turn = 0;
+}
 	std::thread(ReplayThread).detach();
 	return true;
 }
@@ -35,25 +36,28 @@ void ReplayMode::StopReplay(bool is_exiting) {
 	mainGame->actionSignal.Set();
 }
 void ReplayMode::SwapField() {
-	if(is_paused)
+	if(is_paused) {
 		mainGame->dField.ReplaySwap();
-	else
+	} else {
 		is_swaping = true;
 }
+}
 void ReplayMode::Pause(bool is_pause, bool is_step) {
-	if(is_pause)
+	if(is_pause) {
 		is_pausing = true;
-	else {
-		if(!is_step)
+	} else {
+		if(!is_step) {
 			is_pausing = false;
+}
 		mainGame->actionSignal.Set();
 	}
 }
 bool ReplayMode::ReadReplayResponse() {
 	unsigned char resp[SIZE_RETURN_VALUE];
 	bool result = cur_replay.ReadNextResponse(resp);
-	if(result)
+	if(result) {
 		set_responseb(pduel, resp);
+}
 	return result;
 }
 int ReplayMode::ReplayThread() {
@@ -81,8 +85,9 @@ int ReplayMode::ReplayThread() {
 	skip_step = 0;
 	if(mainGame->dInfo.isSingleMode) {
 		int len = get_message(pduel, engineBuffer.data());
-		if (len > 0)
+		if (len > 0) {
 			is_continuing = ReplayAnalyze(engineBuffer.data(), len);
+}
 	} else {
 		ReplayRefreshDeck(0);
 		ReplayRefreshDeck(1);
@@ -91,14 +96,16 @@ int ReplayMode::ReplayThread() {
 	}
 	exit_pending = false;
 	current_step = 0;
-	if(mainGame->dInfo.isReplaySkiping)
+	if(mainGame->dInfo.isReplaySkiping) {
 		mainGame->gMutex.lock();
+}
 	while (is_continuing && !exit_pending) {
 		unsigned int result = process(pduel);
 		int len = result & PROCESSOR_BUFFER_LEN;
 		if (len > 0) {
-			if (len > (int)engineBuffer.size())
+			if (len > (int)engineBuffer.size()) {
 				engineBuffer.resize(len);
+}
 			get_message(pduel, engineBuffer.data());
 			is_continuing = ReplayAnalyze(engineBuffer.data(), len);
 			if(is_restarting) {
@@ -107,8 +114,9 @@ int ReplayMode::ReplayThread() {
 				mainGame->dInfo.isReplaySkiping = true;
 				Restart(false);
 				int step = current_step - 1;
-				if(step < 0)
+				if(step < 0) {
 					step = 0;
+}
 				if(mainGame->dInfo.isSingleMode) {
 					is_continuing = true;
 					skip_step = 0;
@@ -185,46 +193,58 @@ bool ReplayMode::StartDuel() {
 	if(!mainGame->dInfo.isSingleMode) {
 		if(!(opt & DUEL_TAG_MODE)) {
 			int main = cur_replay.ReadInt32();
-			for(int i = 0; i < main; ++i)
+			for(int i = 0; i < main; ++i) {
 				new_card(pduel, cur_replay.ReadInt32(), 0, 0, LOCATION_DECK, 0, POS_FACEDOWN_DEFENSE);
+}
 			int extra = cur_replay.ReadInt32();
-			for(int i = 0; i < extra; ++i)
+			for(int i = 0; i < extra; ++i) {
 				new_card(pduel, cur_replay.ReadInt32(), 0, 0, LOCATION_EXTRA, 0, POS_FACEDOWN_DEFENSE);
+}
 			mainGame->dField.Initial(mainGame->LocalPlayer(0), main, extra);
 			main = cur_replay.ReadInt32();
-			for(int i = 0; i < main; ++i)
+			for(int i = 0; i < main; ++i) {
 				new_card(pduel, cur_replay.ReadInt32(), 1, 1, LOCATION_DECK, 0, POS_FACEDOWN_DEFENSE);
+}
 			extra = cur_replay.ReadInt32();
-			for(int i = 0; i < extra; ++i)
+			for(int i = 0; i < extra; ++i) {
 				new_card(pduel, cur_replay.ReadInt32(), 1, 1, LOCATION_EXTRA, 0, POS_FACEDOWN_DEFENSE);
+}
 			mainGame->dField.Initial(mainGame->LocalPlayer(1), main, extra);
 		} else {
 			int main = cur_replay.ReadInt32();
-			for(int i = 0; i < main; ++i)
+			for(int i = 0; i < main; ++i) {
 				new_card(pduel, cur_replay.ReadInt32(), 0, 0, LOCATION_DECK, 0, POS_FACEDOWN_DEFENSE);
+}
 			int extra = cur_replay.ReadInt32();
-			for(int i = 0; i < extra; ++i)
+			for(int i = 0; i < extra; ++i) {
 				new_card(pduel, cur_replay.ReadInt32(), 0, 0, LOCATION_EXTRA, 0, POS_FACEDOWN_DEFENSE);
+}
 			mainGame->dField.Initial(mainGame->LocalPlayer(0), main, extra);
 			main = cur_replay.ReadInt32();
-			for(int i = 0; i < main; ++i)
+			for(int i = 0; i < main; ++i) {
 				new_tag_card(pduel, cur_replay.ReadInt32(), 0, LOCATION_DECK);
+}
 			extra = cur_replay.ReadInt32();
-			for(int i = 0; i < extra; ++i)
+			for(int i = 0; i < extra; ++i) {
 				new_tag_card(pduel, cur_replay.ReadInt32(), 0, LOCATION_EXTRA);
+}
 			main = cur_replay.ReadInt32();
-			for(int i = 0; i < main; ++i)
+			for(int i = 0; i < main; ++i) {
 				new_card(pduel, cur_replay.ReadInt32(), 1, 1, LOCATION_DECK, 0, POS_FACEDOWN_DEFENSE);
+}
 			extra = cur_replay.ReadInt32();
-			for(int i = 0; i < extra; ++i)
+			for(int i = 0; i < extra; ++i) {
 				new_card(pduel, cur_replay.ReadInt32(), 1, 1, LOCATION_EXTRA, 0, POS_FACEDOWN_DEFENSE);
+}
 			mainGame->dField.Initial(mainGame->LocalPlayer(1), main, extra);
 			main = cur_replay.ReadInt32();
-			for(int i = 0; i < main; ++i)
+			for(int i = 0; i < main; ++i) {
 				new_tag_card(pduel, cur_replay.ReadInt32(), 1, LOCATION_DECK);
+}
 			extra = cur_replay.ReadInt32();
-			for(int i = 0; i < extra; ++i)
+			for(int i = 0; i < extra; ++i) {
 				new_tag_card(pduel, cur_replay.ReadInt32(), 1, LOCATION_EXTRA);
+}
 		}
 	} else {
 		char filename[256];
@@ -238,8 +258,9 @@ bool ReplayMode::StartDuel() {
 			return false;
 		}
 	}
-	if (!(rh.flag & REPLAY_UNIFORM))
+	if (!(rh.flag & REPLAY_UNIFORM)) {
 		opt |= DUEL_OLD_REPLAY;
+}
 	start_duel(pduel, opt);
 	return true;
 }
@@ -268,8 +289,9 @@ void ReplayMode::EndDuel() {
 		mainGame->stTip->setVisible(false);
 		mainGame->device->setEventReceiver(&mainGame->menuHandler);
 		mainGame->gMutex.unlock();
-		if(exit_on_return)
+		if(exit_on_return) {
 			mainGame->device->closeDevice();
+}
 	}
 }
 void ReplayMode::Restart(bool refresh) {
@@ -299,8 +321,9 @@ void ReplayMode::Restart(bool refresh) {
 	skip_turn = 0;
 }
 void ReplayMode::Undo() {
-	if(skip_step > 0 || current_step == 0)
+	if(skip_step > 0 || current_step == 0) {
 		return;
+}
 	is_restarting = true;
 	Pause(false, false);
 }
@@ -309,8 +332,9 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 	int player = 0, count = 0;
 	is_restarting = false;
 	while (pbuf - msg < (int)len) {
-		if(is_closing)
+		if(is_closing) {
 			return false;
+}
 		if(is_restarting) {
 			//is_restarting = false;
 			return true;
@@ -553,10 +577,11 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			/*int cp = pbuf[11];*/
 			pbuf += 16;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
-			if(cl && !(cl & LOCATION_OVERLAY) && (pl != cl || pc != cc))
+			if(cl && !(cl & LOCATION_OVERLAY) && (pl != cl || pc != cc)) {
 				ReplayRefreshSingle(cc, cl, cs);
-			else if(pl == cl && cl == LOCATION_DECK)
+			} else if(pl == cl && cl == LOCATION_DECK) {
 				ReplayRefreshDeck(cc);
+}
 			break;
 		}
 		case MSG_POS_CHANGE: {
@@ -831,13 +856,15 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 				pbuf += 4;
 				for(int seq = 0; seq < 7; ++seq) {
 					int val = BufferIO::ReadUInt8(pbuf);
-					if(val)
+					if(val) {
 						pbuf += 2;
+}
 				}
 				for(int seq = 0; seq < 8; ++seq) {
 					int val = BufferIO::ReadUInt8(pbuf);
-					if(val)
+					if(val) {
 						pbuf++;
+}
 				}
 				pbuf += 6;
 			}
@@ -938,8 +965,9 @@ void ReplayMode::ReplayReload() {
 	ReloadLocation(1, LOCATION_REMOVED, flag, queryBuffer);
 }
 uint32_t ReplayMode::MessageHandler(intptr_t fduel, uint32_t type) {
-	if(!enable_log)
+	if(!enable_log) {
 		return 0;
+}
 	char msgbuf[1024];
 	get_log_message(fduel, msgbuf);
 	mainGame->AddDebugMsg(msgbuf);

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -306,7 +306,7 @@ void ReplayMode::Undo() {
 }
 bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 	unsigned char* pbuf = msg;
-	int player, count;
+	int player = 0, count = 0;
 	is_restarting = false;
 	while (pbuf - msg < (int)len) {
 		if(is_closing)

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -575,8 +575,8 @@ void SingleDuel::Surrender(DuelPlayer* dp) {
 }
 // Analyze ocgcore message
 int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
-	unsigned char* offset, *pbufw, *pbuf = msgbuffer;
-	int player, count, type;
+	unsigned char* offset = nullptr, *pbufw = nullptr, *pbuf = msgbuffer;
+	int player = 0, count = 0, type = 0;
 	while (pbuf - msgbuffer < (int)len) {
 		offset = pbuf;
 		unsigned char engType = BufferIO::ReadUInt8(pbuf);
@@ -706,7 +706,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			player = BufferIO::ReadUInt8(pbuf);
 			pbuf += 3;
 			count = BufferIO::ReadUInt8(pbuf);
-			int c/*, l, s, ss, code*/;
+			int c = 0/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
@@ -724,7 +724,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			player = BufferIO::ReadUInt8(pbuf);
 			pbuf += 4;
 			count = BufferIO::ReadUInt8(pbuf);
-			int c/*, l, s, ss, code*/;
+			int c = 0/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -15,12 +15,14 @@ SingleDuel::~SingleDuel() {
 void SingleDuel::Chat(DuelPlayer* dp, unsigned char* pdata, int len) {
 	unsigned char scc[SIZE_STOC_CHAT];
 	const auto scc_size = NetServer::CreateChatPacket(pdata, len, scc, dp->type);
-	if (!scc_size)
+	if (!scc_size) {
 		return;
+}
 	NetServer::SendBufferToPlayer(players[0], STOC_CHAT, scc, scc_size);
 	NetServer::ReSendToPlayer(players[1]);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
+}
 }
 void SingleDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 	if(!is_creater) {
@@ -55,8 +57,9 @@ void SingleDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater)
 		}
 	}
 	dp->game = this;
-	if(!players[0] && !players[1] && observers.size() == 0)
+	if(!players[0] && !players[1] && observers.size() == 0) {
 		host_player = dp;
+}
 	STOC_JoinGame scjg;
 	scjg.info = host_info;
 	STOC_TypeChange sctc;
@@ -64,18 +67,20 @@ void SingleDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater)
 	if(!players[0] || !players[1]) {
 		STOC_HS_PlayerEnter scpe;
 		BufferIO::CopyCharArray(dp->name, scpe.name);
-		if(!players[0])
+		if(!players[0]) {
 			scpe.pos = 0;
-		else
+		} else {
 			scpe.pos = 1;
+}
 		if(players[0]) {
 			NetServer::SendPacketToPlayer(players[0], STOC_HS_PLAYER_ENTER, scpe);
 		}
 		if(players[1]) {
 			NetServer::SendPacketToPlayer(players[1], STOC_HS_PLAYER_ENTER, scpe);
 		}
-		for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+		for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 			NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_ENTER, scpe);
+}
 		if(!players[0]) {
 			players[0] = dp;
 			dp->type = NETPLAYER_TYPE_PLAYER1;
@@ -91,12 +96,15 @@ void SingleDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater)
 		sctc.type |= NETPLAYER_TYPE_OBSERVER;
 		STOC_HS_WatchChange scwc;
 		scwc.watch_count = (unsigned short)observers.size();
-		if(players[0])
+		if(players[0]) {
 			NetServer::SendPacketToPlayer(players[0], STOC_HS_WATCH_CHANGE, scwc);
-		if(players[1])
+}
+		if(players[1]) {
 			NetServer::SendPacketToPlayer(players[1], STOC_HS_WATCH_CHANGE, scwc);
-		for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+		for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 			NetServer::SendPacketToPlayer(*pit, STOC_HS_WATCH_CHANGE, scwc);
+}
 	}
 	NetServer::SendPacketToPlayer(dp, STOC_JOIN_GAME, scjg);
 	NetServer::SendPacketToPlayer(dp, STOC_TYPE_CHANGE, sctc);
@@ -137,12 +145,15 @@ void SingleDuel::LeaveGame(DuelPlayer* dp) {
 		if(duel_stage == DUEL_STAGE_BEGIN) {
 			STOC_HS_WatchChange scwc;
 			scwc.watch_count = (unsigned short)observers.size();
-			if(players[0])
+			if(players[0]) {
 				NetServer::SendPacketToPlayer(players[0], STOC_HS_WATCH_CHANGE, scwc);
-			if(players[1])
+}
+			if(players[1]) {
 				NetServer::SendPacketToPlayer(players[1], STOC_HS_WATCH_CHANGE, scwc);
-			for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+			for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 				NetServer::SendPacketToPlayer(*pit, STOC_HS_WATCH_CHANGE, scwc);
+}
 		}
 		NetServer::DisconnectPlayer(dp);
 	} else {
@@ -151,19 +162,24 @@ void SingleDuel::LeaveGame(DuelPlayer* dp) {
 			players[dp->type] = nullptr;
 			ready[dp->type] = false;
 			scpc.status = (dp->type << 4) | PLAYERCHANGE_LEAVE;
-			if(players[0] && dp->type != 0)
+			if(players[0] && dp->type != 0) {
 				NetServer::SendPacketToPlayer(players[0], STOC_HS_PLAYER_CHANGE, scpc);
-			if(players[1] && dp->type != 1)
+}
+			if(players[1] && dp->type != 1) {
 				NetServer::SendPacketToPlayer(players[1], STOC_HS_PLAYER_CHANGE, scpc);
-			for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+			for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 				NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
+}
 			NetServer::DisconnectPlayer(dp);
 		} else {
 			if(duel_stage == DUEL_STAGE_SIDING) {
-				if(!ready[0])
+				if(!ready[0]) {
 					NetServer::SendPacketToPlayer(players[0], STOC_DUEL_START);
-				if(!ready[1])
+}
+				if(!ready[1]) {
 					NetServer::SendPacketToPlayer(players[1], STOC_DUEL_START);
+}
 			}
 			if(duel_stage != DUEL_STAGE_END) {
 				unsigned char wbuf[3];
@@ -172,23 +188,27 @@ void SingleDuel::LeaveGame(DuelPlayer* dp) {
 				wbuf[2] = 0x4;
 				NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, wbuf, 3);
 				NetServer::ReSendToPlayer(players[1]);
-				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+				for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 					NetServer::ReSendToPlayer(*oit);
+}
 				EndDuel();
 				NetServer::SendPacketToPlayer(players[0], STOC_DUEL_END);
 				NetServer::ReSendToPlayer(players[1]);
-				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+				for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 					NetServer::ReSendToPlayer(*oit);
+}
 			}
 			NetServer::DisconnectPlayer(dp);
 		}
 	}
 }
 void SingleDuel::ToDuelist(DuelPlayer* dp) {
-	if(dp->type != NETPLAYER_TYPE_OBSERVER)
+	if(dp->type != NETPLAYER_TYPE_OBSERVER) {
 		return;
-	if(players[0] && players[1])
+}
+	if(players[0] && players[1]) {
 		return;
+}
 	observers.erase(dp);
 	STOC_HS_PlayerEnter scpe;
 	BufferIO::CopyCharArray(dp->name, scpe.name);
@@ -218,16 +238,20 @@ void SingleDuel::ToDuelist(DuelPlayer* dp) {
 	NetServer::SendPacketToPlayer(dp, STOC_TYPE_CHANGE, sctc);
 }
 void SingleDuel::ToObserver(DuelPlayer* dp) {
-	if(dp->type > 1)
+	if(dp->type > 1) {
 		return;
+}
 	STOC_HS_PlayerChange scpc;
 	scpc.status = (dp->type << 4) | PLAYERCHANGE_OBSERVE;
-	if(players[0])
+	if(players[0]) {
 		NetServer::SendPacketToPlayer(players[0], STOC_HS_PLAYER_CHANGE, scpc);
-	if(players[1])
+}
+	if(players[1]) {
 		NetServer::SendPacketToPlayer(players[1], STOC_HS_PLAYER_CHANGE, scpc);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
+}
 	players[dp->type] = nullptr;
 	ready[dp->type] = false;
 	dp->type = NETPLAYER_TYPE_OBSERVER;
@@ -237,10 +261,12 @@ void SingleDuel::ToObserver(DuelPlayer* dp) {
 	NetServer::SendPacketToPlayer(dp, STOC_TYPE_CHANGE, sctc);
 }
 void SingleDuel::PlayerReady(DuelPlayer* dp, bool is_ready) {
-	if(dp->type > 1)
+	if(dp->type > 1) {
 		return;
-	if(ready[dp->type] == is_ready)
+}
+	if(ready[dp->type] == is_ready) {
 		return;
+}
 	if(is_ready) {
 		unsigned int deckerror = 0;
 		if(!host_info.no_check_deck) {
@@ -265,30 +291,36 @@ void SingleDuel::PlayerReady(DuelPlayer* dp, bool is_ready) {
 	STOC_HS_PlayerChange scpc;
 	scpc.status = (dp->type << 4) | (is_ready ? PLAYERCHANGE_READY : PLAYERCHANGE_NOTREADY);
 	NetServer::SendPacketToPlayer(players[dp->type], STOC_HS_PLAYER_CHANGE, scpc);
-	if(players[1 - dp->type])
+	if(players[1 - dp->type]) {
 		NetServer::SendPacketToPlayer(players[1 - dp->type], STOC_HS_PLAYER_CHANGE, scpc);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
 }
+}
 void SingleDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
-	if(pos > 1 || dp != host_player || dp == players[pos] || !players[pos])
+	if(pos > 1 || dp != host_player || dp == players[pos] || !players[pos]) {
 		return;
+}
 	LeaveGame(players[pos]);
 }
 void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
-	if(dp->type > 1 || ready[dp->type])
+	if(dp->type > 1 || ready[dp->type]) {
 		return;
-	if (len < 8 || len > sizeof(CTOS_DeckData))
+}
+	if (len < 8 || len > sizeof(CTOS_DeckData)) {
 		return;
+}
 	bool valid = true;
 	CTOS_DeckData deckbuf;
 	std::memcpy(&deckbuf, pdata, len);
-	if (deckbuf.mainc < 0 || deckbuf.mainc > MAINC_MAX)
+	if (deckbuf.mainc < 0 || deckbuf.mainc > MAINC_MAX) {
 		valid = false;
-	else if (deckbuf.sidec < 0 || deckbuf.sidec > SIDEC_MAX)
+	} else if (deckbuf.sidec < 0 || deckbuf.sidec > SIDEC_MAX) {
 		valid = false;
-	else if (len < (2 + deckbuf.mainc + deckbuf.sidec) * (int)sizeof(int32_t))
+	} else if (len < (2 + deckbuf.mainc + deckbuf.sidec) * (int)sizeof(int32_t)) {
 		valid = false;
+}
 	if (!valid) {
 		STOC_ErrorMsg scem;
 		scem.msg = ERRMSG_DECKERROR;
@@ -317,10 +349,12 @@ void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 	}
 }
 void SingleDuel::StartDuel(DuelPlayer* dp) {
-	if(dp != host_player)
+	if(dp != host_player) {
 		return;
-	if(!ready[0] || !ready[1])
+}
+	if(!ready[0] || !ready[1]) {
 		return;
+}
 	NetServer::StopListen();
 	//NetServer::StopBroadcast();
 	NetServer::SendPacketToPlayer(players[0], STOC_DUEL_START);
@@ -352,18 +386,21 @@ void SingleDuel::StartDuel(DuelPlayer* dp) {
 	duel_stage = DUEL_STAGE_FINGER;
 }
 void SingleDuel::HandResult(DuelPlayer* dp, unsigned char res) {
-	if(res > 3)
+	if(res > 3) {
 		return;
-	if(dp->state != CTOS_HAND_RESULT)
+}
+	if(dp->state != CTOS_HAND_RESULT) {
 		return;
+}
 	hand_result[dp->type] = res;
 	if(hand_result[0] && hand_result[1]) {
 		STOC_HandResult schr;
 		schr.res1 = hand_result[0];
 		schr.res2 = hand_result[1];
 		NetServer::SendPacketToPlayer(players[0], STOC_HAND_RESULT, schr);
-		for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+		for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 			NetServer::ReSendToPlayer(*oit);
+}
 		schr.res1 = hand_result[1];
 		schr.res2 = hand_result[0];
 		NetServer::SendPacketToPlayer(players[1], STOC_HAND_RESULT, schr);
@@ -392,8 +429,9 @@ void SingleDuel::HandResult(DuelPlayer* dp, unsigned char res) {
 	}
 }
 void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
-	if(dp->state != CTOS_TP_RESULT)
+	if(dp->state != CTOS_TP_RESULT) {
 		return;
+}
 	duel_stage = DUEL_STAGE_DUELING;
 	bool swapped = false;
 	pplayer[0] = players[0];
@@ -437,8 +475,9 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	set_player_info(pduel, 0, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	set_player_info(pduel, 1, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	unsigned int opt = (unsigned int)host_info.duel_rule << 16;
-	if(host_info.no_shuffle_deck)
+	if(host_info.no_shuffle_deck) {
 		opt |= DUEL_PSEUDO_SHUFFLE;
+}
 	last_replay.WriteInt32(host_info.start_lp, false);
 	last_replay.WriteInt32(host_info.start_hand, false);
 	last_replay.WriteInt32(host_info.draw_count, false);
@@ -470,12 +509,14 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, startbuf, 19);
 	startbuf[1] = 1;
 	NetServer::SendBufferToPlayer(players[1], STOC_GAME_MSG, startbuf, 19);
-	if(!swapped)
+	if(!swapped) {
 		startbuf[1] = 0x10;
-	else
+	} else {
 		startbuf[1] = 0x11;
-	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+}
+	for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 		NetServer::SendBufferToPlayer(*oit, STOC_GAME_MSG, startbuf, 19);
+}
 	RefreshExtra(0);
 	RefreshExtra(1);
 	start_duel(pduel, opt);
@@ -493,40 +534,46 @@ void SingleDuel::Process() {
 	int engLen = 0;
 	int stop = 0;
 	while (!stop) {
-		if (engFlag == PROCESSOR_END)
+		if (engFlag == PROCESSOR_END) {
 			break;
+}
 		unsigned int result = process(pduel);
 		engLen = result & PROCESSOR_BUFFER_LEN;
 		engFlag = result & PROCESSOR_FLAG;
 		if (engLen > 0) {
-			if (engLen > (int)engineBuffer.size())
+			if (engLen > (int)engineBuffer.size()) {
 				engineBuffer.resize(engLen);
+}
 			get_message(pduel, engineBuffer.data());
 			stop = Analyze(engineBuffer.data(), engLen);
 		}
 	}
-	if(stop == 2)
+	if(stop == 2) {
 		DuelEndProc();
+}
 }
 void SingleDuel::DuelEndProc() {
 	if(!match_mode) {
 		NetServer::SendPacketToPlayer(players[0], STOC_DUEL_END);
 		NetServer::ReSendToPlayer(players[1]);
-		for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+		for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 			NetServer::ReSendToPlayer(*oit);
+}
 		duel_stage = DUEL_STAGE_END;
 	} else {
 		int winc[3] = {0, 0, 0};
-		for(int i = 0; i < duel_count; ++i)
+		for(int i = 0; i < duel_count; ++i) {
 			winc[match_result[i]]++;
+}
 		if(match_kill
 		        || (winc[0] == 2 || (winc[0] == 1 && winc[2] == 2))
 		        || (winc[1] == 2 || (winc[1] == 1 && winc[2] == 2))
 		        || (winc[2] == 3 || (winc[0] == 1 && winc[1] == 1 && winc[2] == 1)) ) {
 			NetServer::SendPacketToPlayer(players[0], STOC_DUEL_END);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			duel_stage = DUEL_STAGE_END;
 		} else {
 			if(players[0] != pplayer[0]) {
@@ -544,15 +591,17 @@ void SingleDuel::DuelEndProc() {
 			players[1]->state = CTOS_UPDATE_DECK;
 			NetServer::SendPacketToPlayer(players[0], STOC_CHANGE_SIDE);
 			NetServer::SendPacketToPlayer(players[1], STOC_CHANGE_SIDE);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::SendPacketToPlayer(*oit, STOC_WAITING_SIDE);
+}
 			duel_stage = DUEL_STAGE_SIDING;
 		}
 	}
 }
 void SingleDuel::Surrender(DuelPlayer* dp) {
-	if(dp->type > 1 || !pduel)
+	if(dp->type > 1 || !pduel) {
 		return;
+}
 	unsigned char wbuf[3];
 	uint32_t player = dp->type;
 	wbuf[0] = MSG_WIN;
@@ -560,8 +609,9 @@ void SingleDuel::Surrender(DuelPlayer* dp) {
 	wbuf[2] = 0;
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, wbuf, 3);
 	NetServer::ReSendToPlayer(players[1]);
-	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+	for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 		NetServer::ReSendToPlayer(*oit);
+}
 	if(players[player] == pplayer[player]) {
 		match_result[duel_count++] = 1 - player;
 		tp_player = player;
@@ -605,15 +655,17 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			case 9:
 			case 11: {
 				NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, offset, pbuf - offset);
-				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+				for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 					NetServer::ReSendToPlayer(*oit);
+}
 				break;
 			}
 			case 10: {
 				NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 				NetServer::SendBufferToPlayer(players[1], STOC_GAME_MSG, offset, pbuf - offset);
-				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+				for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 					NetServer::ReSendToPlayer(*oit);
+}
 				break;
 			}
 			}
@@ -624,8 +676,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			type = BufferIO::ReadUInt8(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			if(player > 1) {
 				match_result[duel_count++] = 2;
 				tp_player = 1 - tp_player;
@@ -714,7 +767,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::ReadUInt8(pbuf);
 				/*s = */BufferIO::ReadUInt8(pbuf);
 				/*ss = */BufferIO::ReadUInt8(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) { BufferIO::WriteInt32(pbufw, 0);
+}
 			}
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -732,7 +786,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::ReadUInt8(pbuf);
 				/*s = */BufferIO::ReadUInt8(pbuf);
 				/*ss = */BufferIO::ReadUInt8(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) { BufferIO::WriteInt32(pbufw, 0);
+}
 			}
 			count = BufferIO::ReadUInt8(pbuf);
 			for (int i = 0; i < count; ++i) {
@@ -742,7 +797,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::ReadUInt8(pbuf);
 				/*s = */BufferIO::ReadUInt8(pbuf);
 				/*ss = */BufferIO::ReadUInt8(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) { BufferIO::WriteInt32(pbufw, 0);
+}
 			}
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -806,8 +862,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += count * 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CONFIRM_EXTRATOP: {
@@ -816,8 +873,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += count * 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for (auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CONFIRM_CARDS: {
@@ -827,8 +885,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				pbuf += count * 7;
 				NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 				NetServer::ReSendToPlayer(players[1 - player]);
-				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+				for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 					NetServer::ReSendToPlayer(*oit);
+}
 			} else {
 				pbuf += count * 7;
 				NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -839,19 +898,22 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			player = BufferIO::ReadUInt8(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
 			player = BufferIO::ReadUInt8(pbuf);
 			count = BufferIO::ReadUInt8(pbuf);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
-			for(int i = 0; i < count; ++i)
+			for(int i = 0; i < count; ++i) {
 				BufferIO::WriteInt32(pbuf, 0);
+}
 			NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, offset, pbuf - offset);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshHand(player, 0x781fff, 0);
 			break;
 		}
@@ -859,11 +921,13 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			player = BufferIO::ReadUInt8(pbuf);
 			count = BufferIO::ReadUInt8(pbuf);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
-			for (int i = 0; i < count; ++i)
+			for (int i = 0; i < count; ++i) {
 				BufferIO::WriteInt32(pbuf, 0);
+}
 			NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, offset, pbuf - offset);
-			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for (auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshExtra(player);
 			break;
 		}
@@ -871,32 +935,36 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf++;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SWAP_GRAVE_DECK: {
 			player = BufferIO::ReadUInt8(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshGrave(player);
 			break;
 		}
 		case MSG_REVERSE_DECK: {
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_DECK_TOP: {
 			pbuf += 6;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SHUFFLE_SET_CARD: {
@@ -905,8 +973,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += count * 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			if(loc == LOCATION_MZONE) {
 				RefreshMzone(0, 0x181fff, 0);
 				RefreshMzone(1, 0x181fff, 0);
@@ -929,16 +998,18 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			time_limit[1] = host_info.time_limit;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_NEW_PHASE: {
 			pbuf += 2;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -959,13 +1030,16 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			int cp = pbuf[11];
 			pbuf += 16;
 			NetServer::SendBufferToPlayer(players[cc], STOC_GAME_MSG, offset, pbuf - offset);
-			if (!(cl & (LOCATION_GRAVE + LOCATION_OVERLAY)) && ((cl & (LOCATION_DECK + LOCATION_HAND)) || (cp & POS_FACEDOWN)))
+			if (!(cl & (LOCATION_GRAVE + LOCATION_OVERLAY)) && ((cl & (LOCATION_DECK + LOCATION_HAND)) || (cp & POS_FACEDOWN))) {
 				BufferIO::WriteInt32(pbufw, 0);
+}
 			NetServer::SendBufferToPlayer(players[1 - cc], STOC_GAME_MSG, offset, pbuf - offset);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
-			if (cl != 0 && (cl & LOCATION_OVERLAY) == 0 && (cl != pl || pc != cc))
+}
+			if (cl != 0 && (cl & LOCATION_OVERLAY) == 0 && (cl != pl || pc != cc)) {
 				RefreshSingle(cc, cl, cs);
+}
 			break;
 		}
 		case MSG_POS_CHANGE: {
@@ -977,10 +1051,12 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 9;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
-			if((pp & POS_FACEDOWN) && (cp & POS_FACEUP))
+}
+			if((pp & POS_FACEDOWN) && (cp & POS_FACEUP)) {
 				RefreshSingle(cc, cl, cs);
+}
 			break;
 		}
 		case MSG_SET: {
@@ -988,8 +1064,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 4;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SWAP: {
@@ -1002,8 +1079,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 16;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshSingle(c1, l1, s1);
 			RefreshSingle(c2, l2, s2);
 			break;
@@ -1012,23 +1090,26 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 4;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SUMMONING: {
 			pbuf += 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SUMMONED: {
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1039,15 +1120,17 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SPSUMMONED: {
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1059,15 +1142,17 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_FLIPSUMMONED: {
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1078,16 +1163,18 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 16;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CHAINED: {
 			pbuf++;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1100,16 +1187,18 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf++;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CHAIN_SOLVED: {
 			pbuf++;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1121,8 +1210,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		case MSG_CHAIN_END: {
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1135,16 +1225,18 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf++;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CHAIN_DISABLED: {
 			pbuf++;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CARD_SELECTED: {
@@ -1159,8 +1251,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_BECOME_TARGET: {
@@ -1168,8 +1261,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_DRAW: {
@@ -1179,124 +1273,140 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			for (int i = 0; i < count; ++i) {
-				if(!(pbufw[3] & 0x80))
+				if(!(pbufw[3] & 0x80)) {
 					BufferIO::WriteInt32(pbufw, 0);
-				else
+				} else {
 					pbufw += 4;
+}
 			}
 			NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, offset, pbuf - offset);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_DAMAGE: {
 			pbuf += 5;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_RECOVER: {
 			pbuf += 5;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_EQUIP: {
 			pbuf += 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_LPUPDATE: {
 			pbuf += 5;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_UNEQUIP: {
 			pbuf += 4;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CARD_TARGET: {
 			pbuf += 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CANCEL_TARGET: {
 			pbuf += 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_PAY_LPCOST: {
 			pbuf += 5;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_ADD_COUNTER: {
 			pbuf += 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_REMOVE_COUNTER: {
 			pbuf += 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_ATTACK: {
 			pbuf += 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_BATTLE: {
 			pbuf += 26;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_ATTACK_DISABLED: {
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_DAMAGE_STEP_START: {
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			break;
@@ -1304,8 +1414,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		case MSG_DAMAGE_STEP_END: {
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			break;
@@ -1322,8 +1433,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += count;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_TOSS_DICE: {
@@ -1332,8 +1444,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += count;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_ROCK_PAPER_SCISSORS: {
@@ -1346,8 +1459,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 1;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for (auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_ANNOUNCE_RACE: {
@@ -1377,16 +1491,18 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 9;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_PLAYER_HINT: {
 			pbuf += 6;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_MATCH_KILL: {
@@ -1395,8 +1511,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				match_kill = code;
 				NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 				NetServer::ReSendToPlayer(players[1]);
-				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+				for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 					NetServer::ReSendToPlayer(*oit);
+}
 			}
 			break;
 		}
@@ -1406,24 +1523,27 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 }
 void SingleDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
 	unsigned char resb[SIZE_RETURN_VALUE]{};
-	if (len > SIZE_RETURN_VALUE)
+	if (len > SIZE_RETURN_VALUE) {
 		len = SIZE_RETURN_VALUE;
+}
 	std::memcpy(resb, pdata, len);
 	last_replay.Write<uint8_t>(len);
 	last_replay.WriteData(resb, len);
 	set_responseb(pduel, resb);
 	players[dp->type]->state = 0xff;
 	if(host_info.time_limit) {
-		if(time_limit[dp->type] >= time_elapsed)
+		if(time_limit[dp->type] >= time_elapsed) {
 			time_limit[dp->type] -= time_elapsed;
-		else time_limit[dp->type] = 0;
+		} else { time_limit[dp->type] = 0;
+}
 		time_elapsed = 0;
 	}
 	Process();
 }
 void SingleDuel::EndDuel() {
-	if(!pduel)
+	if(!pduel) {
 		return;
+}
 	last_replay.EndRecord();
 	char replaybuf[0x2000], *pbuf = replaybuf;
 	std::memcpy(pbuf, &last_replay.pheader, sizeof(ReplayHeader));
@@ -1431,8 +1551,9 @@ void SingleDuel::EndDuel() {
 	std::memcpy(pbuf, last_replay.comp_data, last_replay.comp_size);
 	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replaybuf, sizeof(ReplayHeader) + last_replay.comp_size);
 	NetServer::ReSendToPlayer(players[1]);
-	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+	for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 		NetServer::ReSendToPlayer(*oit);
+}
 	end_duel(pduel);
 	event_del(etimer);
 	pduel = 0;
@@ -1448,17 +1569,21 @@ void SingleDuel::WaitforResponse(int playerid) {
 		NetServer::SendPacketToPlayer(players[0], STOC_TIME_LIMIT, sctl);
 		NetServer::SendPacketToPlayer(players[1], STOC_TIME_LIMIT, sctl);
 		players[playerid]->state = CTOS_TIME_CONFIRM;
-	} else
+	} else {
 		players[playerid]->state = CTOS_RESPONSE;
 }
+}
 void SingleDuel::TimeConfirm(DuelPlayer* dp) {
-	if(host_info.time_limit == 0)
+	if(host_info.time_limit == 0) {
 		return;
-	if(dp->type != last_response)
+}
+	if(dp->type != last_response) {
 		return;
+}
 	players[last_response]->state = CTOS_RESPONSE;
-	if(time_elapsed < 10)
+	if(time_elapsed < 10) {
 		time_elapsed = 0;
+}
 }
 inline int SingleDuel::WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
@@ -1478,16 +1603,19 @@ void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 	while(qlen < len) {
 		const int clen = BufferIO::ReadInt32(qbuf);
 		qlen += clen;
-		if (clen <= LEN_HEADER)
+		if (clen <= LEN_HEADER) {
 			continue;
+}
 		auto position = GetPosition(qbuf, 8);
-		if (position & POS_FACEDOWN)
+		if (position & POS_FACEDOWN) {
 			std::memset(qbuf, 0, clen - 4);
+}
 		qbuf += clen - 4;
 	}
 	NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, query_buffer.data(), len + 3);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
+}
 }
 void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
@@ -1499,16 +1627,19 @@ void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 	while(qlen < len) {
 		const int clen = BufferIO::ReadInt32(qbuf);
 		qlen += clen;
-		if (clen <= LEN_HEADER)
+		if (clen <= LEN_HEADER) {
 			continue;
+}
 		auto position = GetPosition(qbuf, 8);
-		if (position & POS_FACEDOWN)
+		if (position & POS_FACEDOWN) {
 			std::memset(qbuf, 0, clen - 4);
+}
 		qbuf += clen - 4;
 	}
 	NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, query_buffer.data(), len + 3);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
+}
 }
 void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
@@ -1520,16 +1651,19 @@ void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
 	while(qlen < len) {
 		const int slen = BufferIO::ReadInt32(qbuf);
 		qlen += slen;
-		if (slen <= LEN_HEADER)
+		if (slen <= LEN_HEADER) {
 			continue;
+}
 		auto position = GetPosition(qbuf, 8);
-		if(!(position & POS_FACEUP))
+		if(!(position & POS_FACEUP)) {
 			std::memset(qbuf, 0, slen - 4);
+}
 		qbuf += slen - 4;
 	}
 	NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, query_buffer.data(), len + 3);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
+}
 }
 void SingleDuel::RefreshGrave(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
@@ -1538,8 +1672,9 @@ void SingleDuel::RefreshGrave(int player, int flag, int use_cache) {
 	auto len = WriteUpdateData(player, LOCATION_GRAVE, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	NetServer::ReSendToPlayer(players[1]);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
+}
 }
 void SingleDuel::RefreshExtra(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
@@ -1558,8 +1693,9 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	BufferIO::WriteInt8(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer, len + 4);
-	if (len <= LEN_HEADER)
+	if (len <= LEN_HEADER) {
 		return;
+}
 	const int clen = BufferIO::ReadInt32(qbuf);
 	auto position = GetPosition(qbuf, 8);
 	if (position & POS_FACEDOWN) {
@@ -1568,12 +1704,14 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 		std::memset(qbuf, 0, clen - 12);
 	}
 	NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, query_buffer, len + 4);
-	for (auto pit = observers.begin(); pit != observers.end(); ++pit)
+	for (auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
 }
+}
 uint32_t SingleDuel::MessageHandler(intptr_t fduel, uint32_t type) {
-	if(!enable_log)
+	if(!enable_log) {
 		return 0;
+}
 	char msgbuf[1024];
 	get_log_message(fduel, msgbuf);
 	mainGame->AddDebugMsg(msgbuf);
@@ -1590,8 +1728,9 @@ void SingleDuel::SingleTimer(evutil_socket_t fd, short events, void* arg) {
 		wbuf[2] = 0x3;
 		NetServer::SendBufferToPlayer(sd->players[0], STOC_GAME_MSG, wbuf, 3);
 		NetServer::ReSendToPlayer(sd->players[1]);
-		for(auto oit = sd->observers.begin(); oit != sd->observers.end(); ++oit)
+		for(auto oit = sd->observers.begin(); oit != sd->observers.end(); ++oit) {
 			NetServer::ReSendToPlayer(*oit);
+}
 		if(sd->players[player] == sd->pplayer[player]) {
 			sd->match_result[sd->duel_count++] = 1 - player;
 			sd->tp_player = player;

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -34,7 +34,7 @@ void SingleDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater)
 		}
 		CTOS_JoinGame packet;
 		std::memcpy(&packet, pdata, sizeof packet);
-		auto pkt = &packet;
+		auto *pkt = &packet;
 		if(pkt->version != PRO_VERSION) {
 			STOC_ErrorMsg scem;
 			scem.msg = ERRMSG_VERERROR;
@@ -330,7 +330,7 @@ void SingleDuel::StartDuel(DuelPlayer* dp) {
 		NetServer::ReSendToPlayer(*oit);
 	}
 	unsigned char deckbuff[12];
-	auto pbuf = deckbuff;
+	auto *pbuf = deckbuff;
 	BufferIO::WriteInt16(pbuf, (short)pdeck[0].main.size());
 	BufferIO::WriteInt16(pbuf, (short)pdeck[0].extra.size());
 	BufferIO::WriteInt16(pbuf, (short)pdeck[0].side.size());
@@ -457,7 +457,7 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	load(pdeck[1].extra, 1, LOCATION_EXTRA);
 	last_replay.Flush();
 	unsigned char startbuf[32]{};
-	auto pbuf = startbuf;
+	auto *pbuf = startbuf;
 	BufferIO::WriteInt8(pbuf, MSG_START);
 	BufferIO::WriteInt8(pbuf, 0);
 	BufferIO::WriteInt8(pbuf, host_info.duel_rule);
@@ -1471,7 +1471,7 @@ inline int SingleDuel::WriteUpdateData(int& player, int location, int& flag, uns
 void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);
-	auto qbuf = query_buffer.data();
+	auto *qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_MZONE, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	int qlen = 0;
@@ -1492,7 +1492,7 @@ void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);
-	auto qbuf = query_buffer.data();
+	auto *qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_SZONE, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	int qlen = 0;
@@ -1513,7 +1513,7 @@ void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);
-	auto qbuf = query_buffer.data();
+	auto *qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_HAND, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	int qlen = 0;
@@ -1534,7 +1534,7 @@ void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
 void SingleDuel::RefreshGrave(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);
-	auto qbuf = query_buffer.data();
+	auto *qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_GRAVE, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	NetServer::ReSendToPlayer(players[1]);
@@ -1544,14 +1544,14 @@ void SingleDuel::RefreshGrave(int player, int flag, int use_cache) {
 void SingleDuel::RefreshExtra(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);
-	auto qbuf = query_buffer.data();
+	auto *qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_EXTRA, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 }
 void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
 	unsigned char query_buffer[0x1000];
-	auto qbuf = query_buffer;
+	auto *qbuf = query_buffer;
 	BufferIO::WriteInt8(qbuf, MSG_UPDATE_CARD);
 	BufferIO::WriteInt8(qbuf, player);
 	BufferIO::WriteInt8(qbuf, location);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -148,7 +148,7 @@ void SingleDuel::LeaveGame(DuelPlayer* dp) {
 	} else {
 		if(duel_stage == DUEL_STAGE_BEGIN) {
 			STOC_HS_PlayerChange scpc;
-			players[dp->type] = 0;
+			players[dp->type] = nullptr;
 			ready[dp->type] = false;
 			scpc.status = (dp->type << 4) | PLAYERCHANGE_LEAVE;
 			if(players[0] && dp->type != 0)
@@ -228,7 +228,7 @@ void SingleDuel::ToObserver(DuelPlayer* dp) {
 		NetServer::SendPacketToPlayer(players[1], STOC_HS_PLAYER_CHANGE, scpc);
 	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
 		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
-	players[dp->type] = 0;
+	players[dp->type] = nullptr;
 	ready[dp->type] = false;
 	dp->type = NETPLAYER_TYPE_OBSERVER;
 	observers.insert(dp);

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -178,8 +178,8 @@ int SingleMode::SinglePlayThread() {
 	return 0;
 }
 bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
-	unsigned char* offset, * pbuf = msg;
-	int player, count;
+	unsigned char* offset = nullptr, * pbuf = msg;
+	int player = 0, count = 0;
 	while (pbuf - msg < (int)len) {
 		if(is_closing || !is_continuing)
 			return false;

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -23,8 +23,9 @@ void SingleMode::StopPlay(bool is_exiting) {
 	mainGame->singleSignal.Set();
 }
 void SingleMode::SetResponse(unsigned char* resp, unsigned int len) {
-	if(!pduel)
+	if(!pduel) {
 		return;
+}
 	last_replay.Write<uint8_t>(len);
 	last_replay.WriteData(resp, len);
 	set_responseb(pduel, resp);
@@ -53,8 +54,9 @@ int SingleMode::SinglePlayThread() {
 	mainGame->dInfo.clientname[0] = 0;
 	mainGame->dInfo.player_type = 0;
 	mainGame->dInfo.turn = 0;
-	if(mainGame->chkSinglePlayReturnDeckTop->isChecked())
+	if(mainGame->chkSinglePlayReturnDeckTop->isChecked()) {
 		opt |= DUEL_RETURN_DECK_TOP;
+}
 	char filename[256]{};
 	int slen = 0;
 	if(open_file) {
@@ -64,16 +66,18 @@ int SingleMode::SinglePlayThread() {
 			wchar_t fname[256]{};
 			myswprintf(fname, L"./single/%ls", open_file_name);
 			slen = BufferIO::EncodeUTF8(fname, filename);
-			if(!preload_script(pduel, filename))
+			if(!preload_script(pduel, filename)) {
 				slen = 0;
+}
 		}
 	} else {
 		const wchar_t* name = mainGame->lstSinglePlayList->getListItem(mainGame->lstSinglePlayList->getSelected());
 		wchar_t fname[256]{};
 		myswprintf(fname, L"./single/%ls", name);
 		slen = BufferIO::EncodeUTF8(fname, filename);
-		if(!preload_script(pduel, filename))
+		if(!preload_script(pduel, filename)) {
 			slen = 0;
+}
 	}
 	if(slen == 0) {
 		end_duel(pduel);
@@ -105,8 +109,9 @@ int SingleMode::SinglePlayThread() {
 	is_closing = false;
 	is_continuing = true;
 	int len = get_message(pduel, engineBuffer.data());
-	if (len > 0)
+	if (len > 0) {
 		is_continuing = SinglePlayAnalyze(engineBuffer.data(), len);
+}
 	last_replay.BeginRecord();
 	last_replay.WriteHeader(rh);
 	uint16_t host_name[20]{};
@@ -127,8 +132,9 @@ int SingleMode::SinglePlayThread() {
 		unsigned int result = process(pduel);
 		len = result & PROCESSOR_BUFFER_LEN;
 		if (len > 0) {
-			if (len > (int)engineBuffer.size())
+			if (len > (int)engineBuffer.size()) {
 				engineBuffer.resize(len);
+}
 			get_message(pduel, engineBuffer.data());
 			is_continuing = SinglePlayAnalyze(engineBuffer.data(), len);
 		}
@@ -154,8 +160,9 @@ int SingleMode::SinglePlayThread() {
 		mainGame->gMutex.unlock();
 		mainGame->WaitFrameSignal(30);
 	}
-	if(mainGame->actionParam)
+	if(mainGame->actionParam) {
 		last_replay.SaveReplay(mainGame->ebRSName->getText());
+}
 	end_duel(pduel);
 	if(!is_closing) {
 		mainGame->gMutex.lock();
@@ -172,8 +179,9 @@ int SingleMode::SinglePlayThread() {
 		mainGame->stTip->setVisible(false);
 		mainGame->device->setEventReceiver(&mainGame->menuHandler);
 		mainGame->gMutex.unlock();
-		if(exit_on_return)
+		if(exit_on_return) {
 			mainGame->device->closeDevice();
+}
 	}
 	return 0;
 }
@@ -181,8 +189,9 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 	unsigned char* offset = nullptr, * pbuf = msg;
 	int player = 0, count = 0;
 	while (pbuf - msg < (int)len) {
-		if(is_closing || !is_continuing)
+		if(is_closing || !is_continuing) {
 			return false;
+}
 		offset = pbuf;
 		mainGame->dInfo.curMsg = BufferIO::ReadUInt8(pbuf);
 		switch (mainGame->dInfo.curMsg) {
@@ -197,8 +206,9 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			/*int type = */BufferIO::ReadUInt8(pbuf);
 			int player = BufferIO::ReadUInt8(pbuf);
 			/*int data = */BufferIO::ReadInt32(pbuf);
-			if(player == 0)
+			if(player == 0) {
 				DuelClient::ClientAnalyze(offset, pbuf - offset);
+}
 			break;
 		}
 		case MSG_WIN: {
@@ -450,8 +460,9 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			/*int cp = pbuf[11];*/
 			pbuf += 16;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
-			if(cl && !(cl & LOCATION_OVERLAY) && (pl != cl || pc != cc))
+			if(cl && !(cl & LOCATION_OVERLAY) && (pl != cl || pc != cc)) {
 				SinglePlayRefreshSingle(cc, cl, cs);
+}
 			break;
 		}
 		case MSG_POS_CHANGE: {
@@ -727,13 +738,15 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 				pbuf += 4;
 				for(int seq = 0; seq < 7; ++seq) {
 					int val = BufferIO::ReadUInt8(pbuf);
-					if(val)
+					if(val) {
 						pbuf += 2;
+}
 				}
 				for(int seq = 0; seq < 8; ++seq) {
 					int val = BufferIO::ReadUInt8(pbuf);
-					if(val)
+					if(val) {
 						pbuf++;
+}
 				}
 				pbuf += 6;
 			}
@@ -834,8 +847,9 @@ void SingleMode::SinglePlayReload() {
 	ReloadLocation(1, LOCATION_REMOVED, flag, queryBuffer);
 }
 uint32_t SingleMode::MessageHandler(intptr_t fduel, uint32_t type) {
-	if(!enable_log)
+	if(!enable_log) {
 		return 0;
+}
 	char msgbuf[1024];
 	get_log_message(fduel, msgbuf);
 	mainGame->AddDebugMsg(msgbuf);

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -750,7 +750,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			char namebuf[128]{};
 			wchar_t wname[20]{};
 			int len = BufferIO::ReadInt16(pbuf);
-			auto begin = pbuf;
+			auto *begin = pbuf;
 			pbuf += len + 1;
 			std::memcpy(namebuf, begin, len + 1);
 			BufferIO::DecodeUTF8(namebuf, wname);
@@ -761,7 +761,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			char msgbuf[1024];
 			wchar_t msg[1024];
 			int len = BufferIO::ReadInt16(pbuf);
-			auto begin = pbuf;
+			auto *begin = pbuf;
 			pbuf += len + 1;
 			std::memcpy(msgbuf, begin, len + 1);
 			BufferIO::DecodeUTF8(msgbuf, msg);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -537,8 +537,8 @@ void TagDuel::Surrender(DuelPlayer* dp) {
 	event_del(etimer);
 }
 int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
-	unsigned char* offset, *pbufw, *pbuf = msgbuffer;
-	int player, count, type;
+	unsigned char* offset = nullptr, *pbufw = nullptr, *pbuf = msgbuffer;
+	int player = 0, count = 0, type = 0;
 	while (pbuf - msgbuffer < (int)len) {
 		offset = pbuf;
 		unsigned char engType = BufferIO::ReadUInt8(pbuf);
@@ -662,7 +662,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			player = BufferIO::ReadUInt8(pbuf);
 			pbuf += 3;
 			count = BufferIO::ReadUInt8(pbuf);
-			int c/*, l, s, ss, code*/;
+			int c = 0/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
@@ -680,7 +680,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			player = BufferIO::ReadUInt8(pbuf);
 			pbuf += 4;
 			count = BufferIO::ReadUInt8(pbuf);
-			int c/*, l, s, ss, code*/;
+			int c = 0/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -19,12 +19,15 @@ TagDuel::~TagDuel() {
 void TagDuel::Chat(DuelPlayer* dp, unsigned char* pdata, int len) {
 	unsigned char scc[SIZE_STOC_CHAT];
 	const auto scc_size = NetServer::CreateChatPacket(pdata, len, scc, dp->type);
-	if (!scc_size)
+	if (!scc_size) {
 		return;
-	for(int i = 0; i < 4; ++i)
+}
+	for(int i = 0; i < 4; ++i) {
 		NetServer::SendBufferToPlayer(players[i], STOC_CHAT, scc, scc_size);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
+}
 }
 void TagDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 	if(!is_creater) {
@@ -59,8 +62,9 @@ void TagDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 		}
 	}
 	dp->game = this;
-	if(!players[0] && !players[1] && !players[2] && !players[3] && observers.size() == 0)
+	if(!players[0] && !players[1] && !players[2] && !players[3] && observers.size() == 0) {
 		host_player = dp;
+}
 	STOC_JoinGame scjg;
 	scjg.info = host_info;
 	STOC_TypeChange sctc;
@@ -68,19 +72,23 @@ void TagDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 	if(!players[0] || !players[1] || !players[2] || !players[3]) {
 		STOC_HS_PlayerEnter scpe;
 		BufferIO::CopyCharArray(dp->name, scpe.name);
-		if(!players[0])
+		if(!players[0]) {
 			scpe.pos = 0;
-		else if(!players[1])
+		} else if(!players[1]) {
 			scpe.pos = 1;
-		else if(!players[2])
+		} else if(!players[2]) {
 			scpe.pos = 2;
-		else
+		} else {
 			scpe.pos = 3;
-		for(int i = 0; i < 4; ++i)
-			if(players[i])
+}
+		for(int i = 0; i < 4; ++i) {
+			if(players[i]) {
 				NetServer::SendPacketToPlayer(players[i], STOC_HS_PLAYER_ENTER, scpe);
-		for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+}
+		for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 			NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_ENTER, scpe);
+}
 		players[scpe.pos] = dp;
 		dp->type = scpe.pos;
 		sctc.type |= scpe.pos;
@@ -90,15 +98,18 @@ void TagDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 		sctc.type |= NETPLAYER_TYPE_OBSERVER;
 		STOC_HS_WatchChange scwc;
 		scwc.watch_count = (unsigned short)observers.size();
-		for(int i = 0; i < 4; ++i)
-			if(players[i])
+		for(int i = 0; i < 4; ++i) {
+			if(players[i]) {
 				NetServer::SendPacketToPlayer(players[i], STOC_HS_WATCH_CHANGE, scwc);
-		for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+}
+		for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 			NetServer::SendPacketToPlayer(*pit, STOC_HS_WATCH_CHANGE, scwc);
+}
 	}
 	NetServer::SendPacketToPlayer(dp, STOC_JOIN_GAME, scjg);
 	NetServer::SendPacketToPlayer(dp, STOC_TYPE_CHANGE, sctc);
-	for(int i = 0; i < 4; ++i)
+	for(int i = 0; i < 4; ++i) {
 		if(players[i]) {
 			STOC_HS_PlayerEnter scpe;
 			BufferIO::CopyCharArray(players[i]->name, scpe.name);
@@ -110,6 +121,7 @@ void TagDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 				NetServer::SendPacketToPlayer(dp, STOC_HS_PLAYER_CHANGE, scpc);
 			}
 		}
+}
 	if(observers.size()) {
 		STOC_HS_WatchChange scwc;
 		scwc.watch_count = (unsigned short)observers.size();
@@ -125,11 +137,14 @@ void TagDuel::LeaveGame(DuelPlayer* dp) {
 		if(duel_stage == DUEL_STAGE_BEGIN) {
 			STOC_HS_WatchChange scwc;
 			scwc.watch_count = (unsigned short)observers.size();
-			for(int i = 0; i < 4; ++i)
-				if(players[i])
+			for(int i = 0; i < 4; ++i) {
+				if(players[i]) {
 					NetServer::SendPacketToPlayer(players[i], STOC_HS_WATCH_CHANGE, scwc);
-			for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+}
+			for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 				NetServer::SendPacketToPlayer(*pit, STOC_HS_WATCH_CHANGE, scwc);
+}
 		}
 		NetServer::DisconnectPlayer(dp);
 	} else {
@@ -138,11 +153,14 @@ void TagDuel::LeaveGame(DuelPlayer* dp) {
 			players[dp->type] = nullptr;
 			ready[dp->type] = false;
 			scpc.status = (dp->type << 4) | PLAYERCHANGE_LEAVE;
-			for(int i = 0; i < 4; ++i)
-				if(players[i])
+			for(int i = 0; i < 4; ++i) {
+				if(players[i]) {
 					NetServer::SendPacketToPlayer(players[i], STOC_HS_PLAYER_CHANGE, scpc);
-			for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+}
+			for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 				NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
+}
 			NetServer::DisconnectPlayer(dp);
 		} else if(duel_stage != DUEL_STAGE_END) {
 			EndDuel();
@@ -152,29 +170,32 @@ void TagDuel::LeaveGame(DuelPlayer* dp) {
 	}
 }
 void TagDuel::ToDuelist(DuelPlayer* dp) {
-	if(players[0] && players[1] && players[2] && players[3])
+	if(players[0] && players[1] && players[2] && players[3]) {
 		return;
+}
 	if(dp->type == NETPLAYER_TYPE_OBSERVER) {
 		observers.erase(dp);
 		STOC_HS_PlayerEnter scpe;
 		BufferIO::CopyCharArray(dp->name, scpe.name);
-		if(!players[0])
+		if(!players[0]) {
 			dp->type = 0;
-		else if(!players[1])
+		} else if(!players[1]) {
 			dp->type = 1;
-		else if(!players[2])
+		} else if(!players[2]) {
 			dp->type = 2;
-		else
+		} else {
 			dp->type = 3;
+}
 		players[dp->type] = dp;
 		scpe.pos = dp->type;
 		STOC_HS_WatchChange scwc;
 		scwc.watch_count = (unsigned short)observers.size();
-		for(int i = 0; i < 4; ++i)
+		for(int i = 0; i < 4; ++i) {
 			if(players[i]) {
 				NetServer::SendPacketToPlayer(players[i], STOC_HS_PLAYER_ENTER, scpe);
 				NetServer::SendPacketToPlayer(players[i], STOC_HS_WATCH_CHANGE, scwc);
 			}
+}
 		for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 			NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_ENTER, scpe);
 			NetServer::SendPacketToPlayer(*pit, STOC_HS_WATCH_CHANGE, scwc);
@@ -183,18 +204,23 @@ void TagDuel::ToDuelist(DuelPlayer* dp) {
 		sctc.type = (dp == host_player ? 0x10 : 0) | dp->type;
 		NetServer::SendPacketToPlayer(dp, STOC_TYPE_CHANGE, sctc);
 	} else {
-		if(ready[dp->type])
+		if(ready[dp->type]) {
 			return;
+}
 		unsigned char dptype = (dp->type + 1) % 4;
-		while(players[dptype])
+		while(players[dptype]) {
 			dptype = (dptype + 1) % 4;
+}
 		STOC_HS_PlayerChange scpc;
 		scpc.status = (dp->type << 4) | dptype;
-		for(int i = 0; i < 4; ++i)
-			if(players[i])
+		for(int i = 0; i < 4; ++i) {
+			if(players[i]) {
 				NetServer::SendPacketToPlayer(players[i], STOC_HS_PLAYER_CHANGE, scpc);
-		for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+}
+		for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 			NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
+}
 		STOC_TypeChange sctc;
 		sctc.type = (dp == host_player ? 0x10 : 0) | dptype;
 		NetServer::SendPacketToPlayer(dp, STOC_TYPE_CHANGE, sctc);
@@ -204,15 +230,19 @@ void TagDuel::ToDuelist(DuelPlayer* dp) {
 	}
 }
 void TagDuel::ToObserver(DuelPlayer* dp) {
-	if(dp->type > 3)
+	if(dp->type > 3) {
 		return;
+}
 	STOC_HS_PlayerChange scpc;
 	scpc.status = (dp->type << 4) | PLAYERCHANGE_OBSERVE;
-	for(int i = 0; i < 4; ++i)
-		if(players[i])
+	for(int i = 0; i < 4; ++i) {
+		if(players[i]) {
 			NetServer::SendPacketToPlayer(players[i], STOC_HS_PLAYER_CHANGE, scpc);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+}
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
+}
 	players[dp->type] = nullptr;
 	ready[dp->type] = false;
 	dp->type = NETPLAYER_TYPE_OBSERVER;
@@ -222,8 +252,9 @@ void TagDuel::ToObserver(DuelPlayer* dp) {
 	NetServer::SendPacketToPlayer(dp, STOC_TYPE_CHANGE, sctc);
 }
 void TagDuel::PlayerReady(DuelPlayer* dp, bool is_ready) {
-	if(dp->type > 3 || ready[dp->type] == is_ready)
+	if(dp->type > 3 || ready[dp->type] == is_ready) {
 		return;
+}
 	if(is_ready) {
 		unsigned int deckerror = 0;
 		if(!host_info.no_check_deck) {
@@ -247,31 +278,38 @@ void TagDuel::PlayerReady(DuelPlayer* dp, bool is_ready) {
 	ready[dp->type] = is_ready;
 	STOC_HS_PlayerChange scpc;
 	scpc.status = (dp->type << 4) | (is_ready ? PLAYERCHANGE_READY : PLAYERCHANGE_NOTREADY);
-	for(int i = 0; i < 4; ++i)
-		if(players[i])
+	for(int i = 0; i < 4; ++i) {
+		if(players[i]) {
 			NetServer::SendPacketToPlayer(players[i], STOC_HS_PLAYER_CHANGE, scpc);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+}
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
 }
+}
 void TagDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
-	if(pos > 3 || dp != host_player || dp == players[pos] || !players[pos])
+	if(pos > 3 || dp != host_player || dp == players[pos] || !players[pos]) {
 		return;
+}
 	LeaveGame(players[pos]);
 }
 void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
-	if(dp->type > 3 || ready[dp->type])
+	if(dp->type > 3 || ready[dp->type]) {
 		return;
-	if (len < 8 || len > sizeof(CTOS_DeckData))
+}
+	if (len < 8 || len > sizeof(CTOS_DeckData)) {
 		return;
+}
 	bool valid = true;
 	CTOS_DeckData deckbuf;
 	std::memcpy(&deckbuf, pdata, len);
-	if (deckbuf.mainc < 0 || deckbuf.mainc > MAINC_MAX)
+	if (deckbuf.mainc < 0 || deckbuf.mainc > MAINC_MAX) {
 		valid = false;
-	else if (deckbuf.sidec < 0 || deckbuf.sidec > SIDEC_MAX)
+	} else if (deckbuf.sidec < 0 || deckbuf.sidec > SIDEC_MAX) {
 		valid = false;
-	else if (len < (2 + deckbuf.mainc + deckbuf.sidec) * (int)sizeof(int32_t))
+	} else if (len < (2 + deckbuf.mainc + deckbuf.sidec) * (int)sizeof(int32_t)) {
 		valid = false;
+}
 	if (!valid) {
 		STOC_ErrorMsg scem;
 		scem.msg = ERRMSG_DECKERROR;
@@ -282,14 +320,17 @@ void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 	deck_error[dp->type] = deckManager.LoadDeck(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec);
 }
 void TagDuel::StartDuel(DuelPlayer* dp) {
-	if(dp != host_player)
+	if(dp != host_player) {
 		return;
-	if(!ready[0] || !ready[1] || !ready[2] || !ready[3])
+}
+	if(!ready[0] || !ready[1] || !ready[2] || !ready[3]) {
 		return;
+}
 	NetServer::StopListen();
 	//NetServer::StopBroadcast();
-	for(int i = 0; i < 4; ++i)
+	for(int i = 0; i < 4; ++i) {
 		NetServer::SendPacketToPlayer(players[i], STOC_DUEL_START);
+}
 	for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 		(*oit)->state = CTOS_LEAVE_GAME;
 		NetServer::ReSendToPlayer(*oit);
@@ -319,20 +360,23 @@ void TagDuel::StartDuel(DuelPlayer* dp) {
 	duel_stage = DUEL_STAGE_FINGER;
 }
 void TagDuel::HandResult(DuelPlayer* dp, unsigned char res) {
-	if(res > 3 || dp->state != CTOS_HAND_RESULT)
+	if(res > 3 || dp->state != CTOS_HAND_RESULT) {
 		return;
-	if(dp->type == 0)
+}
+	if(dp->type == 0) {
 		hand_result[0] = res;
-	else
+	} else {
 		hand_result[1] = res;
+}
 	if(hand_result[0] && hand_result[1]) {
 		STOC_HandResult schr;
 		schr.res1 = hand_result[0];
 		schr.res2 = hand_result[1];
 		NetServer::SendPacketToPlayer(players[0], STOC_HAND_RESULT, schr);
 		NetServer::ReSendToPlayer(players[1]);
-		for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+		for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 			NetServer::ReSendToPlayer(*oit);
+}
 		schr.res1 = hand_result[1];
 		schr.res2 = hand_result[0];
 		NetServer::SendPacketToPlayer(players[2], STOC_HAND_RESULT, schr);
@@ -360,8 +404,9 @@ void TagDuel::HandResult(DuelPlayer* dp, unsigned char res) {
 	}
 }
 void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
-	if(dp->state != CTOS_TP_RESULT)
+	if(dp->state != CTOS_TP_RESULT) {
 		return;
+}
 	duel_stage = DUEL_STAGE_DUELING;
 	bool swapped = false;
 	pplayer[0] = players[0];
@@ -414,8 +459,9 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	set_player_info(pduel, 0, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	set_player_info(pduel, 1, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	unsigned int opt = (unsigned int)host_info.duel_rule << 16;
-	if(host_info.no_shuffle_deck)
+	if(host_info.no_shuffle_deck) {
 		opt |= DUEL_PSEUDO_SHUFFLE;
+}
 	opt |= DUEL_TAG_MODE;
 	last_replay.WriteInt32(host_info.start_lp, false);
 	last_replay.WriteInt32(host_info.start_hand, false);
@@ -461,11 +507,13 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	startbuf[1] = 1;
 	NetServer::SendBufferToPlayer(players[2], STOC_GAME_MSG, startbuf, 19);
 	NetServer::ReSendToPlayer(players[3]);
-	if(!swapped)
+	if(!swapped) {
 		startbuf[1] = 0x10;
-	else startbuf[1] = 0x11;
-	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+	} else { startbuf[1] = 0x11;
+}
+	for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 		NetServer::SendBufferToPlayer(*oit, STOC_GAME_MSG, startbuf, 19);
+}
 	RefreshExtra(0);
 	RefreshExtra(1);
 	start_duel(pduel, opt);
@@ -483,36 +531,42 @@ void TagDuel::Process() {
 	int engLen = 0;
 	int stop = 0;
 	while (!stop) {
-		if (engFlag == PROCESSOR_END)
+		if (engFlag == PROCESSOR_END) {
 			break;
+}
 		unsigned int result = process(pduel);
 		engLen = result & PROCESSOR_BUFFER_LEN;
 		engFlag = result & PROCESSOR_FLAG;
 		if (engLen > 0) {
-			if (engLen > (int)engineBuffer.size())
+			if (engLen > (int)engineBuffer.size()) {
 				engineBuffer.resize(engLen);
+}
 			get_message(pduel, engineBuffer.data());
 			stop = Analyze(engineBuffer.data(), engLen);
 		}
 	}
-	if(stop == 2)
+	if(stop == 2) {
 		DuelEndProc();
+}
 }
 void TagDuel::DuelEndProc() {
 	NetServer::SendPacketToPlayer(players[0], STOC_DUEL_END);
 	NetServer::ReSendToPlayer(players[1]);
 	NetServer::ReSendToPlayer(players[2]);
 	NetServer::ReSendToPlayer(players[3]);
-	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+	for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 		NetServer::ReSendToPlayer(*oit);
+}
 	duel_stage = DUEL_STAGE_END;
 }
 void TagDuel::Surrender(DuelPlayer* dp) {
-	if(dp->type > 3 || !pduel)
+	if(dp->type > 3 || !pduel) {
 		return;
+}
 	uint32_t player = dp->type;
-	if(surrender[player])
+	if(surrender[player]) {
 		return;
+}
 	static const uint32_t teammatemap[] = { 1, 0, 3, 2 };
 	uint32_t teammate = teammatemap[player];
 	if(!surrender[teammate]) {
@@ -530,8 +584,9 @@ void TagDuel::Surrender(DuelPlayer* dp) {
 	NetServer::ReSendToPlayer(players[1]);
 	NetServer::ReSendToPlayer(players[2]);
 	NetServer::ReSendToPlayer(players[3]);
-	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+	for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 		NetServer::ReSendToPlayer(*oit);
+}
 	EndDuel();
 	DuelEndProc();
 	event_del(etimer);
@@ -566,18 +621,23 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			case 8:
 			case 9:
 			case 11: {
-				for(int i = 0; i < 4; ++i)
-					if(players[i] != cur_player[player])
+				for(int i = 0; i < 4; ++i) {
+					if(players[i] != cur_player[player]) {
 						NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
-				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+}
+}
+				for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 					NetServer::ReSendToPlayer(*oit);
+}
 				break;
 			}
 			case 10: {
-				for(int i = 0; i < 4; ++i)
+				for(int i = 0; i < 4; ++i) {
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
-				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+}
+				for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 					NetServer::ReSendToPlayer(*oit);
+}
 				break;
 			}
 			}
@@ -590,8 +650,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			EndDuel();
 			return 2;
 		}
@@ -670,7 +731,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::ReadUInt8(pbuf);
 				/*s = */BufferIO::ReadUInt8(pbuf);
 				/*ss = */BufferIO::ReadUInt8(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) { BufferIO::WriteInt32(pbufw, 0);
+}
 			}
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -688,7 +750,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::ReadUInt8(pbuf);
 				/*s = */BufferIO::ReadUInt8(pbuf);
 				/*ss = */BufferIO::ReadUInt8(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) { BufferIO::WriteInt32(pbufw, 0);
+}
 			}
 			count = BufferIO::ReadUInt8(pbuf);
 			for (int i = 0; i < count; ++i) {
@@ -698,7 +761,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::ReadUInt8(pbuf);
 				/*s = */BufferIO::ReadUInt8(pbuf);
 				/*ss = */BufferIO::ReadUInt8(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) { BufferIO::WriteInt32(pbufw, 0);
+}
 			}
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -764,8 +828,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CONFIRM_EXTRATOP: {
@@ -776,8 +841,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for (auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CONFIRM_CARDS: {
@@ -789,8 +855,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				NetServer::ReSendToPlayer(players[1]);
 				NetServer::ReSendToPlayer(players[2]);
 				NetServer::ReSendToPlayer(players[3]);
-				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+				for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 					NetServer::ReSendToPlayer(*oit);
+}
 			} else {
 				pbuf += count * 7;
 				NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -803,21 +870,26 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
 			player = BufferIO::ReadUInt8(pbuf);
 			count = BufferIO::ReadUInt8(pbuf);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
-			for(int i = 0; i < count; ++i)
+			for(int i = 0; i < count; ++i) {
 				BufferIO::WriteInt32(pbuf, 0);
-			for(int i = 0; i < 4; ++i)
-				if(players[i] != cur_player[player])
+}
+			for(int i = 0; i < 4; ++i) {
+				if(players[i] != cur_player[player]) {
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+}
+}
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshHand(player, 0x781fff, 0);
 			break;
 		}
@@ -825,13 +897,17 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			player = BufferIO::ReadUInt8(pbuf);
 			count = BufferIO::ReadUInt8(pbuf);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
-			for(int i = 0; i < count; ++i)
+			for(int i = 0; i < count; ++i) {
 				BufferIO::WriteInt32(pbuf, 0);
-			for(int i = 0; i < 4; ++i)
-				if(players[i] != cur_player[player])
+}
+			for(int i = 0; i < 4; ++i) {
+				if(players[i] != cur_player[player]) {
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+}
+}
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshExtra(player);
 			break;
 		}
@@ -841,8 +917,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SWAP_GRAVE_DECK: {
@@ -851,8 +928,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshGrave(player);
 			break;
 		}
@@ -861,8 +939,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_DECK_TOP: {
@@ -871,8 +950,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SHUFFLE_SET_CARD: {
@@ -883,8 +963,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			if(loc == LOCATION_MZONE) {
 				RefreshMzone(0, 0x181fff, 0);
 				RefreshMzone(1, 0x181fff, 0);
@@ -902,19 +983,22 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			if(turn_count > 0) {
 				if(turn_count % 2 == 0) {
-					if(cur_player[0] == players[0])
+					if(cur_player[0] == players[0]) {
 						cur_player[0] = players[1];
-					else
+					} else {
 						cur_player[0] = players[0];
+}
 				} else {
-					if(cur_player[1] == players[2])
+					if(cur_player[1] == players[2]) {
 						cur_player[1] = players[3];
-					else
+					} else {
 						cur_player[1] = players[2];
+}
 				}
 			}
 			turn_count++;
@@ -929,8 +1013,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -951,15 +1036,20 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			int cp = pbuf[11];
 			pbuf += 16;
 			NetServer::SendBufferToPlayer(cur_player[cc], STOC_GAME_MSG, offset, pbuf - offset);
-			if (!(cl & (LOCATION_GRAVE + LOCATION_OVERLAY)) && ((cl & (LOCATION_DECK + LOCATION_HAND)) || (cp & POS_FACEDOWN)))
+			if (!(cl & (LOCATION_GRAVE + LOCATION_OVERLAY)) && ((cl & (LOCATION_DECK + LOCATION_HAND)) || (cp & POS_FACEDOWN))) {
 				BufferIO::WriteInt32(pbufw, 0);
-			for(int i = 0; i < 4; ++i)
-				if(players[i] != cur_player[cc])
+}
+			for(int i = 0; i < 4; ++i) {
+				if(players[i] != cur_player[cc]) {
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+}
+}
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
-			if (cl != 0 && (cl & LOCATION_OVERLAY) == 0 && (cl != pl || pc != cc))
+}
+			if (cl != 0 && (cl & LOCATION_OVERLAY) == 0 && (cl != pl || pc != cc)) {
 				RefreshSingle(cc, cl, cs);
+}
 			break;
 		}
 		case MSG_POS_CHANGE: {
@@ -973,10 +1063,12 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
-			if((pp & POS_FACEDOWN) && (cp & POS_FACEUP))
+}
+			if((pp & POS_FACEDOWN) && (cp & POS_FACEUP)) {
 				RefreshSingle(cc, cl, cs);
+}
 			break;
 		}
 		case MSG_SET: {
@@ -986,8 +1078,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SWAP: {
@@ -1002,8 +1095,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshSingle(c1, l1, s1);
 			RefreshSingle(c2, l2, s2);
 			break;
@@ -1014,8 +1108,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SUMMONING: {
@@ -1024,8 +1119,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SUMMONED: {
@@ -1033,8 +1129,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1047,8 +1144,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_SPSUMMONED: {
@@ -1056,8 +1154,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1071,8 +1170,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_FLIPSUMMONED: {
@@ -1080,8 +1180,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1094,8 +1195,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CHAINED: {
@@ -1104,8 +1206,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1120,8 +1223,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CHAIN_SOLVED: {
@@ -1130,8 +1234,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1145,8 +1250,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			RefreshSzone(0);
@@ -1161,8 +1267,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CHAIN_DISABLED: {
@@ -1171,8 +1278,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CARD_SELECTED: {
@@ -1189,8 +1297,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_BECOME_TARGET: {
@@ -1200,8 +1309,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_DRAW: {
@@ -1211,16 +1321,20 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			for (int i = 0; i < count; ++i) {
-				if(!(pbufw[3] & 0x80))
+				if(!(pbufw[3] & 0x80)) {
 					BufferIO::WriteInt32(pbufw, 0);
-				else
+				} else {
 					pbufw += 4;
+}
 			}
-			for(int i = 0; i < 4; ++i)
-				if(players[i] != cur_player[player])
+			for(int i = 0; i < 4; ++i) {
+				if(players[i] != cur_player[player]) {
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+}
+}
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_DAMAGE: {
@@ -1229,8 +1343,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_RECOVER: {
@@ -1239,8 +1354,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_EQUIP: {
@@ -1249,8 +1365,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_LPUPDATE: {
@@ -1259,8 +1376,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_UNEQUIP: {
@@ -1269,8 +1387,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CARD_TARGET: {
@@ -1279,8 +1398,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_CANCEL_TARGET: {
@@ -1289,8 +1409,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_PAY_LPCOST: {
@@ -1299,8 +1420,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_ADD_COUNTER: {
@@ -1309,8 +1431,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_REMOVE_COUNTER: {
@@ -1319,8 +1442,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_ATTACK: {
@@ -1329,8 +1453,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_BATTLE: {
@@ -1339,8 +1464,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_ATTACK_DISABLED: {
@@ -1348,8 +1474,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_DAMAGE_STEP_START: {
@@ -1357,8 +1484,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			break;
@@ -1368,8 +1496,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshMzone(0);
 			RefreshMzone(1);
 			break;
@@ -1388,8 +1517,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_TOSS_DICE: {
@@ -1400,8 +1530,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_ROCK_PAPER_SCISSORS: {
@@ -1416,8 +1547,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for (auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_ANNOUNCE_RACE: {
@@ -1449,8 +1581,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_PLAYER_HINT: {
@@ -1459,8 +1592,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
 			NetServer::ReSendToPlayer(players[3]);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			break;
 		}
 		case MSG_TAG_SWAP: {
@@ -1473,22 +1607,27 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += hcount * 4 + ecount * 4 + 4;
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			for (int i = 0; i < hcount; ++i) {
-				if(!(pbufw[3] & 0x80))
+				if(!(pbufw[3] & 0x80)) {
 					BufferIO::WriteInt32(pbufw, 0);
-				else
+				} else {
 					pbufw += 4;
+}
 			}
 			for (int i = 0; i < ecount; ++i) {
-				if(!(pbufw[3] & 0x80))
+				if(!(pbufw[3] & 0x80)) {
 					BufferIO::WriteInt32(pbufw, 0);
-				else
+				} else {
 					pbufw += 4;
+}
 			}
-			for(int i = 0; i < 4; ++i)
-				if(players[i] != cur_player[player])
+			for(int i = 0; i < 4; ++i) {
+				if(players[i] != cur_player[player]) {
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
-			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+}
+}
+			for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 				NetServer::ReSendToPlayer(*oit);
+}
 			RefreshExtra(player);
 			RefreshMzone(0, 0x81fff, 0);
 			RefreshMzone(1, 0x81fff, 0);
@@ -1508,8 +1647,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 }
 void TagDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
 	unsigned char resb[SIZE_RETURN_VALUE]{};
-	if (len > SIZE_RETURN_VALUE)
+	if (len > SIZE_RETURN_VALUE) {
 		len = SIZE_RETURN_VALUE;
+}
 	std::memcpy(resb, pdata, len);
 	last_replay.Write<uint8_t>(len);
 	last_replay.WriteData(resb, len);
@@ -1517,16 +1657,18 @@ void TagDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len
 	players[dp->type]->state = 0xff;
 	if(host_info.time_limit) {
 		int resp_type = dp->type < 2 ? 0 : 1;
-		if(time_limit[resp_type] >= time_elapsed)
+		if(time_limit[resp_type] >= time_elapsed) {
 			time_limit[resp_type] -= time_elapsed;
-		else time_limit[resp_type] = 0;
+		} else { time_limit[resp_type] = 0;
+}
 		time_elapsed = 0;
 	}
 	Process();
 }
 void TagDuel::EndDuel() {
-	if(!pduel)
+	if(!pduel) {
 		return;
+}
 	last_replay.EndRecord();
 	char replaybuf[0x2000], *pbuf = replaybuf;
 	std::memcpy(pbuf, &last_replay.pheader, sizeof(ReplayHeader));
@@ -1536,8 +1678,9 @@ void TagDuel::EndDuel() {
 	NetServer::ReSendToPlayer(players[1]);
 	NetServer::ReSendToPlayer(players[2]);
 	NetServer::ReSendToPlayer(players[3]);
-	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
+	for(auto oit = observers.begin(); oit != observers.end(); ++oit) {
 		NetServer::ReSendToPlayer(*oit);
+}
 	end_duel(pduel);
 	event_del(etimer);
 	pduel = 0;
@@ -1545,9 +1688,11 @@ void TagDuel::EndDuel() {
 void TagDuel::WaitforResponse(int playerid) {
 	last_response = playerid;
 	unsigned char msg = MSG_WAITING;
-	for(int i = 0; i < 4; ++i)
-		if(players[i] != cur_player[playerid])
+	for(int i = 0; i < 4; ++i) {
+		if(players[i] != cur_player[playerid]) {
 			NetServer::SendPacketToPlayer(players[i], STOC_GAME_MSG, msg);
+}
+}
 	if(host_info.time_limit) {
 		STOC_TimeLimit sctl;
 		sctl.player = playerid;
@@ -1557,17 +1702,21 @@ void TagDuel::WaitforResponse(int playerid) {
 		NetServer::ReSendToPlayer(players[2]);
 		NetServer::ReSendToPlayer(players[3]);
 		cur_player[playerid]->state = CTOS_TIME_CONFIRM;
-	} else
+	} else {
 		cur_player[playerid]->state = CTOS_RESPONSE;
 }
+}
 void TagDuel::TimeConfirm(DuelPlayer* dp) {
-	if(host_info.time_limit == 0)
+	if(host_info.time_limit == 0) {
 		return;
-	if(dp != cur_player[last_response])
+}
+	if(dp != cur_player[last_response]) {
 		return;
+}
 	cur_player[last_response]->state = CTOS_RESPONSE;
-	if(time_elapsed < 10)
+	if(time_elapsed < 10) {
 		time_elapsed = 0;
+}
 }
 inline int TagDuel::WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
@@ -1589,18 +1738,21 @@ void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 	while(qlen < len) {
 		int clen = BufferIO::ReadInt32(qbuf);
 		qlen += clen;
-		if (clen <= LEN_HEADER)
+		if (clen <= LEN_HEADER) {
 			continue;
+}
 		auto position = GetPosition(qbuf, 8);
-		if (position & POS_FACEDOWN)
+		if (position & POS_FACEDOWN) {
 			std::memset(qbuf, 0, clen - 4);
+}
 		qbuf += clen - 4;
 	}
 	pid = 2 - pid;
 	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	NetServer::ReSendToPlayer(players[pid + 1]);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
+}
 }
 void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
@@ -1614,18 +1766,21 @@ void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 	while(qlen < len) {
 		int clen = BufferIO::ReadInt32(qbuf);
 		qlen += clen;
-		if (clen <= LEN_HEADER)
+		if (clen <= LEN_HEADER) {
 			continue;
+}
 		auto position = GetPosition(qbuf, 8);
-		if (position & POS_FACEDOWN)
+		if (position & POS_FACEDOWN) {
 			std::memset(qbuf, 0, clen - 4);
+}
 		qbuf += clen - 4;
 	}
 	pid = 2 - pid;
 	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	NetServer::ReSendToPlayer(players[pid + 1]);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
+}
 }
 void TagDuel::RefreshHand(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
@@ -1637,18 +1792,23 @@ void TagDuel::RefreshHand(int player, int flag, int use_cache) {
 	while(qlen < len) {
 		int slen = BufferIO::ReadInt32(qbuf);
 		qlen += slen;
-		if (slen <= LEN_HEADER)
+		if (slen <= LEN_HEADER) {
 			continue;
+}
 		auto position = GetPosition(qbuf, 8);
-		if(!(position & POS_FACEUP))
+		if(!(position & POS_FACEUP)) {
 			std::memset(qbuf, 0, slen - 4);
+}
 		qbuf += slen - 4;
 	}
-	for(int i = 0; i < 4; ++i)
-		if(players[i] != cur_player[player])
+	for(int i = 0; i < 4; ++i) {
+		if(players[i] != cur_player[player]) {
 			NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, query_buffer.data(), len + 3);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+}
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
+}
 }
 void TagDuel::RefreshGrave(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
@@ -1659,8 +1819,9 @@ void TagDuel::RefreshGrave(int player, int flag, int use_cache) {
 	NetServer::ReSendToPlayer(players[1]);
 	NetServer::ReSendToPlayer(players[2]);
 	NetServer::ReSendToPlayer(players[3]);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 		NetServer::ReSendToPlayer(*pit);
+}
 }
 void TagDuel::RefreshExtra(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
@@ -1687,27 +1848,33 @@ void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 			pid = 2 - pid;
 			NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);
 			NetServer::ReSendToPlayer(players[pid + 1]);
-			for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+			for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 				NetServer::ReSendToPlayer(*pit);
+}
 		}
 	} else {
 		int pid = (player == 0) ? 0 : 2;
 		NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);
 		NetServer::ReSendToPlayer(players[pid + 1]);
-		if(location == LOCATION_REMOVED && (position & POS_FACEDOWN))
+		if(location == LOCATION_REMOVED && (position & POS_FACEDOWN)) {
 			return;
+}
 		if (location & 0x90) {
-			for(int i = 0; i < 4; ++i)
-				if(players[i] != cur_player[player])
+			for(int i = 0; i < 4; ++i) {
+				if(players[i] != cur_player[player]) {
 					NetServer::ReSendToPlayer(players[i]);
-			for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+}
+}
+			for(auto pit = observers.begin(); pit != observers.end(); ++pit) {
 				NetServer::ReSendToPlayer(*pit);
+}
 		}
 	}
 }
 uint32_t TagDuel::MessageHandler(intptr_t fduel, uint32_t type) {
-	if(!enable_log)
+	if(!enable_log) {
 		return 0;
+}
 	char msgbuf[1024];
 	get_log_message(fduel, msgbuf);
 	mainGame->AddDebugMsg(msgbuf);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -9,7 +9,7 @@ namespace ygo {
 
 TagDuel::TagDuel() {
 	for(int i = 0; i < 4; ++i) {
-		players[i] = 0;
+		players[i] = nullptr;
 		ready[i] = false;
 		surrender[i] = false;
 	}
@@ -135,7 +135,7 @@ void TagDuel::LeaveGame(DuelPlayer* dp) {
 	} else {
 		if(duel_stage == DUEL_STAGE_BEGIN) {
 			STOC_HS_PlayerChange scpc;
-			players[dp->type] = 0;
+			players[dp->type] = nullptr;
 			ready[dp->type] = false;
 			scpc.status = (dp->type << 4) | PLAYERCHANGE_LEAVE;
 			for(int i = 0; i < 4; ++i)
@@ -199,7 +199,7 @@ void TagDuel::ToDuelist(DuelPlayer* dp) {
 		sctc.type = (dp == host_player ? 0x10 : 0) | dptype;
 		NetServer::SendPacketToPlayer(dp, STOC_TYPE_CHANGE, sctc);
 		players[dptype] = dp;
-		players[dp->type] = 0;
+		players[dp->type] = nullptr;
 		dp->type = dptype;
 	}
 }
@@ -213,7 +213,7 @@ void TagDuel::ToObserver(DuelPlayer* dp) {
 			NetServer::SendPacketToPlayer(players[i], STOC_HS_PLAYER_CHANGE, scpc);
 	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
 		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
-	players[dp->type] = 0;
+	players[dp->type] = nullptr;
 	ready[dp->type] = false;
 	dp->type = NETPLAYER_TYPE_OBSERVER;
 	observers.insert(dp);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -38,7 +38,7 @@ void TagDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 		}
 		CTOS_JoinGame packet;
 		std::memcpy(&packet, pdata, sizeof packet);
-		auto pkt = &packet;
+		auto *pkt = &packet;
 		if(pkt->version != PRO_VERSION) {
 			STOC_ErrorMsg scem;
 			scem.msg = ERRMSG_VERERROR;
@@ -295,7 +295,7 @@ void TagDuel::StartDuel(DuelPlayer* dp) {
 		NetServer::ReSendToPlayer(*oit);
 	}
 	unsigned char deckbuff[12];
-	auto pbuf = deckbuff;
+	auto *pbuf = deckbuff;
 	BufferIO::WriteInt16(pbuf, (short)pdeck[0].main.size());
 	BufferIO::WriteInt16(pbuf, (short)pdeck[0].extra.size());
 	BufferIO::WriteInt16(pbuf, (short)pdeck[0].side.size());
@@ -446,7 +446,7 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	load_tag(pdeck[2].extra, 1, LOCATION_EXTRA);
 	last_replay.Flush();
 	unsigned char startbuf[32]{};
-	auto pbuf = startbuf;
+	auto *pbuf = startbuf;
 	BufferIO::WriteInt8(pbuf, MSG_START);
 	BufferIO::WriteInt8(pbuf, 0);
 	BufferIO::WriteInt8(pbuf, host_info.duel_rule);
@@ -1580,7 +1580,7 @@ inline int TagDuel::WriteUpdateData(int& player, int location, int& flag, unsign
 void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);
-	auto qbuf = query_buffer.data();
+	auto *qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_MZONE, flag, qbuf, use_cache);
 	int pid = (player == 0) ? 0 : 2;
 	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer.data(), len + 3);
@@ -1605,7 +1605,7 @@ void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);
-	auto qbuf = query_buffer.data();
+	auto *qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_SZONE, flag, qbuf, use_cache);
 	int pid = (player == 0) ? 0 : 2;
 	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer.data(), len + 3);
@@ -1630,7 +1630,7 @@ void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 void TagDuel::RefreshHand(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);
-	auto qbuf = query_buffer.data();
+	auto *qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_HAND, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	int qlen = 0;
@@ -1653,7 +1653,7 @@ void TagDuel::RefreshHand(int player, int flag, int use_cache) {
 void TagDuel::RefreshGrave(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);
-	auto qbuf = query_buffer.data();
+	auto *qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_GRAVE, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	NetServer::ReSendToPlayer(players[1]);
@@ -1665,14 +1665,14 @@ void TagDuel::RefreshGrave(int player, int flag, int use_cache) {
 void TagDuel::RefreshExtra(int player, int flag, int use_cache) {
 	std::vector<unsigned char> query_buffer;
 	query_buffer.resize(SIZE_QUERY_BUFFER);
-	auto qbuf = query_buffer.data();
+	auto *qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_EXTRA, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 }
 void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
 	unsigned char query_buffer[0x1000];
-	auto qbuf = query_buffer;
+	auto *qbuf = query_buffer;
 	BufferIO::WriteInt8(qbuf, MSG_UPDATE_CARD);
 	BufferIO::WriteInt8(qbuf, player);
 	BufferIO::WriteInt8(qbuf, location);


### PR DESCRIPTION
https://clang.llvm.net.cn/extra/clang-tidy/checks/list.html

这是clang-tidy能做的检查的列表，带yes的可以用--fix进行自动修复。
由于选项过多，我便只拿了4个选项做示范。

没有开对于头文件的检查，若有需求，可以用HeaderFilterRegex开启。

clang-tidy做检查很好用（毕竟clang的本职是编译器），但它提供的修复不一定正确，有时会导致编译不通过。
大部分情况下可信赖。

若是有编译命令数据库，那直接 clang-tidy gframe/*.cpp就行，没有的话类似下面：

~~~
clang-tidy ../lib/lua/*.cpp -header-filter=.* --checks=-*,cppcoreguidelines-init-variables -- ccache cache_dir=./ccache/ clang++ -c -std=gnu++23 -w -ferror-limit=2 -O0 -fpermissive -ftrivial-auto-var-init=zero -I ../lib/lua -D LUA_UCID >> 诊断.txt 2>&1 
~~~