### PR TITLE
version 0x1362

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -12,7 +12,7 @@
 #include "single_mode.h"
 #include <thread>
 
-const unsigned short PRO_VERSION = 0x1361;
+const unsigned short PRO_VERSION = 0x1362;
 
 namespace ygo {
 


### PR DESCRIPTION
Security problems after 0x1361
including but not limited to:

從0x1361版本以來的安全性問題
包含但不限於：

#2585
Problems in UTF16 to UTF8 conversions:
did not handle lone surrogate
reading out-of bounds in such cases
writing out-of bounds in such cases
breaking system.conf or even worse

沒有處理lone surrogate
在這種情況下讀取越界
在這種情況下寫入越界
破壞 system.conf 甚至更糟

#2602 
wcscpy and wcscat cause buffer overflow
did not handle lone surrogate in Game::LoadConfig

wcscpy 和 wcscat 導致緩衝區溢出
沒有處理 Game::LoadConfig 中的lone surrogate

Example:
```
YGOPro.exe --deck-category 123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
```

#2619
test.conf (a line with 1000+ characters)
Buffer overflow while reading test.conf

讀取 test.conf 時緩衝區溢出

#2632
If deckManager._lfList is empty
It will dereference nullptr in this case.
如果 deckManager._lfList 為空
在這種情況下它將取消引用 nullptr

#2649
Replay::comp_data is too small
If the server sends the following packet, it will cause buffer overflow.

Replay::comp_data 太小
如果伺服器傳送以下封包將導致緩衝區溢位

proto: STOC_REPLAY
ReplayHeader (32 bytes)
byte array (65500 bytes)


#2699
lflist.conf
12345678901234567890 1
If a line is very long, the behavior is undefined.
如果一行很長，則出現未定義行為

1.ydk
12345678901234567890
If a line is very long, the process will crash.
如果一行很長，則程序崩潰

#2715
If mainGame->gameConf.default_lflist is not a correct index
it will read out-of-bounds.
如果 mainGame->gameConf.default_lflist 不是正確的索引
讀取越界


#2776
The structure of single mode yrp file
```cpp
ReplayHeader pheader;                 // flag: REPLAY_UNIFORM, REPLAY_SINGLE_MODE
std::vector<std::wstring> players;	// 40 bytes null terminated string * 2
DuelParameters params;			// 16 bytes
std::string script_name;		// 2 bytes, script name (max: 256 bytes)
```
The `script_name` can be any path, and ygopro will try to run that script.
So a false replay file can run any script file in the file system.

`script_name` 可以是任何路徑，ygopro 會嘗試執行該腳本
虛假的重播檔案可以運行檔案系統中的任何腳本檔案

----
I strongly suggest that we should move to 0x1362.
Any 0x1361 files are likely to have some of the above security problems, and they are will no longer be supported.

我強烈建議版本號更新到 0x1362。
任何 0x1361 文件都可能存在上述的某些安全性問題，並且將不再支援。


@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust 