### PR TITLE
turn symbols off for release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -460,12 +460,6 @@ jobs:
         make -j 4 config=release
         cd ..
 
-    - name: Strip symbols
-      run: |
-        cd bin/release
-        strip YGOPro
-        cd ../..
-
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/premake5.lua
+++ b/premake5.lua
@@ -328,7 +328,6 @@ workspace "YGOPro"
         disablewarnings { "4244", "4267", "4838", "4996", "6011", "6031", "6054", "6262" }
 
     filter { "configurations:Release", "not action:vs*" }
-        symbols "On"
         defines "NDEBUG"
 
     filter { "configurations:Debug", "action:vs*" }


### PR DESCRIPTION
Added in https://github.com/Fluorohydride/ygopro/blame/551404481a0518d220183938ff422ff5ead1e580/premake4.lua#L40
_I guess it was just for some debug and Fluorohydride forgot to delete it._