### PR TITLE
DeckManager: fix LoadLFListSingle, LoadDeck (std::istringstream)

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -3,6 +3,9 @@
 
 #define _IRR_STATIC_LIB_
 #define IRR_COMPILE_WITH_DX9_DEV_PACK
+
+#include <cerrno>
+
 #ifdef _WIN32
 
 #define NOMINMAX
@@ -22,7 +25,6 @@
 
 #else //_WIN32
 
-#include <errno.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -197,7 +197,7 @@ int DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_pa
 		}
 		if (linebuf[0] < '0' || linebuf[0] > '9')
 			continue;
-		code = std::strtol(linebuf.c_str(), nullptr, 10);
+		code = strtol(linebuf.c_str(), nullptr, 10);
 		if (errno == ERANGE)
 			continue;
 		cardlist[ct++] = code;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -32,7 +32,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 				continue;
 			int code = 0;
 			int count = -1;
-			if (std::sscanf(linebuf, "%9d%[ ]%9d", &code, &count) != 2)
+			if (std::sscanf(linebuf, "%9d%*[ ]%9d", &code, &count) != 2)
 				continue;
 			if (code <= 0 || code > MAX_CARD_ID)
 				continue;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -14,7 +14,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 	char linebuf[256]{};
 	wchar_t strBuffer[256]{};
 	if(fp) {
-		while(std::fgets(linebuf, 256, fp)) {
+		while(std::fgets(linebuf, sizeof linebuf, fp)) {
 			if(linebuf[0] == '#')
 				continue;
 			if(linebuf[0] == '!') {
@@ -28,15 +28,15 @@ void DeckManager::LoadLFListSingle(const char* path) {
 				cur = _lfList.rbegin();
 				continue;
 			}
+			if (cur == _lfList.rend())
+				continue;
 			int code = 0;
 			int count = -1;
-			if (std::sscanf(linebuf, "%d %d", &code, &count) != 2)
+			if (std::sscanf(linebuf, "%9d[ ]%9d", &code, &count) != 2)
 				continue;
 			if (code <= 0 || code > MAX_CARD_ID)
 				continue;
 			if (count < 0 || count > 2)
-				continue;
-			if (cur == _lfList.rend())
 				continue;
 			unsigned int hcode = code;
 			cur->content[code] = count;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -32,7 +32,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 				continue;
 			int code = 0;
 			int count = -1;
-			if (std::sscanf(linebuf, "%9d[ ]%9d", &code, &count) != 2)
+			if (std::sscanf(linebuf, "%9d%[ ]%9d", &code, &count) != 2)
 				continue;
 			if (code <= 0 || code > MAX_CARD_ID)
 				continue;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -197,7 +197,9 @@ int DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_pa
 		}
 		if (linebuf[0] < '0' || linebuf[0] > '9')
 			continue;
-		code = std::stoi(linebuf);
+		code = std::strtol(linebuf.c_str(), nullptr, 10);
+		if (errno == ERANGE)
+			continue;
 		cardlist[ct++] = code;
 		if (is_side)
 			++sidec;


### PR DESCRIPTION
## LoadLFListSingle

C99
7.19.6.2 The fscanf function
10
Except in the case of a % specifier, the input item (or, in the case of a %n directive, the count of input characters) is converted to a type appropriate to the conversion specifier. 
If the input item is not a matching sequence, the execution of the directive fails: this condition is a matching failure. 
Unless assignment suppression was indicated by a *, the result of the conversion is placed in the object pointed to by the first argument following the format argument that has not already received a conversion result. 
If this object does not have an appropriate type, or if the result of the conversion cannot be represented in the object, the behavior is undefined.

If there is a line in `lflist.conf`
```
12345678901234567890 1
```
The behavior is undefined.

Now we only accept
```cpp
std::sscanf(linebuf, "%9d%*[ ]%9d", &code, &count) == 2
```

## LoadDeck (std::istringstream)
https://en.cppreference.com/w/cpp/string/basic_string/stol
Exceptions
- std::invalid_argument if no conversion could be performed.
- std::out_of_range if the converted value would fall out of the range of the result type or if the underlying function (std::strtol or std::strtoll) sets errno to ERANGE. 

`123.ydk`
```
12345678901234567890 
```
The process will terminate when loading `123.ydk`.


Now we use 
```cpp
std::strtol(linebuf.c_str(), nullptr, 10);
```
and check `errno`.


@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust