### PR TITLE
update forced in MSG_SELECT_CHAIN

### DIFF
--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -377,9 +377,9 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					select_options_index.clear();
 					for (size_t i = 0; i < activatable_cards.size(); ++i) {
 						if (activatable_cards[i] == menu_card) {
-							if(activatable_descs[i].second == EDESC_OPERATION)
+							if(activatable_descs[i].second & EDESC_OPERATION)
 								continue;
-							else if(activatable_descs[i].second == EDESC_RESET) {
+							else if(activatable_descs[i].second & EDESC_RESET) {
 								if(id == BUTTON_CMD_ACTIVATE) continue;
 							} else {
 								if(id == BUTTON_CMD_RESET) continue;
@@ -660,7 +660,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						select_options_index.clear();
 						for (size_t i = 0; i < activatable_cards.size(); ++i) {
 							if (activatable_cards[i] == command_card) {
-								if(activatable_descs[i].second == EDESC_OPERATION) {
+								if(activatable_descs[i].second & EDESC_OPERATION) {
 									if(list_command == COMMAND_ACTIVATE) continue;
 								} else {
 									if(list_command == COMMAND_OPERATION) continue;

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -392,7 +392,7 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 		case MSG_SELECT_CHAIN: {
 			player = BufferIO::ReadUInt8(pbuf);
 			count = BufferIO::ReadUInt8(pbuf);
-			pbuf += 10 + count * 13;
+			pbuf += 9 + count * 14;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_PLACE:

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -751,7 +751,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		case MSG_SELECT_CHAIN: {
 			player = BufferIO::ReadUInt8(pbuf);
 			count = BufferIO::ReadUInt8(pbuf);
-			pbuf += 10 + count * 13;
+			pbuf += 9 + count * 14;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -297,7 +297,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		case MSG_SELECT_CHAIN: {
 			player = BufferIO::ReadUInt8(pbuf);
 			count = BufferIO::ReadUInt8(pbuf);
-			pbuf += 10 + count * 13;
+			pbuf += 9 + count * 14;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
 				mainGame->singleSignal.Wait();

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -707,7 +707,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		case MSG_SELECT_CHAIN: {
 			player = BufferIO::ReadUInt8(pbuf);
 			count = BufferIO::ReadUInt8(pbuf);
-			pbuf += 10 + count * 13;
+			pbuf += 9 + count * 14;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;


### PR DESCRIPTION
Problem:

In the Standby phase, _Dark Contract with the Witch_ can select among 2 effects, ① is optional, ③ is forced.

But the client didn't know which is forced. If `chkAutoChain` is enabled, the first effect will be selected to activate.

Solution:

Update `MSG_SELECT_CHAIN`, set `forced` to each chain options.

require https://github.com/Fluorohydride/ygopro-core/pull/753