### PR TITLE
fix _IRR_STATIC_LIB_

### DIFF
--- a/gframe/CGUITTFont.cpp
+++ b/gframe/CGUITTFont.cpp
@@ -28,6 +28,7 @@
    john@suckerfreegames.com
 */
 
+#define _IRR_STATIC_LIB_
 #include <irrlicht.h>
 #include "CGUITTFont.h"
 


### PR DESCRIPTION
> To build Irrlicht as a static library, you must define `_IRR_STATIC_LIB_` in both the Irrlicht build, *and* in the user application, before #including <irrlicht.h>

Currently, this constant is not added when including <irrlicht.h> in CGUITTFont.cpp, and the `ISceneNode::getMaterial` function used there returns `video::IdentityMaterial`, which is declared as:

```cpp
IRRLICHT_API extern SMaterial IdentityMaterial;
```

The value of `IRRLICHT_API` is related to `_IRR_STATIC_LIB_`.

There may be other similar issues in the project, but they do not affect the compilation.