### PR TITLE
rename: GetLFListContent -> GetLFList

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -69,7 +69,18 @@ void DeckBuilder::Initialize() {
 	mainGame->btnSideShuffle->setVisible(false);
 	mainGame->btnSideSort->setVisible(false);
 	mainGame->btnSideReload->setVisible(false);
-	filterList = &deckManager._lfList[mainGame->gameConf.use_lflist ? mainGame->gameConf.default_lflist : deckManager._lfList.size() - 1].content;
+	if (mainGame->gameConf.use_lflist) {
+		if (mainGame->gameConf.default_lflist >= 0 && mainGame->gameConf.default_lflist < (int)deckManager._lfList.size()) {
+			filterList = &deckManager._lfList[mainGame->gameConf.default_lflist];
+		}
+		else {
+			mainGame->gameConf.default_lflist = 0;
+			filterList = &deckManager._lfList.front();
+		}
+	}
+	else {
+		filterList = &deckManager._lfList.back();
+	}
 	ClearSearch();
 	rnd.reset((uint_fast32_t)std::time(nullptr));
 	mouse_pos.set(0, 0);
@@ -1480,7 +1491,7 @@ void DeckBuilder::FilterCards() {
 		if(filter_marks && (data.link_marker & filter_marks) != filter_marks)
 			continue;
 		if(filter_lm) {
-			if(filter_lm <= 3 && (!filterList->count(ptr->first) || (*filterList).at(ptr->first) != filter_lm - 1))
+			if(filter_lm <= 3 && (!filterList->content.count(ptr->first) || filterList->content.at(ptr->first) != filter_lm - 1))
 				continue;
 			if(filter_lm == 4 && !(data.ot & AVAIL_OCG))
 				continue;
@@ -1822,8 +1833,8 @@ void DeckBuilder::pop_side(int seq) {
 bool DeckBuilder::check_limit(code_pointer pointer) {
 	unsigned int limitcode = pointer->second.alias ? pointer->second.alias : pointer->first;
 	int limit = 3;
-	auto flit = filterList->find(limitcode);
-	if(flit != filterList->end())
+	auto flit = filterList->content.find(limitcode);
+	if(flit != filterList->content.end())
 		limit = flit->second;
 	for(auto it = deckManager.current_deck.main.begin(); it != deckManager.current_deck.main.end(); ++it) {
 		if((*it)->first == limitcode || (*it)->second.alias == limitcode)

--- a/gframe/deck_con.h
+++ b/gframe/deck_con.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <irrlicht.h>
 #include "data_manager.h"
+#include "deck_manager.h"
 #include "../ocgcore/mtrandom.h"
 
 namespace ygo {
@@ -81,7 +82,7 @@ public:
 	bool showing_pack{};
 	mt19937 rnd;
 
-	const std::unordered_map<int, int>* filterList;
+	const LFList* filterList{};
 	std::vector<code_pointer> results;
 	wchar_t result_string[8]{};
 	std::vector<std::wstring> expansionPacks;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -61,7 +61,7 @@ const wchar_t* DeckManager::GetLFListName(int lfhash) {
 		return lit->listName.c_str();
 	return dataManager.unknown_string;
 }
-const LFList* DeckManager::GetLFListContent(unsigned int lfhash) {
+const LFList* DeckManager::GetLFList(unsigned int lfhash) {
 	auto lit = std::find_if(_lfList.begin(), _lfList.end(), [lfhash](const ygo::LFList& list) {
 		return list.hash == lfhash;
 	});
@@ -87,7 +87,7 @@ unsigned int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 		return (DECKERROR_EXTRACOUNT << 28) | (unsigned)deck.extra.size();
 	if(deck.side.size() > SIDE_MAX_SIZE)
 		return (DECKERROR_SIDECOUNT << 28) | (unsigned)deck.side.size();
-	auto lflist = GetLFListContent(lfhash);
+	auto lflist = GetLFList(lfhash);
 	if (!lflist)
 		return 0;
 	auto& list = lflist->content;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -53,7 +53,7 @@ void DeckManager::LoadLFList() {
 	nolimit.hash = 0;
 	_lfList.push_back(nolimit);
 }
-const wchar_t* DeckManager::GetLFListName(int lfhash) {
+const wchar_t* DeckManager::GetLFListName(unsigned int lfhash) {
 	auto lit = std::find_if(_lfList.begin(), _lfList.end(), [lfhash](const ygo::LFList& list) {
 		return list.hash == lfhash;
 	});

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -61,12 +61,12 @@ const wchar_t* DeckManager::GetLFListName(int lfhash) {
 		return lit->listName.c_str();
 	return dataManager.unknown_string;
 }
-const std::unordered_map<int, int>* DeckManager::GetLFListContent(int lfhash) {
+const LFList* DeckManager::GetLFListContent(unsigned int lfhash) {
 	auto lit = std::find_if(_lfList.begin(), _lfList.end(), [lfhash](const ygo::LFList& list) {
 		return list.hash == lfhash;
 	});
-	if(lit != _lfList.end())
-		return &lit->content;
+	if (lit != _lfList.end())
+		return &(*lit);
 	return nullptr;
 }
 static unsigned int checkAvail(unsigned int ot, unsigned int avail) {
@@ -87,9 +87,10 @@ unsigned int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 		return (DECKERROR_EXTRACOUNT << 28) | (unsigned)deck.extra.size();
 	if(deck.side.size() > SIDE_MAX_SIZE)
 		return (DECKERROR_SIDECOUNT << 28) | (unsigned)deck.side.size();
-	auto list = GetLFListContent(lfhash);
-	if (!list)
+	auto lflist = GetLFListContent(lfhash);
+	if (!lflist)
 		return 0;
+	auto& list = lflist->content;
 	const unsigned int rule_map[6] = { AVAIL_OCG, AVAIL_TCG, AVAIL_SC, AVAIL_CUSTOM, AVAIL_OCGTCG, 0 };
 	unsigned int avail = 0;
 	if (rule >= 0 && rule < (int)(sizeof rule_map / sizeof rule_map[0]))
@@ -105,8 +106,8 @@ unsigned int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 		int dc = ccount[code];
 		if(dc > 3)
 			return (DECKERROR_CARDCOUNT << 28) | cit->first;
-		auto it = list->find(code);
-		if(it != list->end() && dc > it->second)
+		auto it = list.find(code);
+		if(it != list.end() && dc > it->second)
 			return (DECKERROR_LFLIST << 28) | cit->first;
 	}
 	for (auto& cit : deck.extra) {
@@ -120,8 +121,8 @@ unsigned int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 		int dc = ccount[code];
 		if(dc > 3)
 			return (DECKERROR_CARDCOUNT << 28) | cit->first;
-		auto it = list->find(code);
-		if(it != list->end() && dc > it->second)
+		auto it = list.find(code);
+		if(it != list.end() && dc > it->second)
 			return (DECKERROR_LFLIST << 28) | cit->first;
 	}
 	for (auto& cit : deck.side) {
@@ -135,8 +136,8 @@ unsigned int DeckManager::CheckDeck(Deck& deck, int lfhash, int rule) {
 		int dc = ccount[code];
 		if(dc > 3)
 			return (DECKERROR_CARDCOUNT << 28) | cit->first;
-		auto it = list->find(code);
-		if(it != list->end() && dc > it->second)
+		auto it = list.find(code);
+		if(it != list.end() && dc > it->second)
 			return (DECKERROR_LFLIST << 28) | cit->first;
 	}
 	return 0;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -30,17 +30,14 @@ void DeckManager::LoadLFListSingle(const char* path) {
 			}
 			if (cur == _lfList.rend())
 				continue;
-			int code = 0;
+			unsigned int code = 0;
 			int count = -1;
-			if (std::sscanf(linebuf, "%9d%*[ ]%9d", &code, &count) != 2)
-				continue;
-			if (code <= 0 || code > MAX_CARD_ID)
+			if (std::sscanf(linebuf, "%9u%*[ ]%9d", &code, &count) != 2)
 				continue;
 			if (count < 0 || count > 2)
 				continue;
-			unsigned int hcode = code;
 			cur->content[code] = count;
-			cur->hash = cur->hash ^ ((hcode << 18) | (hcode >> 14)) ^ ((hcode << (27 + count)) | (hcode >> (5 - count)));
+			cur->hash = cur->hash ^ ((code << 18) | (code >> 14)) ^ ((code << (27 + count)) | (code >> (5 - count)));
 		}
 		std::fclose(fp);
 	}

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -44,7 +44,7 @@ public:
 
 	void LoadLFListSingle(const char* path);
 	void LoadLFList();
-	const wchar_t* GetLFListName(int lfhash);
+	const wchar_t* GetLFListName(unsigned int lfhash);
 	const LFList* GetLFList(unsigned int lfhash);
 	unsigned int CheckDeck(Deck& deck, int lfhash, int rule);
 	int LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_packlist = false);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -45,7 +45,7 @@ public:
 	void LoadLFListSingle(const char* path);
 	void LoadLFList();
 	const wchar_t* GetLFListName(int lfhash);
-	const LFList* GetLFListContent(unsigned int lfhash);
+	const LFList* GetLFList(unsigned int lfhash);
 	unsigned int CheckDeck(Deck& deck, int lfhash, int rule);
 	int LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_packlist = false);
 	int LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -45,7 +45,7 @@ public:
 	void LoadLFListSingle(const char* path);
 	void LoadLFList();
 	const wchar_t* GetLFListName(int lfhash);
-	const std::unordered_map<int, int>* GetLFListContent(int lfhash);
+	const LFList* GetLFListContent(unsigned int lfhash);
 	unsigned int CheckDeck(Deck& deck, int lfhash, int rule);
 	int LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_packlist = false);
 	int LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -16,7 +16,7 @@ namespace ygo {
 struct LFList {
 	unsigned int hash{};
 	std::wstring listName;
-	std::unordered_map<int, int> content;
+	std::unordered_map<unsigned int, int> content;
 };
 struct Deck {
 	std::vector<code_pointer> main;

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1126,9 +1126,9 @@ void Game::WaitFrameSignal(int frame) {
 	signalFrame = (gameConf.quick_animation && frame >= 12) ? 12 : frame;
 	frameSignal.Wait();
 }
-void Game::DrawThumb(code_pointer cp, irr::core::vector2di pos, const std::unordered_map<int,int>* lflist, bool drag) {
+void Game::DrawThumb(code_pointer cp, irr::core::vector2di pos, const LFList* lflist, bool drag) {
 	int code = cp->first;
-	int lcode = cp->second.alias;
+	auto lcode = cp->second.alias;
 	if(lcode == 0)
 		lcode = code;
 	irr::video::ITexture* img = imageManager.GetTextureThumb(code);
@@ -1144,8 +1144,9 @@ void Game::DrawThumb(code_pointer cp, irr::core::vector2di pos, const std::unord
 		otloc = recti(pos.X + 7, pos.Y + 50 * mainGame->yScale, pos.X + 37 * mainGame->xScale, pos.Y + 65 * mainGame->yScale);
 	}
 	driver->draw2DImage(img, dragloc, rect<s32>(0, 0, size.Width, size.Height));
-	if(lflist->count(lcode)) {
-		switch((*lflist).at(lcode)) {
+	auto lfit = lflist->content.find(lcode);
+	if (lfit != lflist->content.end()) {
+		switch(lfit->second) {
 		case 0:
 			driver->draw2DImage(imageManager.tLim, limitloc, recti(0, 0, 64, 64), 0, 0, true);
 			break;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -502,7 +502,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		mainGame->dInfo.time_left[1] = 0;
 		mainGame->deckBuilder.filterList = deckManager.GetLFListContent(pkt->info.lflist);
 		if(mainGame->deckBuilder.filterList == nullptr)
-			mainGame->deckBuilder.filterList = &deckManager._lfList[0].content;
+			mainGame->deckBuilder.filterList = &deckManager._lfList[0];
 		mainGame->stHostPrepOB->setText(L"");
 		mainGame->SetStaticText(mainGame->stHostPrepRule, 180, mainGame->guiFont, str.c_str());
 		mainGame->RefreshCategoryDeck(mainGame->cbCategorySelect, mainGame->cbDeckSelect);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -500,7 +500,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		mainGame->dInfo.time_limit = pkt->info.time_limit;
 		mainGame->dInfo.time_left[0] = 0;
 		mainGame->dInfo.time_left[1] = 0;
-		mainGame->deckBuilder.filterList = deckManager.GetLFListContent(pkt->info.lflist);
+		mainGame->deckBuilder.filterList = deckManager.GetLFList(pkt->info.lflist);
 		if(mainGame->deckBuilder.filterList == nullptr)
 			mainGame->deckBuilder.filterList = &deckManager._lfList[0];
 		mainGame->stHostPrepOB->setText(L"");

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -1939,7 +1939,7 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 				mainGame->cbLFlist->setEnabled(mainGame->gameConf.use_lflist);
 				mainGame->cbLFlist->setSelected(mainGame->gameConf.use_lflist ? mainGame->gameConf.default_lflist : mainGame->cbLFlist->getItemCount() - 1);
 				mainGame->cbHostLFlist->setSelected(mainGame->gameConf.use_lflist ? mainGame->gameConf.default_lflist : mainGame->cbHostLFlist->getItemCount() - 1);
-				mainGame->deckBuilder.filterList = &deckManager._lfList[mainGame->cbLFlist->getSelected()].content;
+				mainGame->deckBuilder.filterList = &deckManager._lfList[mainGame->cbLFlist->getSelected()];
 				return true;
 				break;
 			}
@@ -1951,7 +1951,7 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 			case COMBOBOX_LFLIST: {
 				mainGame->gameConf.default_lflist = mainGame->cbLFlist->getSelected();
 				mainGame->cbHostLFlist->setSelected(mainGame->gameConf.default_lflist);
-				mainGame->deckBuilder.filterList = &deckManager._lfList[mainGame->gameConf.default_lflist].content;
+				mainGame->deckBuilder.filterList = &deckManager._lfList[mainGame->gameConf.default_lflist];
 				return true;
 				break;
 			}

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -169,7 +169,7 @@ public:
 	void HideElement(irr::gui::IGUIElement* element, bool set_action = false);
 	void PopupElement(irr::gui::IGUIElement* element, int hideframe = 0);
 	void WaitFrameSignal(int frame);
-	void DrawThumb(code_pointer cp, irr::core::vector2di pos, const std::unordered_map<int,int>* lflist, bool drag = false);
+	void DrawThumb(code_pointer cp, irr::core::vector2di pos, const LFList* lflist, bool drag = false);
 	void DrawDeckBd();
 	void LoadConfig();
 	void SaveConfig();


### PR DESCRIPTION
a41adff75e3a703c1291ff0d6fd60688034ef674
DeckBuilder::filterList
It should be a pointer to somewhere in `deckManager._lfList`, not any `unordered_map`.
Fix:
If `mainGame->gameConf.default_lflist` is not a correct index, the process will crash.


----
fded4dea69c9d9b1048cf5aa84bd81f7c1617c20
```cpp
const LFList* GetLFList(unsigned int lfhash);
```
Now the return value is `const LFList*`.
rename: GetLFListContent -> GetLFList


----
37eb11354b001dbbf2a43c1c71aa242d3c90be4e
```cpp
struct LFList {
	unsigned int hash{};
	std::wstring listName;
	std::unordered_map<unsigned int, int> content;
};
```

`card_data::code` is uint32
The key of `LFList::content` should be uint32

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust


