### PR TITLE
fix CopyString & CopyWideString

### DIFF
--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -62,13 +62,13 @@ public:
 	}
 	template<size_t N>
 	static void CopyString(const char* src, char(&dst)[N]) {
-		dst[0] = 0;
-		std::strncat(dst, src, N - 1);
+		std::strncpy(dst, src, N - 1);
+		dst[N - 1] = 0;
 	}
 	template<size_t N>
 	static void CopyWideString(const wchar_t* src, wchar_t(&dst)[N]) {
-		dst[0] = 0;
-		std::wcsncat(dst, src, N - 1);
+		std::wcsncpy(dst, src, N - 1);
+		dst[N - 1] = 0;
 	}
 	template<typename T>
 	static bool CheckUTF8Byte(const T* str, int len) {


### PR DESCRIPTION
Using strncat requires that:

1. src must be null-terminated.
2. dst must be a valid C string (null-terminated and properly initialized).

If src is not null-terminated, or dst contains old data, strncat can cause undefined behavior, like memory corruption or crashes.

Using strncpy is safer:

* It copies a fixed number of characters.
* You can manually add the null terminator.
* It does not depend on the existing content of dst.
