### PR TITLE
add myfopen, fix setlocale

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -72,6 +72,18 @@ inline FILE* mywfopen(const wchar_t* filename, const char* mode) {
 	return fp;
 }
 
+#ifdef _WIN32
+inline FILE* myfopen(const char* filename, const char* mode) {
+	wchar_t wfilename[256]{};
+	BufferIO::DecodeUTF8(filename, wfilename);
+	wchar_t wmode[20]{};
+	BufferIO::CopyCharArray(mode, wmode);
+	return _wfopen(wfilename, wmode);
+}
+#else
+#define myfopen std::fopen
+#endif
+
 #include <irrlicht.h>
 using namespace irr;
 using namespace core;

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -72,7 +72,12 @@ inline FILE* mywfopen(const wchar_t* filename, const char* mode) {
 	return fp;
 }
 
-#ifdef _WIN32
+#if !defined(_WIN32)
+#define myfopen std::fopen
+#elif defined(WDK_NTDDI_VERSION) && (WDK_NTDDI_VERSION >= 0x0A000005) // Redstone 4, Version 1803, Build 17134.
+#define FOPEN_WINDOWS_SUPPORT_UTF8
+#define myfopen std::fopen
+#else
 inline FILE* myfopen(const char* filename, const char* mode) {
 	wchar_t wfilename[256]{};
 	BufferIO::DecodeUTF8(filename, wfilename);
@@ -80,8 +85,6 @@ inline FILE* myfopen(const char* filename, const char* mode) {
 	BufferIO::CopyCharArray(mode, wmode);
 	return _wfopen(wfilename, wmode);
 }
-#else
-#define myfopen std::fopen
 #endif
 
 #include <irrlicht.h>

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -108,7 +108,7 @@ bool DataManager::LoadDB(const wchar_t* wfile) {
 	return ret;
 }
 bool DataManager::LoadStrings(const char* file) {
-	FILE* fp = std::fopen(file, "r");
+	FILE* fp = myfopen(file, "r");
 	if(!fp)
 		return false;
 	char linebuf[TEXT_LINE_SIZE]{};
@@ -431,7 +431,7 @@ unsigned char* DataManager::ReadScriptFromIrrFS(const char* script_name, int* sl
 	return scriptBuffer;
 }
 unsigned char* DataManager::ReadScriptFromFile(const char* script_name, int* slen) {
-	FILE* fp = std::fopen(script_name, "rb");
+	FILE* fp = myfopen(script_name, "rb");
 	if (!fp)
 		return nullptr;
 	size_t len = std::fread(scriptBuffer, 1, sizeof scriptBuffer, fp);

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -10,7 +10,7 @@ DeckManager deckManager;
 
 void DeckManager::LoadLFListSingle(const char* path) {
 	auto cur = _lfList.rend();
-	FILE* fp = std::fopen(path, "r");
+	FILE* fp = myfopen(path, "r");
 	char linebuf[256]{};
 	wchar_t strBuffer[256]{};
 	if(fp) {

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1282,7 +1282,7 @@ void Game::RefreshBot() {
 	if(!gameConf.enable_bot_mode)
 		return;
 	botInfo.clear();
-	FILE* fp = std::fopen("bot.conf", "r");
+	FILE* fp = myfopen("bot.conf", "r");
 	char linebuf[256]{};
 	char strbuf[256]{};
 	if(fp) {
@@ -1335,7 +1335,7 @@ void Game::RefreshBot() {
 	}
 }
 void Game::LoadConfig() {
-	FILE* fp = std::fopen("system.conf", "r");
+	FILE* fp = myfopen("system.conf", "r");
 	if(!fp)
 		return;
 	char linebuf[CONFIG_LINE_SIZE]{};
@@ -1473,7 +1473,7 @@ void Game::LoadConfig() {
 	std::fclose(fp);
 }
 void Game::SaveConfig() {
-	FILE* fp = std::fopen("system.conf", "w");
+	FILE* fp = myfopen("system.conf", "w");
 	std::fprintf(fp, "#config file\n#nickname & gamename should be less than 20 characters\n");
 	char linebuf[CONFIG_LINE_SIZE];
 	std::fprintf(fp, "use_d3d = %d\n", gameConf.use_d3d ? 1 : 0);
@@ -1726,7 +1726,7 @@ void Game::AddDebugMsg(const char* msg) {
 	}
 }
 void Game::ErrorLog(const char* msg) {
-	FILE* fp = std::fopen("error.log", "a");
+	FILE* fp = myfopen("error.log", "a");
 	if(!fp)
 		return;
 	time_t nowtime = std::time(nullptr);

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -23,10 +23,12 @@ void ClickButton(irr::gui::IGUIElement* btn) {
 }
 
 int main(int argc, char* argv[]) {
-#if !defined(_WIN32)
-	std::setlocale(LC_CTYPE, "UTF-8");
-#elif defined(FOPEN_WINDOWS_SUPPORT_UTF8)
-	setlocale(LC_CTYPE, ".UTF8");
+#if defined(FOPEN_WINDOWS_SUPPORT_UTF8)
+	setlocale(LC_CTYPE, ".UTF-8");
+#elif defined(__APPLE__)
+	setlocale(LC_CTYPE, "C.UTF-8");
+#elif !defined(_WIN32)
+	setlocale(LC_CTYPE, "");
 #endif
 #ifdef __APPLE__
 	CFURLRef bundle_url = CFBundleCopyBundleURL(CFBundleGetMainBundle());

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -24,11 +24,11 @@ void ClickButton(irr::gui::IGUIElement* btn) {
 
 int main(int argc, char* argv[]) {
 #if defined(FOPEN_WINDOWS_SUPPORT_UTF8)
-	setlocale(LC_CTYPE, ".UTF-8");
+	std::setlocale(LC_CTYPE, ".UTF-8");
 #elif defined(__APPLE__)
-	setlocale(LC_CTYPE, "C.UTF-8");
+	std::setlocale(LC_CTYPE, "C.UTF-8");
 #elif !defined(_WIN32)
-	setlocale(LC_CTYPE, "");
+	std::setlocale(LC_CTYPE, "");
 #endif
 #ifdef __APPLE__
 	CFURLRef bundle_url = CFBundleCopyBundleURL(CFBundleGetMainBundle());

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -23,8 +23,10 @@ void ClickButton(irr::gui::IGUIElement* btn) {
 }
 
 int main(int argc, char* argv[]) {
-#ifndef _WIN32
+#if !defined(_WIN32)
 	std::setlocale(LC_CTYPE, "UTF-8");
+#elif defined(FOPEN_WINDOWS_SUPPORT_UTF8)
+	setlocale(LC_CTYPE, ".UTF8");
 #endif
 #ifdef __APPLE__
 	CFURLRef bundle_url = CFBundleCopyBundleURL(CFBundleGetMainBundle());

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -24,7 +24,7 @@ void Replay::BeginRecord() {
 #else
 	if(is_recording)
 		std::fclose(fp);
-	fp = std::fopen("./replay/_LastReplay.yrp", "wb");
+	fp = myfopen("./replay/_LastReplay.yrp", "wb");
 	if(!fp)
 		return;
 #endif


### PR DESCRIPTION
`std::fopen` support UTF-8 filename on windows since version 1803 (10.0.17134.0) of the Windows SDK, so we can use that.
In case of some developer using old SDK, a fallback is neccessary.

fix #2711
close #2751
close #2752

-----

For the value of `locale`, I've did some tests:

**Windows:**  
- `""`: doesn't work  
- `UTF-8`: doesn't work  
-  **`.UTF-8`: works (recommended by [official documentation](https://learn.microsoft.com/zh-cn/cpp/c-runtime-library/reference/setlocale-wsetlocale?view=msvc-170#utf-8-support))**  
- `C.UTF-8`: doesn't work  
- `zh_CN.UTF-8`: works  
- `en_US.UTF-8`: works  

**Linux:**  
- **`""`: works (recommended by [official documentation](https://linux.die.net/man/3/setlocale); can be overridden by environment variables; on my system, it resolves to `zh_CN.UTF-8`)** 
- `UTF-8`: doesn't work  
- `.UTF-8`: doesn't work  
- `C.UTF-8`: works  
- `zh_CN.UTF-8`: works  
- `en_US.UTF-8`: doesn't work  

**macOS:**  
- `""`: doesn't work  
- `UTF-8`: works  
- `.UTF-8`: doesn't work  
- **`C.UTF-8`: works (present in the output of `locale -a`)**  
- `zh_CN.UTF-8`: works  
- `en_US.UTF-8`: works  

Although `zh_CN.UTF-8` works, it may not align with multilingual goals.
