### PR TITLE
Revert "add cdialect, cppdialect"

### DIFF
--- a/gframe/lzma/premake5.lua
+++ b/gframe/lzma/premake5.lua
@@ -1,4 +1,3 @@
 project "clzma"
     kind "StaticLib"
-    cdialect "C11"
     files { "*.c", "*.h" }

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -3,8 +3,6 @@ include "spmemvfs/."
 
 project "YGOPro"
     kind "WindowedApp"
-    cdialect "C11"
-    cppdialect "C++14"
 
     files { "*.cpp", "*.h" }
     includedirs { "../ocgcore" }
@@ -67,7 +65,7 @@ project "YGOPro"
         end
         links { "opengl32", "ws2_32", "winmm", "gdi32", "kernel32", "user32", "imm32" }
     filter "not action:vs*"
-        buildoptions { "-fno-rtti" }
+        buildoptions { "-std=c++14", "-fno-rtti" }
     filter "not system:windows"
         links { "event_pthreads", "dl", "pthread" }
     filter "system:macosx"

--- a/gframe/spmemvfs/premake5.lua
+++ b/gframe/spmemvfs/premake5.lua
@@ -1,6 +1,5 @@
 project "cspmemvfs"
     kind "StaticLib"
-    cdialect "C11"
     files { "*.c", "*.h" }
 
     if BUILD_SQLITE then

--- a/premake/event/premake5.lua
+++ b/premake/event/premake5.lua
@@ -1,6 +1,5 @@
 project "event"
     kind "StaticLib"
-    cdialect "C11"
 
     includedirs { "include", "compat" }
 

--- a/premake/freetype/premake5.lua
+++ b/premake/freetype/premake5.lua
@@ -1,6 +1,5 @@
 project "freetype"
     kind "StaticLib"
-    cdialect "C11"
 
     includedirs { "include" }
     defines { "FT2_BUILD_LIBRARY" }

--- a/premake/irrlicht/premake5.lua
+++ b/premake/irrlicht/premake5.lua
@@ -1,7 +1,5 @@
 project "irrlicht"
     kind "StaticLib"
-    cdialect "C11"
-    cppdialect "C++14"
 
     includedirs { "include", "source/Irrlicht", "source/Irrlicht/jpeglib", "source/Irrlicht/libpng", "source/Irrlicht/zlib" }
     

--- a/premake/lua/premake5.lua
+++ b/premake/lua/premake5.lua
@@ -1,7 +1,5 @@
 project "lua"
     kind "StaticLib"
-    cdialect "C11"
-    cppdialect "C++14"
 
     files { "src/*.c", "src/*.h", "src/*.hpp" }
     removefiles { "src/lua.c", "src/luac.c" }

--- a/premake/sqlite3/premake5.lua
+++ b/premake/sqlite3/premake5.lua
@@ -1,5 +1,4 @@
 project "sqlite3"
     kind "StaticLib"
-    cdialect "C11"
 
     files { "sqlite3.c", "sqlite3.h" }


### PR DESCRIPTION
Reverts Fluorohydride/ygopro#2723

We was relying on the "auto" or "default" version of compiler, it seems that those versions are different from the versions selected in that PR.

https://github.com/mercury233/ygopro/actions/runs/13870401498/job/38816292233

@salix5 So I suggest to merge https://github.com/Fluorohydride/ygopro/pull/2721 before doing other build-related changes.


