### PR TITLE
add premake --lua-deb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: YGOPro-${{ matrix.os }}
+        name: YGOPro-${{ matrix.os }}-${{ matrix.lua_package }}
         path: |
           bin/release/YGOPro
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,6 +239,10 @@ jobs:
 #          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
+        lua_package:
+          - liblua5.3-dev
+          - liblua5.4-dev
+          - source
         include:
 #          - os: ubuntu-20.04
 #            premake_version: 5.0.0-beta2
@@ -272,6 +276,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libevent-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libsqlite3-dev libxxf86vm-dev libopusfile-dev libvorbis-dev
 
+    - name: Install Lua from APT
+      if: matrix.lua_package != 'source'
+      run: |
+        sudo apt-get install -y ${{ matrix.lua_package }}
+
     - name: Download premake
       id: premake
       uses: mercury233/action-cache-download-file@v1.0.0
@@ -284,13 +293,15 @@ jobs:
         tar xf ${{ steps.premake.outputs.filepath }}
         chmod +x ./premake5
 
-    - name: Download lua
+    - name: Download lua (source)
+      if: matrix.lua_package == 'source'
       id: lua
       uses: mercury233/action-cache-download-file@v1.0.0
       with:
         url: https://www.lua.org/ftp/lua-5.4.7.tar.gz
 
-    - name: Extract lua
+    - name: Extract lua (source)
+      if: matrix.lua_package == 'source'
       run: |
         tar xf ${{ steps.lua.outputs.filepath }}
         mv lua-5.4.7 lua
@@ -311,7 +322,13 @@ jobs:
         cp -r premake/* .
         cp -r resource/* .
 
-    - name: Use premake to generate make files
+    - name: Use premake to generate make files (with apt lua)
+      if: matrix.lua_package != 'source'
+      run: |
+        ./premake5 gmake --lua-deb
+
+    - name: Use premake to generate make files (with source lua)
+      if: matrix.lua_package == 'source'
       run: |
         ./premake5 gmake
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -104,7 +104,7 @@ if GetParam("lua-deb") then
     local lua_versions = { "5.4", "5.3" }
     local lua_version = nil
     for _, version in ipairs(lua_versions) do
-        local lua_lib_dir = os.findlib("lua" .. version)
+        local lua_lib_dir = os.findlib("lua" .. version .. "-c++")
         if lua_lib_dir then
             print("Found lua " .. version .. " at " .. lua_lib_dir)
             lua_version = version

--- a/premake5.lua
+++ b/premake5.lua
@@ -22,6 +22,7 @@ newoption { trigger = "no-build-lua", category = "YGOPro - lua", description = "
 newoption { trigger = "lua-include-dir", category = "YGOPro - lua", description = "", value = "PATH" }
 newoption { trigger = "lua-lib-dir", category = "YGOPro - lua", description = "", value = "PATH" }
 newoption { trigger = "lua-lib-name", category = "YGOPro - lua", description = "", value = "NAME", default = LUA_LIB_NAME }
+newoption { trigger = "lua-deb", category = "YGOPro - lua", description = "Use Debian lua package" }
 
 newoption { trigger = "build-event", category = "YGOPro - event", description = "" }
 newoption { trigger = "no-build-event", category = "YGOPro - event", description = "" }
@@ -96,6 +97,26 @@ if not BUILD_LUA then
     LUA_LIB_NAME = GetParam("lua-lib-name")
     LUA_INCLUDE_DIR = GetParam("lua-include-dir") or os.findheader("lua.h")
     LUA_LIB_DIR = GetParam("lua-lib-dir") or os.findlib(LUA_LIB_NAME)
+end
+
+if GetParam("lua-deb") then
+    BUILD_LUA = false
+    local lua_versions = { "5.4", "5.3" }
+    local lua_version = nil
+    for _, version in ipairs(lua_versions) do
+        local lua_lib_dir = os.findlib("lua" .. version)
+        if lua_lib_dir then
+            print("Found lua " .. version .. " at " .. lua_lib_dir)
+            lua_version = version
+            LUA_LIB_DIR = lua_lib_dir
+            break
+        end
+    end
+    if not lua_version then
+        error("Lua library not found. Please install lua by command 'sudo apt -y install liblua5.4-dev'")
+    end
+    LUA_LIB_NAME = "lua" .. lua_version .. "-c++"
+    LUA_INCLUDE_DIR = path.join("/usr/include", "lua" .. lua_version)
 end
 
 if GetParam("build-event") then


### PR DESCRIPTION
~~The thing existed long ago on server~~

`--lua-deb` is for Debian-based Linux distros, using package `liblua5.4-dev` or `liblua5.3-dev` for Lua. It would use higher version if both exists.

Wiki is updated on `patch-luadeb` branch on `github.com:Fluorohydride/ygopro.wiki.git`