### PR TITLE
read bit field with sqlite3_column_int64

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -76,7 +76,7 @@ bool DataManager::ReadDB(sqlite3* pDB) {
 		}
 		else if (step != SQLITE_DONE)
 			return Error(pDB, pStmt);
-	} while (step != SQLITE_DONE);
+	} while (step == SQLITE_ROW);
 	sqlite3_finalize(pStmt);
 	return true;
 }

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -13,10 +13,10 @@ DataManager::DataManager() : _datas(32768), _strings(32768) {
 	extra_setcode = { {8512558u, {0x8f, 0x54, 0x59, 0x82, 0x13a}}, };
 }
 bool DataManager::ReadDB(sqlite3* pDB) {
-	sqlite3_stmt* pStmt{};
+	sqlite3_stmt* pStmt = nullptr;
 	const char* sql = "select * from datas,texts where datas.id=texts.id";
 	if (sqlite3_prepare_v2(pDB, sql, -1, &pStmt, 0) != SQLITE_OK)
-		return Error(pDB);
+		return Error(pDB, pStmt);
 	wchar_t strBuffer[4096];
 	int step = 0;
 	do {

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -29,7 +29,7 @@ bool DataManager::ReadDB(sqlite3* pDB) {
 			cd.code = sqlite3_column_int(pStmt, 0);
 			cd.ot = sqlite3_column_int(pStmt, 1);
 			cd.alias = sqlite3_column_int(pStmt, 2);
-			auto setcode = sqlite3_column_int64(pStmt, 3);
+			uint64_t setcode = static_cast<uint64_t>(sqlite3_column_int64(pStmt, 3));
 			if (setcode) {
 				auto it = extra_setcode.find(cd.code);
 				if (it != extra_setcode.end()) {
@@ -42,7 +42,7 @@ bool DataManager::ReadDB(sqlite3* pDB) {
 				else
 					cd.set_setcode(setcode);
 			}
-			cd.type = sqlite3_column_int(pStmt, 4);
+			cd.type = static_cast<decltype(cd.type)>(sqlite3_column_int64(pStmt, 4));
 			cd.attack = sqlite3_column_int(pStmt, 5);
 			cd.defense = sqlite3_column_int(pStmt, 6);
 			if (cd.type & TYPE_LINK) {
@@ -51,13 +51,13 @@ bool DataManager::ReadDB(sqlite3* pDB) {
 			}
 			else
 				cd.link_marker = 0;
-			unsigned int level = sqlite3_column_int(pStmt, 7);
+			uint32_t level = static_cast<uint32_t>(sqlite3_column_int(pStmt, 7));
 			cd.level = level & 0xff;
 			cd.lscale = (level >> 24) & 0xff;
 			cd.rscale = (level >> 16) & 0xff;
-			cd.race = sqlite3_column_int(pStmt, 8);
-			cd.attribute = sqlite3_column_int(pStmt, 9);
-			cd.category = sqlite3_column_int(pStmt, 10);
+			cd.race = static_cast<decltype(cd.race)>(sqlite3_column_int64(pStmt, 8));
+			cd.attribute = static_cast<decltype(cd.attribute)>(sqlite3_column_int64(pStmt, 9));
+			cd.category = static_cast<decltype(cd.category)>(sqlite3_column_int64(pStmt, 10));
 			_datas[cd.code] = cd;
 			if (const char* text = (const char*)sqlite3_column_text(pStmt, 12)) {
 				BufferIO::DecodeUTF8(text, strBuffer);

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -23,9 +23,7 @@ bool DataManager::ReadDB(sqlite3* pDB) {
 		CardDataC cd;
 		CardString cs;
 		step = sqlite3_step(pStmt);
-		if (step == SQLITE_BUSY || step == SQLITE_ERROR || step == SQLITE_MISUSE)
-			return Error(pDB, pStmt);
-		else if (step == SQLITE_ROW) {
+		if (step == SQLITE_ROW) {
 			cd.code = sqlite3_column_int(pStmt, 0);
 			cd.ot = sqlite3_column_int(pStmt, 1);
 			cd.alias = sqlite3_column_int(pStmt, 2);
@@ -76,6 +74,8 @@ bool DataManager::ReadDB(sqlite3* pDB) {
 			}
 			_strings[cd.code] = cs;
 		}
+		else if (step != SQLITE_DONE)
+			return Error(pDB, pStmt);
 	} while (step != SQLITE_DONE);
 	sqlite3_finalize(pStmt);
 	return true;


### PR DESCRIPTION
# read bit field with sqlite3_column_int64
C99
6.3.1.3 Signed and unsigned integers
- When a value with integer type is converted to another integer type other than _Bool, if the value can be represented by the new type, it is unchanged.
 - Otherwise, if the new type is unsigned, the value is converted by repeatedly adding or subtracting one more than the maximum value that can be represented in the new type until the value is in the range of the new type.)
 - Otherwise, the new type is signed and the value cannot be represented in it; either the result is implementation-defined or an implementation-defined signal is raised.

https://www.sqlite.org/c3ref/c_blob.html
Every value in SQLite has one of five fundamental datatypes:
- 64-bit signed integer
- 64-bit IEEE floating point number
- string
- BLOB
- NULL

If we want to store a bit field `type= 0xFF FF FF FF` in cdb file:

Berfore:
```cpp
int64_t type=0xFFFFFFFF;
int result = type; // sqlite3_column_int
```
The result is implementation-defined.
轉成signed type只保證保留數值
如果數值超過int範圍，轉換結果由實作決定

After:
```cpp
int64_t type=0xFFFFFFFF;
uint32_t result = static_cast<uint32_t>(type);
```
Bit fields should be `uint32_t`, and casting to unsigned types will truncated to 4 bytes.
bit field要使用unsigned type
轉換成uint32_t會截斷只保留最低4字節

# handle all error code in v2
https://www.sqlite.org/c3ref/step.html
In the legacy interface, the return value will be either [SQLITE_BUSY](https://www.sqlite.org/rescode.html#busy), [SQLITE_DONE](https://www.sqlite.org/rescode.html#done), [SQLITE_ROW](https://www.sqlite.org/rescode.html#row), [SQLITE_ERROR](https://www.sqlite.org/rescode.html#error), or [SQLITE_MISUSE](https://www.sqlite.org/rescode.html#misuse). 
With the "v2" interface, any of the other [result codes](https://www.sqlite.org/rescode.html) or [extended result codes](https://www.sqlite.org/rescode.html#extrc) might be returned as well.

In V2 interface, there are more result codes than the 5 legacy codes.
We only accept SQLITE_ROW, SQLITE_DONE.
除了舊版的5種以外，V2的sqlite3_step可能傳回更多不同的result code
我們只接受SQLITE_ROW, SQLITE_DONE


# always finalize stmt in ReadDB
https://www.sqlite.org/c3ref/finalize.html
Invoking sqlite3_finalize() on a NULL pointer is a harmless no-op.

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust
