### PR TITLE
disable PNG_ARM_NEON for all systems

### DIFF
--- a/premake/irrlicht/premake5.lua
+++ b/premake/irrlicht/premake5.lua
@@ -62,6 +62,8 @@ project "irrlicht"
         "NO__IRR_COMPILE_WITH_WAD_ARCHIVE_LOADER_",
         "NO_IRR_COMPILE_WITH_ZIP_ENCRYPTION_",
         "PNG_INTEL_SSE",
+        "PNG_ARM_NEON_OPT=0",
+        "PNG_ARM_NEON_IMPLEMENTATION=0",
     }
 
     files {
@@ -159,7 +161,7 @@ project "irrlicht"
 
     filter { "system:macosx" }
         cppdialect "gnu++14"
-        defines { "GL_SILENCE_DEPRECATION", "PNG_ARM_NEON_OPT=0", "PNG_ARM_NEON_IMPLEMENTATION=0" }
+        defines { "GL_SILENCE_DEPRECATION" }
         undefines { "NO_IRR_COMPILE_WITH_JOYSTICK_EVENTS_" }
         files {
             "source/Irrlicht/MacOSX/*.mm",


### PR DESCRIPTION
fix https://github.com/Fluorohydride/ygopro/pull/2777#issuecomment-2853077144

> Arm Neon is an advanced single instruction multiple data (SIMD) architecture extension for the Arm Cortex-A and Arm Cortex-R series of processors with capabilities that vastly improve use cases on mobile devices, such as multimedia encoding/decoding, user interface, 2D/3D graphics and gaming.

It is not avail for most processors.