### PR TITLE
fix setlocale on macOS

### DIFF
--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* argv[]) {
 #if defined(FOPEN_WINDOWS_SUPPORT_UTF8)
 	std::setlocale(LC_CTYPE, ".UTF-8");
 #elif defined(__APPLE__)
-	std::setlocale(LC_CTYPE, "C.UTF-8");
+	std::setlocale(LC_CTYPE, "UTF-8");
 #elif !defined(_WIN32)
 	std::setlocale(LC_CTYPE, "");
 #endif


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro/pull/2713

According to [my test](https://github.com/mercury233/macos-setlocale-test/actions),  
`C.UTF-8` is only supported on macOS 15, but `UTF-8` is supported on both macOS 13 and 15.

Some interesting observations:
- `UTF-8` cannot be used with `LC_ALL`, but it can be used with `LC_CTYPE`.
- If you run a program from the terminal on macOS, `setlocale(LC_CTYPE, "")` will resolve to `zh_CN.UTF-8` or `en_US.UTF-8`. However, if you pin the program to the Dock and launch it from there, `setlocale(LC_CTYPE, "")` will resolve to `C`.