### PR TITLE
fix define WIN32

### DIFF
--- a/premake/event/premake5.lua
+++ b/premake/event/premake5.lua
@@ -11,3 +11,4 @@ project "event"
     filter "system:windows"
         prebuildcommands { "xcopy /E /Y $(ProjectDir)..\\event\\WIN32-Code $(ProjectDir)..\\event\\include" }
         files { "win32select.c", "evthread_win32.c", "buffer_iocp.c", "event_iocp.c", "bufferevent_async.c" }
+        defines { "WIN32" } -- quirk of old libevent

--- a/premake5.lua
+++ b/premake5.lua
@@ -154,7 +154,6 @@ workspace "YGOPro"
     configurations { "Release", "Debug" }
 
     filter "system:windows"
-        defines { "WIN32", "_WIN32" }
         entrypoint "mainCRTStartup"
         systemversion "latest"
         startproject "YGOPro"


### PR DESCRIPTION
`WIN32` is not standard value of Windows, but `_WIN32` is. And `_WIN32` will be defined by compiler automatically.
https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170#:~:text=project.%20Otherwise%2C%20undefined.-,_WIN32,-Defined%20as%201

libevent fixed this years ago, but we are using 2.0.22 which is before this fix.
https://github.com/libevent/libevent/commit/9f560bfa114b8216af2dac28966eae53c0c97ed3

require https://github.com/Fluorohydride/ygopro-core/pull/748