### PR TITLE
replace position2d with vector2d

### DIFF
--- a/gframe/CGUIImageButton.cpp
+++ b/gframe/CGUIImageButton.cpp
@@ -313,8 +313,8 @@ void CGUIImageButton::draw() {
 		return;
 	IGUISkin* skin = Environment->getSkin();
 	video::IVideoDriver* driver = Environment->getVideoDriver();
-	core::position2di center = AbsoluteRect.getCenter();
-	core::position2di pos = center;
+	core::vector2di center = AbsoluteRect.getCenter();
+	core::vector2di pos = center;
 	pos.X -= (s32)(ImageRect.getWidth() * imageScale.X * 0.5f);
 	pos.Y -= (s32)(ImageRect.getHeight() * imageScale.Y * 0.5f);
 	if(Pressed) {

--- a/gframe/CGUIImageButton.cpp
+++ b/gframe/CGUIImageButton.cpp
@@ -15,7 +15,7 @@ namespace irr {
 namespace gui {
 
 void Draw2DImageRotation(video::IVideoDriver* driver, video::ITexture* image, core::rect<s32> sourceRect,
-                         core::position2d<s32> position, core::position2d<s32> rotationPoint, f32 rotation, core::vector2df scale, bool useAlphaChannel, video::SColor color) {
+                         core::vector2d<s32> position, core::vector2d<s32> rotationPoint, f32 rotation, core::vector2df scale, bool useAlphaChannel, video::SColor color) {
 	irr::video::SMaterial material;
 	irr::core::matrix4 oldProjMat = driver->getTransform(irr::video::ETS_PROJECTION);
 	driver->setTransform(irr::video::ETS_PROJECTION, irr::core::matrix4());
@@ -63,7 +63,7 @@ void Draw2DImageRotation(video::IVideoDriver* driver, video::ITexture* image, co
 	driver->setTransform(irr::video::ETS_VIEW, oldViewMat);
 }
 void Draw2DImageQuad(video::IVideoDriver* driver, video::ITexture* image, core::rect<s32> sourceRect,
-                         core::position2d<s32> corner[4], bool useAlphaChannel, video::SColor color) {
+                         core::vector2d<s32> corner[4], bool useAlphaChannel, video::SColor color) {
 	irr::video::SMaterial material;
 	irr::core::matrix4 oldProjMat = driver->getTransform(irr::video::ETS_PROJECTION);
 	driver->setTransform(irr::video::ETS_PROJECTION, irr::core::matrix4());
@@ -255,7 +255,7 @@ bool CGUIImageButton::OnEvent(const SEvent& event)
 		if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN)
 		{
 			if (Environment->hasFocus(this) &&
-				!AbsoluteClippingRect.isPointInside(core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y)))
+				!AbsoluteClippingRect.isPointInside(core::vector2d<s32>(event.MouseInput.X, event.MouseInput.Y)))
 			{
 				Environment->removeFocus(this);
 				return false;
@@ -272,7 +272,7 @@ bool CGUIImageButton::OnEvent(const SEvent& event)
 			{
 				bool wasPressed = Pressed;
 
-				if (!AbsoluteClippingRect.isPointInside(core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y)))
+				if (!AbsoluteClippingRect.isPointInside(core::vector2d<s32>(event.MouseInput.X, event.MouseInput.Y)))
 				{
 					if (!IsPushButton)
 						setPressed(false);
@@ -341,7 +341,7 @@ void CGUIImageButton::setImage(video::ITexture* image)
 
 	Image = image;
 	if(image) {
-		ImageRect = core::rect<s32>(core::position2d<s32>(0, 0), image->getOriginalSize());
+		ImageRect = core::rect<s32>(core::vector2d<s32>(0, 0), image->getOriginalSize());
 		if(isFixedSize)
 			imageScale = core::vector2df((irr::f32)imageSize.Width / image->getSize().Width, (irr::f32)imageSize.Height / image->getSize().Height);
 	}
@@ -413,7 +413,7 @@ void CGUIImageButton::setPressedImage(video::ITexture* image)
 
 	PressedImage = image;
 	if (image)
-		PressedImageRect = core::rect<s32>(core::position2d<s32>(0, 0), image->getOriginalSize());
+		PressedImageRect = core::rect<s32>(core::vector2d<s32>(0, 0), image->getOriginalSize());
 }
 
 

--- a/gframe/CGUIImageButton.h
+++ b/gframe/CGUIImageButton.h
@@ -20,10 +20,10 @@ namespace gui {
 class IGUISpriteBank;
 
 void Draw2DImageRotation(video::IVideoDriver* driver, video::ITexture* image, core::rect<s32> sourceRect,
-                         core::position2d<s32> position, core::position2d<s32> rotationPoint, f32 rotation = 0.0f,
+                         core::vector2d<s32> position, core::vector2d<s32> rotationPoint, f32 rotation = 0.0f,
                          core::vector2df scale = core::vector2df(1.0, 1.0), bool useAlphaChannel = true, video::SColor color = 0xffffffff);
 void Draw2DImageQuad(video::IVideoDriver* driver, video::ITexture* image, core::rect<s32> sourceRect,
-                     core::position2d<s32> corner[4], bool useAlphaChannel = true, video::SColor color = 0xffffffff);
+                     core::vector2d<s32> corner[4], bool useAlphaChannel = true, video::SColor color = 0xffffffff);
 
 class CGUIImageButton : public IGUIButton {
 public:

--- a/gframe/CGUITTFont.cpp
+++ b/gframe/CGUITTFont.cpp
@@ -505,7 +505,7 @@ void CGUITTFont::drawUstring(const core::ustring& utext, const core::rect<s32>&p
 
 	// Set up some variables.
 	core::dimension2d<s32> textDimension;
-	core::position2d<s32> offset = position.UpperLeftCorner;
+	core::vector2d<s32> offset = position.UpperLeftCorner;
 
 	// Determine offset positions.
 	if (hcenter || vcenter) {

--- a/gframe/CGUITTFont.cpp
+++ b/gframe/CGUITTFont.cpp
@@ -561,7 +561,7 @@ void CGUITTFont::drawUstring(const core::ustring& utext, const core::rect<s32>&p
 			// Determine rendering information.
 			SGUITTGlyph& glyph = Glyphs[n - 1];
 			CGUITTGlyphPage* const page = Glyph_Pages[glyph.glyph_page];
-			page->render_positions.push_back(core::position2di(offset.X + offx, offset.Y + offy));
+			page->render_positions.push_back(core::vector2di(offset.X + offx, offset.Y + offy));
 			page->render_source_rects.push_back(glyph.source_rect);
 			Render_Map.set(glyph.glyph_page, page);
 		}
@@ -832,7 +832,7 @@ video::IImage* CGUITTFont::createTextureFromChar(const uchar32_t& ch) {
 	// Copy the image data out of the page texture.
 	core::dimension2du glyph_size(glyph.source_rect.getSize());
 	video::IImage* image = Driver->createImage(format, glyph_size);
-	pageholder->copyTo(image, core::position2di(0, 0), glyph.source_rect);
+	pageholder->copyTo(image, core::vector2di(0, 0), glyph.source_rect);
 
 	tex->unlock();
 	return image;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1224,7 +1224,7 @@ void DeckBuilder::GetHoveredCard() {
 	irr::gui::IGUIElement* root = mainGame->env->getRootGUIElement();
 	if(root->getElementFromPoint(mouse_pos) != root)
 		return;
-	position2di pos = mainGame->ResizeReverse(mouse_pos.X, mouse_pos.Y);
+	irr::core::vector2di pos = mainGame->ResizeReverse(mouse_pos.X, mouse_pos.Y);
 	int x = pos.X;
 	int y = pos.Y;
 	is_lastcard = 0;

--- a/gframe/deck_con.h
+++ b/gframe/deck_con.h
@@ -1,9 +1,9 @@
 #ifndef DECK_CON_H
 #define DECK_CON_H
 
-#include "config.h"
 #include <unordered_map>
 #include <vector>
+#include <irrlicht.h>
 #include "data_manager.h"
 #include "../ocgcore/mtrandom.h"
 
@@ -28,7 +28,7 @@ public:
 	void ChangeCategory(int catesel);
 	void ShowDeckManage();
 	void ShowBigCard(int code, float zoom);
-	void ZoomBigCard(s32 centerx = -1, s32 centery = -1);
+	void ZoomBigCard(irr::s32 centerx = -1, irr::s32 centery = -1);
 	void CloseBigCard();
 
 	bool CardNameContains(const wchar_t *haystack, const wchar_t *needle);
@@ -74,7 +74,7 @@ public:
 	code_pointer draging_pointer;
 	int prev_category{};
 	int prev_deck{};
-	s32 prev_operation{};
+	irr::s32 prev_operation{};
 	int prev_sel{ -1 };
 	bool is_modified{};
 	bool readonly{};

--- a/gframe/deck_con.h
+++ b/gframe/deck_con.h
@@ -56,7 +56,7 @@ public:
 	unsigned int filter_scl{};
 	unsigned int filter_marks{};
 	int filter_lm{};
-	position2di mouse_pos;
+	irr::core::vector2di mouse_pos;
 	int hovered_code{};
 	int hovered_pos{};
 	int hovered_seq{ -1 };

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -896,8 +896,8 @@ void Game::DrawSpec() {
 		}
 		case 100: {
 			if(showcardp < 60) {
-				driver->draw2DImage(imageManager.tHand[(showcardcode >> 16) & 0x3], position2di((615 + 44.5) * xScale - 44.5, (showcarddif + 64) * yScale - 64));
-				driver->draw2DImage(imageManager.tHand[showcardcode & 0x3], position2di((615 + 44.5) * xScale - 44.5, (540 - showcarddif + 64) * yScale - 64));
+				driver->draw2DImage(imageManager.tHand[(showcardcode >> 16) & 0x3], irr::core::vector2di((615 + 44.5) * xScale - 44.5, (showcarddif + 64) * yScale - 64));
+				driver->draw2DImage(imageManager.tHand[showcardcode & 0x3], irr::core::vector2di((615 + 44.5) * xScale - 44.5, (540 - showcarddif + 64) * yScale - 64));
 				float dy = -0.333333f * showcardp + 10;
 				showcardp++;
 				if(showcardp < 30)
@@ -1020,7 +1020,7 @@ void Game::DrawSpec() {
 
 			recti rectloc(x, y - chatRectY - h, x + 2 + w, y - chatRectY);
 			recti msgloc(x, y - chatRectY - h, x - 4, y - chatRectY);
-			recti shadowloc = msgloc + position2di(1, 1);
+			recti shadowloc = msgloc + irr::core::vector2di(1, 1);
 
 			driver->draw2DRectangle(rectloc, 0xa0000000, 0xa0000000, 0xa0000000, 0xa0000000);
 			guiFont->drawUstring(msg, msgloc, 0xff000000, false, false);
@@ -1041,7 +1041,7 @@ void Game::ShowElement(irr::gui::IGUIElement * win, int autoframe) {
 	for(auto fit = fadingList.begin(); fit != fadingList.end(); ++fit)
 		if(win == fit->guiFading && win != wOptions && win != wANNumber) // the size of wOptions is always setted by ClientField::ShowSelectOption before showing it
 			fu.fadingSize = fit->fadingSize;
-	irr::core::position2di center = fu.fadingSize.getCenter();
+	irr::core::vector2di center = fu.fadingSize.getCenter();
 	fu.fadingDiff.X = fu.fadingSize.getWidth() / 10;
 	fu.fadingDiff.Y = (fu.fadingSize.getHeight() - 4) / 10;
 	fu.fadingUL = center;
@@ -1126,7 +1126,7 @@ void Game::WaitFrameSignal(int frame) {
 	signalFrame = (gameConf.quick_animation && frame >= 12) ? 12 : frame;
 	frameSignal.Wait();
 }
-void Game::DrawThumb(code_pointer cp, position2di pos, const std::unordered_map<int,int>* lflist, bool drag) {
+void Game::DrawThumb(code_pointer cp, irr::core::vector2di pos, const std::unordered_map<int,int>* lflist, bool drag) {
 	int code = cp->first;
 	int lcode = cp->second.alias;
 	if(lcode == 0)
@@ -1217,7 +1217,7 @@ void Game::DrawDeckBd() {
 	int padding = scrPackCards->getPos() * lx;
 	for(int i = 0; i < mainsize - padding && i < 7 * lx; ++i) {
 		int j = i + padding;
-		DrawThumb(deckManager.current_deck.main[j], position2di(314 + (i % lx) * dx, 164 + (i / lx) * dy), deckBuilder.filterList);
+		DrawThumb(deckManager.current_deck.main[j], irr::core::vector2di(314 + (i % lx) * dx, 164 + (i / lx) * dy), deckBuilder.filterList);
 		if(deckBuilder.hovered_pos == 1 && deckBuilder.hovered_seq == j)
 			driver->draw2DRectangleOutline(Resize(313 + (i % lx) * dx, 163 + (i / lx) * dy, 359 + (i % lx) * dx, 228 + (i / lx) * dy));
 	}
@@ -1233,7 +1233,7 @@ void Game::DrawDeckBd() {
 			dx = 436.0f / 9;
 		else dx = 436.0f / (deckManager.current_deck.extra.size() - 1);
 		for(size_t i = 0; i < deckManager.current_deck.extra.size(); ++i) {
-			DrawThumb(deckManager.current_deck.extra[i], position2di(314 + i * dx, 466), deckBuilder.filterList);
+			DrawThumb(deckManager.current_deck.extra[i], irr::core::vector2di(314 + i * dx, 466), deckBuilder.filterList);
 			if(deckBuilder.hovered_pos == 2 && deckBuilder.hovered_seq == (int)i)
 				driver->draw2DRectangleOutline(Resize(313 + i * dx, 465, 359 + i * dx, 531));
 		}
@@ -1248,7 +1248,7 @@ void Game::DrawDeckBd() {
 			dx = 436.0f / 9;
 		else dx = 436.0f / (deckManager.current_deck.side.size() - 1);
 		for(size_t i = 0; i < deckManager.current_deck.side.size(); ++i) {
-			DrawThumb(deckManager.current_deck.side[i], position2di(314 + i * dx, 564), deckBuilder.filterList);
+			DrawThumb(deckManager.current_deck.side[i], irr::core::vector2di(314 + i * dx, 564), deckBuilder.filterList);
 			if(deckBuilder.hovered_pos == 3 && deckBuilder.hovered_seq == (int)i)
 				driver->draw2DRectangleOutline(Resize(313 + i * dx, 563, 359 + i * dx, 629));
 		}
@@ -1275,7 +1275,7 @@ void Game::DrawDeckBd() {
 		}
 		if(deckBuilder.hovered_pos == 4 && deckBuilder.hovered_seq == (int)i)
 			driver->draw2DRectangle(0x80000000, Resize(806, 164 + i * 66, 1019, 230 + i * 66));
-		DrawThumb(ptr, position2di(810, 165 + i * 66), deckBuilder.filterList);
+		DrawThumb(ptr, irr::core::vector2di(810, 165 + i * 66), deckBuilder.filterList);
 		const wchar_t* availBuffer = L"";
 		if ((ptr->second.ot & AVAIL_OCGTCG) == AVAIL_OCG)
 			availBuffer = L" [OCG]";
@@ -1325,7 +1325,7 @@ void Game::DrawDeckBd() {
 		}
 	}
 	if(deckBuilder.is_draging) {
-		DrawThumb(deckBuilder.draging_pointer, position2di(deckBuilder.dragx - CARD_THUMB_WIDTH / 2 * mainGame->xScale, deckBuilder.dragy - CARD_THUMB_HEIGHT / 2 * mainGame->yScale), deckBuilder.filterList, true);
+		DrawThumb(deckBuilder.draging_pointer, irr::core::vector2di(deckBuilder.dragx - CARD_THUMB_WIDTH / 2 * mainGame->xScale, deckBuilder.dragy - CARD_THUMB_HEIGHT / 2 * mainGame->yScale), deckBuilder.filterList, true);
 	}
 }
 }

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -874,15 +874,15 @@ void Game::DrawSpec() {
 			float mul = xScale;
 			if(xScale > yScale)
 				mul = yScale;
-			core::position2d<s32> corner[4];
+			irr::core::vector2d<s32> corner[4];
 			float y = sin(showcarddif * 3.1415926f / 180.0f) * CARD_IMG_HEIGHT * mul;
 			s32 winx = midx * xScale + (574 - midx) * mul;
 			s32 winx2 = midx * xScale + (751 - midx) * mul;
 			s32 winy = midy * yScale + (404 - midy) * mul;
-			corner[0] = core::position2d<s32>(winx - (CARD_IMG_HEIGHT * mul - y) * 0.3f, winy - y);
-			corner[1] = core::position2d<s32>(winx2 + (CARD_IMG_HEIGHT * mul - y) * 0.3f, winy - y);
-			corner[2] = core::position2d<s32>(winx, winy);
-			corner[3] = core::position2d<s32>(winx2, winy);
+			corner[0] = irr::core::vector2d<s32>(winx - (CARD_IMG_HEIGHT * mul - y) * 0.3f, winy - y);
+			corner[1] = irr::core::vector2d<s32>(winx2 + (CARD_IMG_HEIGHT * mul - y) * 0.3f, winy - y);
+			corner[2] = irr::core::vector2d<s32>(winx, winy);
+			corner[3] = irr::core::vector2d<s32>(winx2, winy);
 			irr::gui::Draw2DImageQuad(driver, imageManager.GetTexture(showcardcode, true), ResizeFit(0, 0, CARD_IMG_WIDTH, CARD_IMG_HEIGHT), corner);
 			showcardp++;
 			showcarddif += 9;

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -1073,8 +1073,8 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			if(!mainGame->dInfo.isStarted)
 				break;
 			hovered_location = 0;
-			position2di pos = mainGame->ResizeReverse(event.MouseInput.X, event.MouseInput.Y);
-			position2di mousepos(event.MouseInput.X, event.MouseInput.Y);
+			irr::core::vector2di pos = mainGame->ResizeReverse(event.MouseInput.X, event.MouseInput.Y);
+			irr::core::vector2di mousepos(event.MouseInput.X, event.MouseInput.Y);
 			s32 x = pos.X;
 			s32 y = pos.Y;
 			if(x < 300)
@@ -1496,8 +1496,8 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			if(!mainGame->dInfo.isStarted)
 				break;
 			bool should_show_tip = false;
-			position2di pos = mainGame->ResizeReverse(event.MouseInput.X, event.MouseInput.Y);
-			position2di mousepos = position2di(event.MouseInput.X, event.MouseInput.Y);
+			irr::core::vector2di pos = mainGame->ResizeReverse(event.MouseInput.X, event.MouseInput.Y);
+			irr::core::vector2di mousepos = irr::core::vector2di(event.MouseInput.X, event.MouseInput.Y);
 			s32 x = pos.X;
 			s32 y = pos.Y;
 			wchar_t formatBuffer[2048];
@@ -1554,7 +1554,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 				if(mainGame->stTip->isVisible()) {
 					should_show_tip = true;
 					irr::core::recti tpos = mainGame->stTip->getRelativePosition();
-					mainGame->stTip->setRelativePosition(irr::core::position2di(mousepos.X - tpos.getWidth() - 10, mcard ? mousepos.Y - tpos.getHeight() - 10 : y + 10));
+					mainGame->stTip->setRelativePosition(irr::core::vector2di(mousepos.X - tpos.getWidth() - 10, mcard ? mousepos.Y - tpos.getHeight() - 10 : y + 10));
 				}
 			}
 			if(mcard != hovered_card) {
@@ -2078,7 +2078,7 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 void ClientField::GetHoverField(int x, int y) {
 	irr::core::recti sfRect(430, 504, 875, 600);
 	irr::core::recti ofRect(531, 135, 800, 191);
-	irr::core::position2di pos(x, y);
+	irr::core::vector2di pos(x, y);
 	int rule = (mainGame->dInfo.duel_rule >= 4) ? 1 : 0;
 	if(sfRect.isPointInside(pos)) {
 		int hc = hand[0].size();
@@ -2315,22 +2315,22 @@ void ClientField::ShowMenu(int flag, int x, int y) {
 	int offset = mainGame->gameConf.resize_popup_menu ? ((mainGame->yScale >= 0.666) ? 21 * mainGame->yScale : 14) : 21;
 	if(flag & COMMAND_ACTIVATE) {
 		mainGame->btnActivate->setVisible(true);
-		mainGame->btnActivate->setRelativePosition(position2di(1, height));
+		mainGame->btnActivate->setRelativePosition(irr::core::vector2di(1, height));
 		height += offset;
 	} else mainGame->btnActivate->setVisible(false);
 	if(flag & COMMAND_SUMMON) {
 		mainGame->btnSummon->setVisible(true);
-		mainGame->btnSummon->setRelativePosition(position2di(1, height));
+		mainGame->btnSummon->setRelativePosition(irr::core::vector2di(1, height));
 		height += offset;
 	} else mainGame->btnSummon->setVisible(false);
 	if(flag & COMMAND_SPSUMMON) {
 		mainGame->btnSPSummon->setVisible(true);
-		mainGame->btnSPSummon->setRelativePosition(position2di(1, height));
+		mainGame->btnSPSummon->setRelativePosition(irr::core::vector2di(1, height));
 		height += offset;
 	} else mainGame->btnSPSummon->setVisible(false);
 	if(flag & COMMAND_MSET) {
 		mainGame->btnMSet->setVisible(true);
-		mainGame->btnMSet->setRelativePosition(position2di(1, height));
+		mainGame->btnMSet->setRelativePosition(irr::core::vector2di(1, height));
 		height += offset;
 	} else mainGame->btnMSet->setVisible(false);
 	if(flag & COMMAND_SSET) {
@@ -2339,7 +2339,7 @@ void ClientField::ShowMenu(int flag, int x, int y) {
 		else
 			mainGame->btnSSet->setText(dataManager.GetSysString(1159));
 		mainGame->btnSSet->setVisible(true);
-		mainGame->btnSSet->setRelativePosition(position2di(1, height));
+		mainGame->btnSSet->setRelativePosition(irr::core::vector2di(1, height));
 		height += offset;
 	} else mainGame->btnSSet->setVisible(false);
 	if(flag & COMMAND_REPOS) {
@@ -2350,27 +2350,27 @@ void ClientField::ShowMenu(int flag, int x, int y) {
 		else
 			mainGame->btnRepos->setText(dataManager.GetSysString(1156));
 		mainGame->btnRepos->setVisible(true);
-		mainGame->btnRepos->setRelativePosition(position2di(1, height));
+		mainGame->btnRepos->setRelativePosition(irr::core::vector2di(1, height));
 		height += offset;
 	} else mainGame->btnRepos->setVisible(false);
 	if(flag & COMMAND_ATTACK) {
 		mainGame->btnAttack->setVisible(true);
-		mainGame->btnAttack->setRelativePosition(position2di(1, height));
+		mainGame->btnAttack->setRelativePosition(irr::core::vector2di(1, height));
 		height += offset;
 	} else mainGame->btnAttack->setVisible(false);
 	if(flag & COMMAND_LIST) {
 		mainGame->btnShowList->setVisible(true);
-		mainGame->btnShowList->setRelativePosition(position2di(1, height));
+		mainGame->btnShowList->setRelativePosition(irr::core::vector2di(1, height));
 		height += offset;
 	} else mainGame->btnShowList->setVisible(false);
 	if(flag & COMMAND_OPERATION) {
 		mainGame->btnOperation->setVisible(true);
-		mainGame->btnOperation->setRelativePosition(position2di(1, height));
+		mainGame->btnOperation->setRelativePosition(irr::core::vector2di(1, height));
 		height += offset;
 	} else mainGame->btnOperation->setVisible(false);
 	if(flag & COMMAND_RESET) {
 		mainGame->btnReset->setVisible(true);
-		mainGame->btnReset->setRelativePosition(position2di(1, height));
+		mainGame->btnReset->setRelativePosition(irr::core::vector2di(1, height));
 		height += offset;
 	} else mainGame->btnReset->setVisible(false);
 	panel = mainGame->wCmdMenu;

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -88,8 +88,6 @@ bool Game::Initialize() {
 	ignore_chain = false;
 	chain_when_avail = false;
 	is_building = false;
-	menuHandler.prev_operation = 0;
-	menuHandler.prev_sel = -1;
 	deckManager.LoadLFList();
 	driver = device->getVideoDriver();
 	driver->setTextureCreationFlag(irr::video::ETCF_CREATE_MIP_MAPS, false);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -2048,15 +2048,15 @@ recti Game::Resize(s32 x, s32 y, s32 x2, s32 y2, s32 dx, s32 dy, s32 dx2, s32 dy
 	y2 = y2 * yScale + dy2;
 	return recti(x, y, x2, y2);
 }
-position2di Game::Resize(s32 x, s32 y) {
+irr::core::vector2di Game::Resize(s32 x, s32 y) {
 	x = x * xScale;
 	y = y * yScale;
-	return position2di(x, y);
+	return irr::core::vector2di(x, y);
 }
-position2di Game::ResizeReverse(s32 x, s32 y) {
+irr::core::vector2di Game::ResizeReverse(s32 x, s32 y) {
 	x = x / xScale;
 	y = y / yScale;
-	return position2di(x, y);
+	return irr::core::vector2di(x, y);
 }
 recti Game::ResizeWin(s32 x, s32 y, s32 x2, s32 y2) {
 	s32 w = x2 - x;
@@ -2087,7 +2087,7 @@ recti Game::ResizeCardImgWin(s32 x, s32 y, s32 mx, s32 my) {
 recti Game::ResizeCardHint(s32 x, s32 y, s32 x2, s32 y2) {
 	return ResizeCardMid(x, y, x2, y2, (x + x2) * 0.5, (y + y2) * 0.5);
 }
-position2di Game::ResizeCardHint(s32 x, s32 y) {
+irr::core::vector2di Game::ResizeCardHint(s32 x, s32 y) {
 	return ResizeCardMid(x, y, x + CARD_IMG_WIDTH * 0.5, y + CARD_IMG_HEIGHT * 0.5);
 }
 recti Game::ResizeCardMid(s32 x, s32 y, s32 x2, s32 y2, s32 midx, s32 midy) {
@@ -2102,7 +2102,7 @@ recti Game::ResizeCardMid(s32 x, s32 y, s32 x2, s32 y2, s32 midx, s32 midy) {
 	y2 = cy + (y2 - midy) * mul;
 	return recti(x, y, x2, y2);
 }
-position2di Game::ResizeCardMid(s32 x, s32 y, s32 midx, s32 midy) {
+irr::core::vector2di Game::ResizeCardMid(s32 x, s32 y, s32 midx, s32 midy) {
 	float mul = xScale;
 	if(xScale > yScale)
 		mul = yScale;
@@ -2110,7 +2110,7 @@ position2di Game::ResizeCardMid(s32 x, s32 y, s32 midx, s32 midy) {
 	s32 cy = midy * yScale;
 	x = cx + (x - midx) * mul;
 	y = cy + (y - midy) * mul;
-	return position2di(x, y);
+	return irr::core::vector2di(x, y);
 }
 recti Game::ResizeFit(s32 x, s32 y, s32 x2, s32 y2) {
 	float mul = xScale;

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -169,7 +169,7 @@ public:
 	void HideElement(irr::gui::IGUIElement* element, bool set_action = false);
 	void PopupElement(irr::gui::IGUIElement* element, int hideframe = 0);
 	void WaitFrameSignal(int frame);
-	void DrawThumb(code_pointer cp, position2di pos, const std::unordered_map<int,int>* lflist, bool drag = false);
+	void DrawThumb(code_pointer cp, irr::core::vector2di pos, const std::unordered_map<int,int>* lflist, bool drag = false);
 	void DrawDeckBd();
 	void LoadConfig();
 	void SaveConfig();
@@ -205,15 +205,15 @@ public:
 	void ResizeChatInputWindow();
 	recti Resize(s32 x, s32 y, s32 x2, s32 y2);
 	recti Resize(s32 x, s32 y, s32 x2, s32 y2, s32 dx, s32 dy, s32 dx2, s32 dy2);
-	position2di Resize(s32 x, s32 y);
-	position2di ResizeReverse(s32 x, s32 y);
+	irr::core::vector2di Resize(s32 x, s32 y);
+	irr::core::vector2di ResizeReverse(s32 x, s32 y);
 	recti ResizePhaseHint(s32 x, s32 y, s32 x2, s32 y2, s32 width);
 	recti ResizeWin(s32 x, s32 y, s32 x2, s32 y2);
 	recti ResizeCardImgWin(s32 x, s32 y, s32 mx, s32 my);
 	recti ResizeCardHint(s32 x, s32 y, s32 x2, s32 y2);
-	position2di ResizeCardHint(s32 x, s32 y);
+	irr::core::vector2di ResizeCardHint(s32 x, s32 y);
 	recti ResizeCardMid(s32 x, s32 y, s32 x2, s32 y2, s32 midx, s32 midy);
-	position2di ResizeCardMid(s32 x, s32 y, s32 midx, s32 midy);
+	irr::core::vector2di ResizeCardMid(s32 x, s32 y, s32 midx, s32 midy);
 	recti ResizeFit(s32 x, s32 y, s32 x2, s32 y2);
 
 	void SetWindowsIcon();

--- a/gframe/menu_handler.h
+++ b/gframe/menu_handler.h
@@ -1,15 +1,15 @@
 #ifndef MENU_HANDLER_H
 #define MENU_HANDLER_H
 
-#include "config.h"
+#include <irrlicht.h>
 
 namespace ygo {
 
 class MenuHandler: public irr::IEventReceiver {
 public:
 	bool OnEvent(const irr::SEvent& event) override;
-	s32 prev_operation;
-	int prev_sel;
+	irr::s32 prev_operation{ 0 };
+	int prev_sel{ -1 };
 
 };
 


### PR DESCRIPTION
https://irrlicht.sourceforge.io/docu/deprecated.html
https://irrlicht.sourceforge.io/docu/namespaceirr_1_1core.html#a3643c2cc7820dd78cd87e73a46b92145
[Deprecated:](https://irrlicht.sourceforge.io/docu/deprecated.html#_deprecated000026)
position2d is now a synonym for [vector2d](https://irrlicht.sourceforge.io/docu/classirr_1_1core_1_1vector2d.html), but [vector2d](https://irrlicht.sourceforge.io/docu/classirr_1_1core_1_1vector2d.html) should be used directly.