### PR TITLE
setlocale LC_ALL

### DIFF
--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -24,11 +24,11 @@ void ClickButton(irr::gui::IGUIElement* btn) {
 
 int main(int argc, char* argv[]) {
 #if defined(FOPEN_WINDOWS_SUPPORT_UTF8)
-	std::setlocale(LC_CTYPE, ".UTF-8");
+	std::setlocale(LC_ALL, ".UTF-8");
 #elif defined(__APPLE__)
-	std::setlocale(LC_CTYPE, "UTF-8");
+	std::setlocale(LC_ALL, "UTF-8");
 #elif !defined(_WIN32)
-	std::setlocale(LC_CTYPE, "");
+	std::setlocale(LC_ALL, "");
 #endif
 #ifdef __APPLE__
 	CFURLRef bundle_url = CFBundleCopyBundleURL(CFBundleGetMainBundle());


### PR DESCRIPTION
https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setlocale-wsetlocale?view=msvc-170
After calling setlocale(LC_ALL, ".UTF8"), you may pass "😊" to mbtowcs and it will be properly translated to a wchar_t string. Previously, there wasn't a locale setting available to do this translation.

https://linux.die.net/man/3/setlocale
On startup of the main program, the portable "C""" locale is selected as default. A program may be made portable to all locales by calling:
setlocale(LC_ALL, "");

https://en.cppreference.com/w/c/locale/LC_categories
LC_COLLATE
selects the collation category of the C locale 

我能找到的參考資料幾乎都是直接修改LC_ALL
似乎沒有必要只修改LC_CTYPE

@mercury233 
