### PR TITLE
include header files in lzma

### DIFF
--- a/premake/irrlicht/premake5.lua
+++ b/premake/irrlicht/premake5.lua
@@ -69,6 +69,7 @@ project "irrlicht"
     files {
         "include/*.h",
         "source/Irrlicht/*.cpp",
+        "source/Irrlicht/lzma/*.h",
         "source/Irrlicht/zlib/zlib.h",
         "source/Irrlicht/zlib/adler32.c",
         "source/Irrlicht/zlib/compress.c",


### PR DESCRIPTION
https://github.com/mercury233/irrlicht/blob/b00b64f1991ce2fdc21fda4e8282f2fa5c20d763/source/Irrlicht/CZipReader.cpp#L40
```cpp
#ifdef _IRR_COMPILE_WITH_LZMA_
#include "lzma/LzmaDec.h"
#endif
```

It still needs `lzma/LzmaDec.h`
If you delete the header files in lzma, the compile will fail.
The headers should be included in the project, or we might have to change `CZipReader.cpp`.

仍然需要 `lzma/LzmaDec.h`
如果刪除lzma中的頭文件，編譯將會失敗。
標題應該包含在專案中，否則我們可能必須更改`CZipReader.cpp`。

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust 
