### PR TITLE
cleanup premake links

### DIFF
--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -71,7 +71,7 @@ project "YGOPro"
         entrypoint "mainCRTStartup"
         defines { "_IRR_WCHAR_FILESYSTEM" }
         files "ygopro.rc"
-        links { "opengl32", "ws2_32", "winmm", "gdi32", "kernel32", "user32", "imm32" }
+        links { "ws2_32" }
         if USE_AUDIO and AUDIO_LIB == "irrklang" then
             links { "irrKlang" }
             if IRRKLANG_PRO then
@@ -83,11 +83,10 @@ project "YGOPro"
                 filter {}
             end
         end
-    filter "not system:windows"
-        links { "dl", "pthread" }
+
     filter "system:macosx"
         openmp "Off"
-        links { "z" }
+        links { "OpenGL.framework", "Cocoa.framework", "IOKit.framework" }
         defines { "GL_SILENCE_DEPRECATION" }
         if MAC_ARM then
             linkoptions { "-arch arm64" }
@@ -98,6 +97,7 @@ project "YGOPro"
         if USE_AUDIO and AUDIO_LIB == "irrklang" then
             links { "irrklang" }
         end
+
     filter "system:linux"
         links { "GL", "X11", "Xxf86vm" }
         linkoptions { "-fopenmp" }

--- a/premake/irrlicht/premake5.lua
+++ b/premake/irrlicht/premake5.lua
@@ -161,9 +161,6 @@ project "irrlicht"
             defines { "NO_IRR_COMPILE_WITH_DIRECT3D_9_" }
         end
 
-    filter { "system:linux" }
-        links { "X11", "Xxf86vm" }
-
     filter { "system:macosx" }
         cppdialect "gnu++14"
         defines { "GL_SILENCE_DEPRECATION" }

--- a/premake/miniaudio/premake5.lua
+++ b/premake/miniaudio/premake5.lua
@@ -138,6 +138,3 @@ project "miniaudio"
             includedirs { OPUS_INCLUDE_DIR, OPUSFILE_INCLUDE_DIR, VORBIS_INCLUDE_DIR, OGG_INCLUDE_DIR }
         end
     end
-
-    filter "system:linux"
-        links { "dl", "pthread", "m" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -293,7 +293,6 @@ workspace "YGOPro"
         if MAC_ARM and MAC_INTEL then
             architecture "universal"
         end
-        links { "OpenGL.framework", "Cocoa.framework", "IOKit.framework" }
 
     filter "system:linux"
         buildoptions { "-U_FORTIFY_SOURCE" }


### PR DESCRIPTION
* The `links` directive in Premake applies to a project, not to the workspace.
* Specifying `links` for a static library has no actual effect.
* On Windows, libraries such as `opengl32` and `imm32` are already brought in via `#pragma comment(lib, ...)`.
* On Windows, system libraries like `kernel32` and `user32` are linked automatically by MSVC.
* Starting with [glibc 2.34](https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html), there is no longer any need to link against `libdl` or `libpthread` explicitly.
* `libz` (zlib) is bundled in the source trees of Irrlicht and FreeType, so it does not need to be linked separately.
* `libm` (`math.h`) is a dependency of libstdc++, so it also does not need to be linked explicitly.