### PR TITLE
update imageScaleNNAA, add OpenMP

### DIFF
--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1262,7 +1262,7 @@ void Game::DrawDeckBd() {
 		driver->draw2DRectangle(Resize(805, 160, 1020, 630), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 		driver->draw2DRectangleOutline(Resize(804, 159, 1020, 630));
 	}
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 	constexpr int MAX_RESULT = 9;
 #else
 	constexpr int MAX_RESULT = 7;

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1262,7 +1262,12 @@ void Game::DrawDeckBd() {
 		driver->draw2DRectangle(Resize(805, 160, 1020, 630), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 		driver->draw2DRectangleOutline(Resize(804, 159, 1020, 630));
 	}
-	for(int i = 0; i < 9 && i + scrFilter->getPos() < (int)deckBuilder.results.size(); ++i) {
+#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+	constexpr int MAX_RESULT = 9;
+#else
+	constexpr int MAX_RESULT = 7;
+#endif
+	for(int i = 0; i < MAX_RESULT && i + scrFilter->getPos() < (int)deckBuilder.results.size(); ++i) {
 		code_pointer ptr = deckBuilder.results[i + scrFilter->getPos()];
 		if(i >= 7)
 		{

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -1,6 +1,6 @@
 #include "image_manager.h"
 #include "game.h"
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 #include <thread>
 #endif
 #ifdef _OPENMP
@@ -22,7 +22,7 @@ bool ImageManager::Initial() {
 	tUnknownFit = nullptr;
 	tUnknownThumb = nullptr;
 	tBigPicture = nullptr;
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 	tLoading = nullptr;
 	tThumbLoadingThreadRunning = false;
 #endif
@@ -66,7 +66,7 @@ void ImageManager::ClearTexture() {
 			driver->removeTexture(tit->second);
 	}
 	for(auto tit = tThumb.begin(); tit != tThumb.end(); ++tit) {
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 		if(tit->second && tit->second != tLoading)
 #else
 		if(tit->second)
@@ -80,7 +80,7 @@ void ImageManager::ClearTexture() {
 	tMap[0].clear();
 	tMap[1].clear();
 	tThumb.clear();
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 	tThumbLoadingMutex.lock();
 	tThumbLoading.clear();
 	while(!tThumbLoadingCodes.empty())
@@ -123,7 +123,7 @@ void ImageManager::ResizeTexture() {
 	driver->removeTexture(tUnknown);
 	driver->removeTexture(tUnknownFit);
 	driver->removeTexture(tUnknownThumb);
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 	driver->removeTexture(tLoading);
 	tLoading = GetTextureFromFile("textures/cover.jpg", imgWidthThumb, imgHeightThumb);
 #endif
@@ -298,7 +298,7 @@ irr::video::ITexture* ImageManager::GetBigPicture(int code, float zoom) {
 	tBigPicture = texture;
 	return texture;
 }
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 int ImageManager::LoadThumbThread() {
 	while(true) {
 		imageManager.tThumbLoadingMutex.lock();
@@ -354,11 +354,11 @@ int ImageManager::LoadThumbThread() {
 	imageManager.tThumbLoadingMutex.unlock();
 	return 0;
 }
-#endif // YGOPRO_USE_THUMB_LOAD_THERAD
+#endif // YGOPRO_USE_THUMB_LOAD_THREAD
 irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 	if(code == 0)
 		return tUnknownThumb;
-#ifndef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifndef YGOPRO_USE_THUMB_LOAD_THREAD
 	auto tit = tThumb.find(code);
 	if(tit == tThumb.end()) {
 		char file[256];
@@ -381,7 +381,7 @@ irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 		tThumb[code] = img;
 		return (img == NULL) ? tUnknownThumb : img;
 	}
-#else // YGOPRO_USE_THUMB_LOAD_THERAD
+#else // YGOPRO_USE_THUMB_LOAD_THREAD
 	imageManager.tThumbLoadingMutex.lock();
 	auto lit = tThumbLoading.find(code);
 	if(lit != tThumbLoading.end()) {
@@ -409,7 +409,7 @@ irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 		imageManager.tThumbLoadingMutex.unlock();
 		return tLoading;
 	}
-#endif // YGOPRO_USE_THUMB_LOAD_THERAD
+#endif // YGOPRO_USE_THUMB_LOAD_THREAD
 	if(tit->second)
 		return tit->second;
 	else

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -362,19 +362,19 @@ irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 	auto tit = tThumb.find(code);
 	if(tit == tThumb.end()) {
 		char file[256];
-		sprintf(file, "expansions/pics/thumbnail/%d.jpg", code);
+		std::snprintf(file, sizeof file, "expansions/pics/thumbnail/%d.jpg", code);
 		int width = CARD_THUMB_WIDTH * mainGame->xScale;
 		int height = CARD_THUMB_HEIGHT * mainGame->yScale;
 		irr::video::ITexture* img = GetTextureFromFile(file, width, height);
 		if(img == NULL) {
-			sprintf(file, "pics/thumbnail/%d.jpg", code);
+			std::snprintf(file, sizeof file, "pics/thumbnail/%d.jpg", code);
 			img = GetTextureFromFile(file, width, height);
 		}
 		if(img == NULL && mainGame->gameConf.use_image_scale) {
-			sprintf(file, "expansions/pics/%d.jpg", code);
+			std::snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
 			img = GetTextureFromFile(file, width, height);
 			if(img == NULL) {
-				sprintf(file, "pics/%d.jpg", code);
+				std::snprintf(file, sizeof file, "pics/%d.jpg", code);
 				img = GetTextureFromFile(file, width, height);
 			}
 		}

--- a/gframe/image_manager.h
+++ b/gframe/image_manager.h
@@ -1,11 +1,17 @@
 #ifndef IMAGEMANAGER_H
 #define IMAGEMANAGER_H
 
+#ifndef _OPENMP
+#define YGOPRO_USE_THUMB_LOAD_THERAD
+#endif
+
 #include "config.h"
 #include "data_manager.h"
 #include <unordered_map>
+#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
 #include <queue>
 #include <mutex>
+#endif
 
 namespace ygo {
 
@@ -21,15 +27,19 @@ public:
 	irr::video::ITexture* GetBigPicture(int code, float zoom);
 	irr::video::ITexture* GetTextureThumb(int code);
 	irr::video::ITexture* GetTextureField(int code);
+#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
 	static int LoadThumbThread();
+#endif
 
 	std::unordered_map<int, irr::video::ITexture*> tMap[2];
 	std::unordered_map<int, irr::video::ITexture*> tThumb;
 	std::unordered_map<int, irr::video::ITexture*> tFields;
+#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
 	std::unordered_map<int, irr::video::IImage*> tThumbLoading;
 	std::queue<int> tThumbLoadingCodes;
 	std::mutex tThumbLoadingMutex;
 	bool tThumbLoadingThreadRunning;
+#endif
 	irr::IrrlichtDevice* device;
 	irr::video::IVideoDriver* driver;
 	irr::video::ITexture* tCover[4];
@@ -37,7 +47,9 @@ public:
 	irr::video::ITexture* tUnknownFit;
 	irr::video::ITexture* tUnknownThumb;
 	irr::video::ITexture* tBigPicture;
+#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
 	irr::video::ITexture* tLoading;
+#endif
 	irr::video::ITexture* tAct;
 	irr::video::ITexture* tAttack;
 	irr::video::ITexture* tNegated;

--- a/gframe/image_manager.h
+++ b/gframe/image_manager.h
@@ -2,13 +2,13 @@
 #define IMAGEMANAGER_H
 
 #ifndef _OPENMP
-#define YGOPRO_USE_THUMB_LOAD_THERAD
+#define YGOPRO_USE_THUMB_LOAD_THREAD
 #endif
 
 #include "config.h"
 #include "data_manager.h"
 #include <unordered_map>
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 #include <queue>
 #include <mutex>
 #endif
@@ -27,14 +27,14 @@ public:
 	irr::video::ITexture* GetBigPicture(int code, float zoom);
 	irr::video::ITexture* GetTextureThumb(int code);
 	irr::video::ITexture* GetTextureField(int code);
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 	static int LoadThumbThread();
 #endif
 
 	std::unordered_map<int, irr::video::ITexture*> tMap[2];
 	std::unordered_map<int, irr::video::ITexture*> tThumb;
 	std::unordered_map<int, irr::video::ITexture*> tFields;
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 	std::unordered_map<int, irr::video::IImage*> tThumbLoading;
 	std::queue<int> tThumbLoadingCodes;
 	std::mutex tThumbLoadingMutex;
@@ -47,7 +47,7 @@ public:
 	irr::video::ITexture* tUnknownFit;
 	irr::video::ITexture* tUnknownThumb;
 	irr::video::ITexture* tBigPicture;
-#ifdef YGOPRO_USE_THUMB_LOAD_THERAD
+#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 	irr::video::ITexture* tLoading;
 #endif
 	irr::video::ITexture* tAct;

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -69,6 +69,7 @@ project "YGOPro"
     filter "not system:windows"
         links { "event_pthreads", "dl", "pthread" }
     filter "system:macosx"
+        openmp "Off"
         links { "z" }
         defines { "GL_SILENCE_DEPRECATION" }
         if MAC_ARM then
@@ -80,6 +81,7 @@ project "YGOPro"
         end
     filter "system:linux"
         links { "GL", "X11", "Xxf86vm" }
+        linkoptions { "-fopenmp" }
         if USE_IRRKLANG then
             links { "IrrKlang" }
             linkoptions{ IRRKLANG_LINK_RPATH }

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -5,6 +5,7 @@ project "YGOPro"
     kind "WindowedApp"
     cppdialect "C++14"
     rtti "Off"
+    openmp "On"
 
     files { "*.cpp", "*.h" }
     includedirs { "../ocgcore" }


### PR DESCRIPTION
Use OpenMP to make the image loading progress can use all CPU cores.

The speed is 5 times faster on my computer.

In that case, the thumbnail loading thread added in https://github.com/Fluorohydride/ygopro/pull/2207 will be unnecessary. The speed of loading thumbnail is fast enough.

-----

The Apple clang [don't support OpenMP](https://mac.r-project.org/openmp/).