### PR TITLE
DeckManager: use uint32_t code

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -47,7 +47,7 @@ static inline bool havePopupWindow() {
 }
 
 static inline void get_deck_file(wchar_t* ret) {
-	deckManager.GetDeckFile(ret, mainGame->cbDBCategory->getSelected(), mainGame->cbDBCategory->getText(), mainGame->cbDBDecks->getText());
+	DeckManager::GetDeckFile(ret, mainGame->cbDBCategory->getSelected(), mainGame->cbDBCategory->getText(), mainGame->cbDBDecks->getText());
 }
 
 static inline void load_current_deck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBox* cbDeck) {
@@ -184,7 +184,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					break;
 				wchar_t filepath[256];
 				get_deck_file(filepath);
-				if(deckManager.SaveDeck(deckManager.current_deck, filepath)) {
+				if(DeckManager::SaveDeck(deckManager.current_deck, filepath)) {
 					mainGame->stACMessage->setText(dataManager.GetSysString(1335));
 					mainGame->PopupElement(mainGame->wACMessage, 20);
 					is_modified = false;
@@ -210,10 +210,10 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				}
 				int catesel = mainGame->cbDBCategory->getSelected();
 				wchar_t catepath[256];
-				deckManager.GetCategoryPath(catepath, catesel, mainGame->cbDBCategory->getText());
+				DeckManager::GetCategoryPath(catepath, catesel, mainGame->cbDBCategory->getText());
 				wchar_t filepath[256];
 				myswprintf(filepath, L"%ls/%ls.ydk", catepath, dname);
-				if(deckManager.SaveDeck(deckManager.current_deck, filepath)) {
+				if(DeckManager::SaveDeck(deckManager.current_deck, filepath)) {
 					mainGame->stACMessage->setText(dataManager.GetSysString(1335));
 					mainGame->PopupElement(mainGame->wACMessage, 20);
 					is_modified = false;
@@ -393,7 +393,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				case BUTTON_NEW_CATEGORY: {
 					int catesel = 0;
 					const wchar_t* catename = mainGame->ebDMName->getText();
-					if(deckManager.CreateCategory(catename)) {
+					if(DeckManager::CreateCategory(catename)) {
 						mainGame->cbDBCategory->addItem(catename);
 						mainGame->lstCategories->addItem(catename);
 						catesel = mainGame->lstCategories->getItemCount() - 1;
@@ -420,7 +420,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					int catesel = mainGame->lstCategories->getSelected();
 					const wchar_t* oldcatename = mainGame->lstCategories->getListItem(catesel);
 					const wchar_t* newcatename = mainGame->ebDMName->getText();
-					if(deckManager.RenameCategory(oldcatename, newcatename)) {
+					if(DeckManager::RenameCategory(oldcatename, newcatename)) {
 						mainGame->cbDBCategory->removeItem(catesel);
 						mainGame->cbDBCategory->addItem(newcatename);
 						mainGame->lstCategories->removeItem(catesel);
@@ -449,7 +449,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				case BUTTON_DELETE_CATEGORY: {
 					int catesel = mainGame->lstCategories->getSelected();
 					const wchar_t* catename = mainGame->lstCategories->getListItem(catesel);
-					if(deckManager.DeleteCategory(catename)) {
+					if(DeckManager::DeleteCategory(catename)) {
 						mainGame->cbDBCategory->removeItem(catesel);
 						mainGame->lstCategories->removeItem(catesel);
 						catesel = 2;
@@ -467,7 +467,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				case BUTTON_NEW_DECK: {
 					const wchar_t* deckname = mainGame->ebDMName->getText();
 					wchar_t catepath[256];
-					deckManager.GetCategoryPath(catepath, mainGame->cbDBCategory->getSelected(), mainGame->cbDBCategory->getText());
+					DeckManager::GetCategoryPath(catepath, mainGame->cbDBCategory->getSelected(), mainGame->cbDBCategory->getText());
 					wchar_t filepath[256];
 					myswprintf(filepath, L"%ls/%ls.ydk", catepath, deckname);
 					bool res = false;
@@ -475,7 +475,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 						deckManager.current_deck.main.clear();
 						deckManager.current_deck.extra.clear();
 						deckManager.current_deck.side.clear();
-						res = deckManager.SaveDeck(deckManager.current_deck, filepath);
+						res = DeckManager::SaveDeck(deckManager.current_deck, filepath);
 						RefreshDeckList();
 						ChangeCategory(mainGame->lstCategories->getSelected());
 					}
@@ -532,7 +532,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					int decksel = mainGame->lstDecks->getSelected();
 					wchar_t filepath[256];
 					get_deck_file(filepath);
-					if(deckManager.DeleteDeck(filepath)) {
+					if(DeckManager::DeleteDeck(filepath)) {
 						mainGame->lstDecks->removeItem(decksel);
 						mainGame->cbDBDecks->removeItem(decksel);
 						decksel--;
@@ -608,7 +608,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					}
 					bool res = false;
 					if(!FileSystem::IsFileExists(newfilepath)) {
-						res = deckManager.SaveDeck(deckManager.current_deck, newfilepath);
+						res = DeckManager::SaveDeck(deckManager.current_deck, newfilepath);
 					}
 					mainGame->lstCategories->setSelected(newcatename);
 					int catesel = mainGame->lstCategories->getSelected();
@@ -709,7 +709,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					mainGame->cbDBDecks->setSelected(sel);
 					wchar_t filepath[256];
 					get_deck_file(filepath);
-					if(deckManager.DeleteDeck(filepath)) {
+					if(DeckManager::DeleteDeck(filepath)) {
 						mainGame->cbDBDecks->removeItem(sel);
 						int count = mainGame->cbDBDecks->getItemCount();
 						if(sel >= count)
@@ -1004,7 +1004,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					break;
 				wchar_t filepath[256];
 				wchar_t catepath[256];
-				deckManager.GetCategoryPath(catepath, mainGame->lstCategories->getSelected(), mainGame->lstCategories->getListItem(mainGame->lstCategories->getSelected()));
+				DeckManager::GetCategoryPath(catepath, mainGame->lstCategories->getSelected(), mainGame->lstCategories->getListItem(mainGame->lstCategories->getSelected()));
 				myswprintf(filepath, L"%ls/%ls.ydk", catepath, mainGame->lstDecks->getListItem(decksel));
 				deckManager.LoadCurrentDeck(filepath, showing_pack);
 				RefreshPackListScroll();
@@ -1608,7 +1608,7 @@ void DeckBuilder::RefreshDeckList() {
 	irr::gui::IGUIListBox* lstCategories = mainGame->lstCategories;
 	irr::gui::IGUIListBox* lstDecks = mainGame->lstDecks;
 	wchar_t catepath[256];
-	deckManager.GetCategoryPath(catepath, lstCategories->getSelected(), lstCategories->getListItem(lstCategories->getSelected()));
+	DeckManager::GetCategoryPath(catepath, lstCategories->getSelected(), lstCategories->getListItem(lstCategories->getSelected()));
 	lstDecks->clear();
 	mainGame->RefreshDeck(catepath, [lstDecks](const wchar_t* item) { lstDecks->addItem(item); });
 }

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -183,7 +183,7 @@ uint32_t DeckManager::LoadDeck(Deck& deck, uint32_t dbuf[], int mainc, int sidec
 	}
 	return errorcode;
 }
-uint32_t DeckManager::LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist) {
+uint32_t DeckManager::LoadDeckFromStream(Deck& deck, std::istringstream& deckStream, bool is_packlist) {
 	int ct = 0;
 	int mainc = 0, sidec = 0;
 	uint32_t cardlist[PACK_MAX_SIZE]{};
@@ -299,8 +299,8 @@ bool DeckManager::LoadCurrentDeck(const wchar_t* file, bool is_packlist) {
 		return false;
 	}
 	std::istringstream deckStream(deckBuffer);
-	LoadDeck(current_deck, deckStream, is_packlist);
-	return true;  // the above LoadDeck has return value but we ignore it here for now
+	LoadDeckFromStream(current_deck, deckStream, is_packlist);
+	return true;  // the above function has return value but we ignore it here for now
 }
 bool DeckManager::LoadCurrentDeck(int category_index, const wchar_t* category_name, const wchar_t* deckname) {
 	wchar_t filepath[256];

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -13,6 +13,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 	FILE* fp = std::fopen(path, "r");
 	char linebuf[256]{};
 	wchar_t strBuffer[256]{};
+	char str1[16]{};
 	if(fp) {
 		while(std::fgets(linebuf, sizeof linebuf, fp)) {
 			if(linebuf[0] == '#')
@@ -32,10 +33,11 @@ void DeckManager::LoadLFListSingle(const char* path) {
 				continue;
 			unsigned int code = 0;
 			int count = -1;
-			if (std::sscanf(linebuf, "%9u%*[ ]%9d", &code, &count) != 2)
+			if (std::sscanf(linebuf, "%10s%*[ ]%1d", str1, &count) != 2)
 				continue;
 			if (count < 0 || count > 2)
 				continue;
+			code = std::strtoul(str1, nullptr, 10);
 			cur->content[code] = count;
 			cur->hash = cur->hash ^ ((code << 18) | (code >> 14)) ^ ((code << (27 + count)) | (code >> (5 - count)));
 		}

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -47,9 +47,9 @@ public:
 	const wchar_t* GetLFListName(unsigned int lfhash);
 	const LFList* GetLFList(unsigned int lfhash);
 	unsigned int CheckDeck(const Deck& deck, unsigned int lfhash, int rule);
-	int LoadDeck(Deck& deck, int* dbuf, int mainc, int sidec, bool is_packlist = false);
-	int LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
-	bool LoadSide(Deck& deck, int* dbuf, int mainc, int sidec);
+	uint32_t LoadDeck(Deck& deck, uint32_t dbuf[], int mainc, int sidec, bool is_packlist = false);
+	uint32_t LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
+	bool LoadSide(Deck& deck, uint32_t dbuf[], int mainc, int sidec);
 	void GetCategoryPath(wchar_t* ret, int index, const wchar_t* text);
 	void GetDeckFile(wchar_t* ret, int category_index, const wchar_t* category_name, const wchar_t* deckname);
 	FILE* OpenDeckFile(const wchar_t* file, const char* mode);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -47,21 +47,22 @@ public:
 	const wchar_t* GetLFListName(unsigned int lfhash);
 	const LFList* GetLFList(unsigned int lfhash);
 	unsigned int CheckDeck(const Deck& deck, unsigned int lfhash, int rule);
-	uint32_t LoadDeck(Deck& deck, uint32_t dbuf[], int mainc, int sidec, bool is_packlist = false);
-	uint32_t LoadDeckFromStream(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
-	bool LoadSide(Deck& deck, uint32_t dbuf[], int mainc, int sidec);
-	void GetCategoryPath(wchar_t* ret, int index, const wchar_t* text);
-	void GetDeckFile(wchar_t* ret, int category_index, const wchar_t* category_name, const wchar_t* deckname);
-	FILE* OpenDeckFile(const wchar_t* file, const char* mode);
-	irr::io::IReadFile* OpenDeckReader(const wchar_t* file);
 	bool LoadCurrentDeck(const wchar_t* file, bool is_packlist = false);
 	bool LoadCurrentDeck(int category_index, const wchar_t* category_name, const wchar_t* deckname);
-	bool SaveDeck(Deck& deck, const wchar_t* file);
-	bool DeleteDeck(const wchar_t* file);
-	bool CreateCategory(const wchar_t* name);
-	bool RenameCategory(const wchar_t* oldname, const wchar_t* newname);
-	bool DeleteCategory(const wchar_t* name);
 	bool SaveDeckBuffer(const int deckbuf[], const wchar_t* name);
+
+	static uint32_t LoadDeck(Deck& deck, uint32_t dbuf[], int mainc, int sidec, bool is_packlist = false);
+	static uint32_t LoadDeckFromStream(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
+	static bool LoadSide(Deck& deck, uint32_t dbuf[], int mainc, int sidec);
+	static void GetCategoryPath(wchar_t* ret, int index, const wchar_t* text);
+	static void GetDeckFile(wchar_t* ret, int category_index, const wchar_t* category_name, const wchar_t* deckname);
+	static FILE* OpenDeckFile(const wchar_t* file, const char* mode);
+	static irr::io::IReadFile* OpenDeckReader(const wchar_t* file);
+	static bool SaveDeck(Deck& deck, const wchar_t* file);
+	static bool DeleteDeck(const wchar_t* file);
+	static bool CreateCategory(const wchar_t* name);
+	static bool RenameCategory(const wchar_t* oldname, const wchar_t* newname);
+	static bool DeleteCategory(const wchar_t* name);
 };
 
 extern DeckManager deckManager;

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -48,7 +48,7 @@ public:
 	const LFList* GetLFList(unsigned int lfhash);
 	unsigned int CheckDeck(const Deck& deck, unsigned int lfhash, int rule);
 	uint32_t LoadDeck(Deck& deck, uint32_t dbuf[], int mainc, int sidec, bool is_packlist = false);
-	uint32_t LoadDeck(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
+	uint32_t LoadDeckFromStream(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
 	bool LoadSide(Deck& deck, uint32_t dbuf[], int mainc, int sidec);
 	void GetCategoryPath(wchar_t* ret, int index, const wchar_t* text);
 	void GetDeckFile(wchar_t* ret, int category_index, const wchar_t* category_name, const wchar_t* deckname);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1226,7 +1226,7 @@ void Game::RefreshDeck(irr::gui::IGUIComboBox* cbCategory, irr::gui::IGUIComboBo
 		return;
 	}
 	wchar_t catepath[256];
-	deckManager.GetCategoryPath(catepath, cbCategory->getSelected(), cbCategory->getText());
+	DeckManager::GetCategoryPath(catepath, cbCategory->getSelected(), cbCategory->getText());
 	cbDeck->clear();
 	RefreshDeck(catepath, [cbDeck](const wchar_t* item) { cbDeck->addItem(item); });
 }

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -367,7 +367,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				wchar_t arg1[512];
 				if(mainGame->botInfo[sel].select_deckfile) {
 					wchar_t botdeck[256];
-					deckManager.GetDeckFile(botdeck, mainGame->cbBotDeckCategory->getSelected(), mainGame->cbBotDeckCategory->getText(), mainGame->cbBotDeck->getText());
+					DeckManager::GetDeckFile(botdeck, mainGame->cbBotDeckCategory->getSelected(), mainGame->cbBotDeckCategory->getText(), mainGame->cbBotDeck->getText());
 					myswprintf(arg1, L"%ls DeckFile='%ls'", mainGame->botInfo[sel].command, botdeck);
 				}
 				else
@@ -386,7 +386,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					wchar_t warg1[512];
 					if(mainGame->botInfo[sel].select_deckfile) {
 						wchar_t botdeck[256];
-						deckManager.GetDeckFile(botdeck, mainGame->cbBotDeckCategory->getSelected(), mainGame->cbBotDeckCategory->getText(), mainGame->cbBotDeck->getText());
+						DeckManager::GetDeckFile(botdeck, mainGame->cbBotDeckCategory->getSelected(), mainGame->cbBotDeckCategory->getText(), mainGame->cbBotDeck->getText());
 						myswprintf(warg1, L"%ls DeckFile='%ls'", mainGame->botInfo[sel].command, botdeck);
 					}
 					else

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -57,7 +57,7 @@ static_assert(sizeof(HostRequest) == 2, "size mismatch: HostRequest");
 struct CTOS_DeckData {
 	int32_t mainc{};
 	int32_t sidec{};
-	int32_t list[MAINC_MAX + SIDEC_MAX]{};
+	uint32_t list[MAINC_MAX + SIDEC_MAX]{};
 };
 check_trivially_copyable(CTOS_DeckData);
 

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -297,9 +297,9 @@ void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 		return;
 	}
 	if(duel_count == 0) {
-		deck_error[dp->type] = deckManager.LoadDeck(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec);
+		deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec);
 	} else {
-		if(deckManager.LoadSide(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec)) {
+		if(DeckManager::LoadSide(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec)) {
 			ready[dp->type] = true;
 			NetServer::SendPacketToPlayer(dp, STOC_DUEL_START);
 			if(ready[0] && ready[1]) {

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -279,7 +279,7 @@ void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 		NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
 		return;
 	}
-	deck_error[dp->type] = deckManager.LoadDeck(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec);
+	deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec);
 }
 void TagDuel::StartDuel(DuelPlayer* dp) {
 	if(dp != host_player)


### PR DESCRIPTION
```cpp
static uint32_t LoadDeck(Deck& deck, uint32_t dbuf[], int mainc, int sidec, bool is_packlist = false);
static uint32_t LoadDeckFromStream(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
static bool LoadSide(Deck& deck, uint32_t dbuf[], int mainc, int sidec);
```
- The input is treated as uint32_t array.
- They are static member functions.
- Rename: `LoadDeck(Deck& deck, std::istringstream& deckStream` -> LoadDeckFromStream


----
```cpp
struct CTOS_DeckData {
	int32_t mainc{};
	int32_t sidec{};
	uint32_t list[MAINC_MAX + SIDEC_MAX]{};
};
```
The code list is treated as uint32_t .

----
DeckManager::LoadDeckFromStream
consider `1.ydk`
```
1
4294967296
```

Before:
reject if `strtoul` fails

on some platforms:
8 bytes long
ULONG_MAX = 18446744073709551615
accept 4294967296
sequence length: 2

on Windows:
4 bytes long
ULONG_MAX = 4294967295
reject 4294967296
sequence length: 1

The same file will be converted to sequences of different length.

After:
reject if value >= UINT32_MAX

on some platforms:
8 bytes long
return 4294967296
reject

on Windows:
4 bytes long
return ULONG_MAX = 4294967295
reject

@edo9300 
https://en.cppreference.com/w/cpp/string/basic_string/stoul
1) Calls [std::strtoul](http://en.cppreference.com/w/cpp/string/byte/strtoul)(str.c_str(), &ptr, base).

`stoul` is a wrapper of `strtoul`, so I think the deck loading function of edopro has the same problem.

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust


