### PR TITLE
fix: compare signed and unsigned

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1557,7 +1557,7 @@ void Game::ShowCardInfo(int code, bool resize) {
 		myswprintf(formatBuffer, L"%ls[%08d]", dataManager.GetName(code), code);
 	}
 	stName->setText(formatBuffer);
-	if(guiFont->getDimension(formatBuffer).Width > stName->getRelativePosition().getWidth() - gameConf.textfontsize)
+	if((int)guiFont->getDimension(formatBuffer).Width > stName->getRelativePosition().getWidth() - gameConf.textfontsize)
 		stName->setToolTipText(formatBuffer);
 	else
 		stName->setToolTipText(nullptr);


### PR DESCRIPTION
https://irrlicht.sourceforge.io/docu/classirr_1_1gui_1_1_i_g_u_i_font.html#aa7612db0c9dc2837b44a1a2fa5668797
core::dimension2d<u32> CGUITTFont::getDimension(const wchar_t* text) const