### PR TITLE
add new font to fallback list

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -138,6 +138,7 @@ bool Game::Initialize() {
 			L"/usr/share/fonts/google-noto-cjk/NotoSansCJK-Regular.ttc",
 			L"/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
 			L"/System/Library/Fonts/PingFang.ttc",
+			L"/System/Library/Fonts/STHeiti Medium.ttc",
 			L"./fonts/textFont.ttf",
 			L"./fonts/textFont.ttc",
 			L"./fonts/textFont.otf"


### PR DESCRIPTION
![mmexport1745027610909](https://github.com/user-attachments/assets/b55129e6-91b2-4f38-8ed7-b0b0b57051c2)
_Don't looks good but better than nothing._

_macOS had moved PingFang to `/System/Library/AssetsV2/com_apple_MobileAsset_Font`, which can't be used._

Require https://github.com/Fluorohydride/ygopro/pull/2756 to work fully.