### PR TITLE
fix for latest freetype

### DIFF
--- a/premake/freetype/premake5.lua
+++ b/premake/freetype/premake5.lua
@@ -43,6 +43,10 @@ project "freetype"
             "src/type42/type42.c",
             "src/winfonts/winfnt.c" }
 
+    if os.isfile("src/svg/svg.c") then
+        files { "src/svg/svg.c" }
+    end
+
     filter "system:windows"
         files { "builds/windows/ftsystem.c",
                 "builds/windows/ftdebug.c" }


### PR DESCRIPTION
fix: freetype.lib(ftinit.obj) : error LNK2001: unresolved external symbol _ft_svg_renderer_class 
Or maybe we can use some switch to disable the svg feature of freetypee