### PR TITLE
remove windows-2019 matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022]
         audiolib: [miniaudio, irrklang]
 
     runs-on: ${{ matrix.os }}
@@ -197,20 +197,10 @@ jobs:
         xcopy /E premake\* .
         xcopy /E resource\* .
 
-    - name: Use premake to generate Visual Studio solution (2019, miniaudio)
-      if: matrix.os == 'windows-2019' && matrix.audiolib == 'miniaudio'
-      run: |
-        .\premake5.exe vs2019 --winxp-support
-
     - name: Use premake to generate Visual Studio solution (2022, miniaudio)
       if: matrix.os == 'windows-2022' && matrix.audiolib == 'miniaudio'
       run: |
         .\premake5.exe vs2022
-
-    - name: Use premake to generate Visual Studio solution (2019, irrKlang)
-      if: matrix.os == 'windows-2019' && matrix.audiolib == 'irrklang'
-      run: |
-        .\premake5.exe vs2019 --winxp-support --audio-lib=irrklang
 
     - name: Use premake to generate Visual Studio solution (2022, irrKlang)
       if: matrix.os == 'windows-2022' && matrix.audiolib == 'irrklang'


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/12045
Breaking changes

We will soon start the deprecation process for Windows 2019. While the image is being deprecated, you may experience longer queue times during peak usage hours. Deprecation will begin on 2025-06-01 and the image will be fully unsupported by 2025-06-30.

To raise awareness of the upcoming removal, we will temporarily fail jobs using windows 2019. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

- June 3 13:00 - 21:00 UTC
- June 10 13:00-21:00 UTC
- June 17 13:00-21:00 UTC
- June 24 13:00-21:00 UTC

Possible impact
Workflows using the windows-2019 image label should be updated to windows-2022 or windows-2025.

Windows 2019 action runner
將在6/1棄用
在6月每隔一段時間停止服務
並且在6/30完全
公告已明確提到建議升級到windows-2022

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust 
