### PR TITLE
 fix: seeding std::mt19937 with only 1 uint32_t

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -715,7 +715,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_REPLAY: {
-		if (len < 1 + (int)sizeof(ReplayHeader))
+		if (len < 1 + (int)sizeof(ExtendedReplayHeader))
 			return;
 		mainGame->gMutex.lock();
 		mainGame->wPhase->setVisible(false);
@@ -726,10 +726,10 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		Replay new_replay;
 		std::memcpy(&new_replay.pheader, prep, sizeof(new_replay.pheader));
 		time_t starttime;
-		if (new_replay.pheader.flag & REPLAY_UNIFORM)
-			starttime = new_replay.pheader.start_time;
+		if (new_replay.pheader.base.flag & REPLAY_UNIFORM)
+			starttime = new_replay.pheader.base.start_time;
 		else
-			starttime = new_replay.pheader.seed;
+			starttime = new_replay.pheader.base.seed;
 		
 		wchar_t timetext[40];
 		std::wcsftime(timetext, sizeof timetext / sizeof timetext[0], L"%Y-%m-%d %H-%M-%S", std::localtime(&starttime));
@@ -751,9 +751,9 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 			mainGame->WaitFrameSignal(30);
 		}
 		if(mainGame->actionParam || !is_host) {
-			prep += sizeof(ReplayHeader);
-			std::memcpy(new_replay.comp_data, prep, len - sizeof(ReplayHeader) - 1);
-			new_replay.comp_size = len - sizeof(ReplayHeader) - 1;
+			prep += sizeof new_replay.pheader;
+			std::memcpy(new_replay.comp_data, prep, len - sizeof new_replay.pheader - 1);
+			new_replay.comp_size = len - sizeof new_replay.pheader - 1;
 			if(mainGame->actionParam)
 				new_replay.SaveReplay(mainGame->ebRSName->getText());
 			else

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -309,7 +309,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				myswprintf(replay_path, L"./replay/%ls", replay_filename);
 				if (!replay.OpenReplay(replay_path))
 					break;
-				if (replay.pheader.flag & REPLAY_SINGLE_MODE)
+				if (replay.pheader.base.flag & REPLAY_SINGLE_MODE)
 					break;
 				for (size_t i = 0; i < replay.decks.size(); ++i) {
 					BufferIO::CopyWideString(replay.players[Replay::GetDeckPlayer(i)].c_str(), namebuf[i]);
@@ -537,24 +537,25 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				wchar_t infobuf[256]{};
 				std::wstring repinfo;
 				time_t curtime;
-				if(temp_replay.pheader.flag & REPLAY_UNIFORM)
-					curtime = temp_replay.pheader.start_time;
+				const auto& rh = temp_replay.pheader.base;
+				if(temp_replay.pheader.base.flag & REPLAY_UNIFORM)
+					curtime = rh.start_time;
 				else{
-					curtime = temp_replay.pheader.seed;
+					curtime = rh.seed;
 					wchar_t version_info[256]{};
-					myswprintf(version_info, L"version 0x%X\n", temp_replay.pheader.version);
+					myswprintf(version_info, L"version 0x%X\n", rh.version);
 					repinfo.append(version_info);
 				}
 				std::wcsftime(infobuf, sizeof infobuf / sizeof infobuf[0], L"%Y/%m/%d %H:%M:%S\n", std::localtime(&curtime));
 				repinfo.append(infobuf);
-				if (temp_replay.pheader.flag & REPLAY_SINGLE_MODE) {
+				if (rh.flag & REPLAY_SINGLE_MODE) {
 					wchar_t path[256]{};
 					BufferIO::DecodeUTF8(temp_replay.script_name.c_str(), path);
 					repinfo.append(path);
 					repinfo.append(L"\n");
 				}
 				const auto& player_names = temp_replay.players;
-				if(temp_replay.pheader.flag & REPLAY_TAG)
+				if(rh.flag & REPLAY_TAG)
 					myswprintf(infobuf, L"%ls\n%ls\n===VS===\n%ls\n%ls\n", player_names[0].c_str(), player_names[1].c_str(), player_names[2].c_str(), player_names[3].c_str());
 				else
 					myswprintf(infobuf, L"%ls\n===VS===\n%ls\n", player_names[0].c_str(), player_names[1].c_str());

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -292,7 +292,7 @@ public:
 #define STOC_LEAVE_GAME		0x14	// reserved
 #define STOC_DUEL_START		0x15	// no data
 #define STOC_DUEL_END		0x16	// no data
-#define STOC_REPLAY			0x17	// ReplayHeader + byte array
+#define STOC_REPLAY			0x17	// ExtendedReplayHeader + byte array
 #define STOC_TIME_LIMIT		0x18	// STOC_TimeLimit
 #define STOC_CHAT			0x19	// uint16_t + uint16_t array
 #define STOC_HS_PLAYER_ENTER	0x20	// STOC_HS_PlayerEnter

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -32,7 +32,7 @@ void Replay::BeginRecord() {
 	Reset();
 	is_recording = true;
 }
-void Replay::WriteHeader(ReplayHeader& header) {
+void Replay::WriteHeader(ExtendedReplayHeader& header) {
 	pheader = header;
 #ifdef _WIN32
 	DWORD size;
@@ -77,11 +77,11 @@ void Replay::EndRecord() {
 #else
 	std::fclose(fp);
 #endif
-	pheader.datasize = replay_size;
-	pheader.flag |= REPLAY_COMPRESSED;
+	pheader.base.datasize = replay_size;
+	pheader.base.flag |= REPLAY_COMPRESSED;
 	size_t propsize = 5;
 	comp_size = MAX_COMP_SIZE;
-	int ret = LzmaCompress(comp_data, &comp_size, replay_data, replay_size, pheader.props, &propsize, 5, 0x1U << 24, 3, 0, 2, 32, 1);
+	int ret = LzmaCompress(comp_data, &comp_size, replay_data, replay_size, pheader.base.props, &propsize, 5, 0x1U << 24, 3, 0, 2, 32, 1);
 	if (ret != SZ_OK) {
 		std::memcpy(comp_data, &ret, sizeof ret);
 		comp_size = sizeof ret;
@@ -112,27 +112,31 @@ bool Replay::OpenReplay(const wchar_t* name) {
 
 	Reset();
 	bool correct_header = true;
-	if (std::fread(&pheader, sizeof pheader, 1, rfp) < 1)
+	if (std::fread(&pheader, sizeof pheader.base, 1, rfp) < 1)
 		correct_header = false;
-	else if (pheader.id != 0x31707279)
+	else if (pheader.base.id != REPLAY_ID_YRP1 && pheader.base.id != REPLAY_ID_YRP2)
 		correct_header = false;
-	else if (pheader.version < 0x12d0u)
+	else if (pheader.base.version < 0x12d0u)
 		correct_header = false;
-	else if (pheader.version >= 0x1353u && !(pheader.flag & REPLAY_UNIFORM))
+	else if (pheader.base.version >= 0x1353u && !(pheader.base.flag & REPLAY_UNIFORM))
 		correct_header = false;
 	if (!correct_header) {
 		std::fclose(rfp);
 		return false;
 	}
-	if(pheader.flag & REPLAY_COMPRESSED) {
+	if (pheader.base.id == REPLAY_ID_YRP2 && std::fread(&pheader.seed_sequence, sizeof pheader.seed_sequence, 1, rfp) < 1) {
+		std::fclose(rfp);
+		return false;
+	}
+	if(pheader.base.flag & REPLAY_COMPRESSED) {
 		comp_size = std::fread(comp_data, 1, MAX_COMP_SIZE, rfp);
 		std::fclose(rfp);
-		if (pheader.datasize > MAX_REPLAY_SIZE)
+		if (pheader.base.datasize > MAX_REPLAY_SIZE)
 			return false;
-		replay_size = pheader.datasize;
-		if (LzmaUncompress(replay_data, &replay_size, comp_data, &comp_size, pheader.props, 5) != SZ_OK)
+		replay_size = pheader.base.datasize;
+		if (LzmaUncompress(replay_data, &replay_size, comp_data, &comp_size, pheader.base.props, 5) != SZ_OK)
 			return false;
-		if (replay_size != pheader.datasize) {
+		if (replay_size != pheader.base.datasize) {
 			replay_size = 0;
 			return false;
 		}
@@ -189,7 +193,7 @@ bool Replay::ReadName(wchar_t* data) {
 	BufferIO::CopyWStr(buffer, data, 20);
 	return true;
 }
-void Replay::ReadHeader(ReplayHeader& header) {
+void Replay::ReadHeader(ExtendedReplayHeader& header) {
 	header = pheader;
 }
 bool Replay::ReadData(void* data, size_t length) {
@@ -232,7 +236,7 @@ bool Replay::IsReplaying() const {
 	return is_replaying;
 }
 bool Replay::ReadInfo() {
-	int player_count = (pheader.flag & REPLAY_TAG) ? 4 : 2;
+	int player_count = (pheader.base.flag & REPLAY_TAG) ? 4 : 2;
 	for (int i = 0; i < player_count; ++i) {
 		wchar_t name[20]{};
 		if (!ReadName(name))
@@ -241,11 +245,11 @@ bool Replay::ReadInfo() {
 	}
 	if (!ReadData(&params, sizeof params))
 		return false;
-	bool is_tag1 = pheader.flag & REPLAY_TAG;
+	bool is_tag1 = pheader.base.flag & REPLAY_TAG;
 	bool is_tag2 = params.duel_flag & DUEL_TAG_MODE;
 	if (is_tag1 != is_tag2)
 		return false;
-	if (pheader.flag & REPLAY_SINGLE_MODE) {
+	if (pheader.base.flag & REPLAY_SINGLE_MODE) {
 		uint16_t slen = Read<uint16_t>();
 		char filename[256]{};
 		if (slen == 0 || slen > sizeof(filename) - 1)

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -33,6 +33,10 @@ struct ReplayHeader {
 struct ExtendedReplayHeader {
 	ReplayHeader base;
 	uint32_t seed_sequence[SEED_COUNT]{};
+	uint32_t header_version{ 1 };
+	uint32_t value1{};
+	uint32_t value2{};
+	uint32_t value3{};
 };
 
 struct DuelParameters {

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -13,6 +13,9 @@ namespace ygo {
 #define REPLAY_SINGLE_MODE	0x8
 #define REPLAY_UNIFORM		0x10
 
+#define REPLAY_ID_YRP1	0x31707279
+#define REPLAY_ID_YRP2	0x32707279
+
 // max size
 constexpr int MAX_REPLAY_SIZE = 0x80000;
 constexpr int MAX_COMP_SIZE = UINT16_MAX + 1;
@@ -25,6 +28,11 @@ struct ReplayHeader {
 	uint32_t datasize{};
 	uint32_t start_time{};
 	uint8_t props[8]{};
+};
+
+struct ExtendedReplayHeader {
+	ReplayHeader base;
+	uint32_t seed_sequence[SEED_COUNT]{};
 };
 
 struct DuelParameters {
@@ -41,7 +49,7 @@ public:
 
 	// record
 	void BeginRecord();
-	void WriteHeader(ReplayHeader& header);
+	void WriteHeader(ExtendedReplayHeader& header);
 	void WriteData(const void* data, size_t length, bool flush = true);
 	template<typename T>
 	void Write(T data, bool flush = true) {
@@ -68,7 +76,7 @@ public:
 	bool OpenReplay(const wchar_t* name);
 	bool ReadNextResponse(unsigned char resp[]);
 	bool ReadName(wchar_t* data);
-	void ReadHeader(ReplayHeader& header);
+	void ReadHeader(ExtendedReplayHeader& header);
 	bool ReadData(void* data, size_t length);
 	template<typename T>
 	T Read() {
@@ -87,7 +95,7 @@ public:
 	HANDLE recording_fp{ nullptr };
 #endif
 
-	ReplayHeader pheader;
+	ExtendedReplayHeader pheader;
 	unsigned char* comp_data;
 	size_t comp_size{};
 

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -411,15 +411,14 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	}
 	dp->state = CTOS_RESPONSE;
 	std::random_device rd;
-	unsigned int seed = rd();
-	mt19937 rnd((uint_fast32_t)seed);
-	auto duel_seed = rnd.rand();
-	ReplayHeader rh;
-	rh.id = 0x31707279;
-	rh.version = PRO_VERSION;
-	rh.flag = REPLAY_UNIFORM;
-	rh.seed = seed;
-	rh.start_time = (unsigned int)std::time(nullptr);
+	ExtendedReplayHeader rh;
+	rh.base.id = REPLAY_ID_YRP2;
+	rh.base.version = PRO_VERSION;
+	rh.base.flag = REPLAY_UNIFORM;
+	rh.base.start_time = (uint32_t)std::time(nullptr);
+	for (auto& x : rh.seed_sequence)
+		x = rd();
+	mt19937 rnd(rh.seed_sequence, SEED_COUNT);
 	last_replay.BeginRecord();
 	last_replay.WriteHeader(rh);
 	last_replay.WriteData(players[0]->name, 40, false);
@@ -433,7 +432,7 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	set_script_reader(DataManager::ScriptReaderEx);
 	set_card_reader(DataManager::CardReader);
 	set_message_handler(SingleDuel::MessageHandler);
-	pduel = create_duel(duel_seed);
+	pduel = create_duel_v2(rh.seed_sequence);
 	set_player_info(pduel, 0, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	set_player_info(pduel, 1, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	unsigned int opt = (unsigned int)host_info.duel_rule << 16;
@@ -1426,10 +1425,10 @@ void SingleDuel::EndDuel() {
 		return;
 	last_replay.EndRecord();
 	char replaybuf[0x2000], *pbuf = replaybuf;
-	std::memcpy(pbuf, &last_replay.pheader, sizeof(ReplayHeader));
-	pbuf += sizeof(ReplayHeader);
+	std::memcpy(pbuf, &last_replay.pheader, sizeof last_replay.pheader);
+	pbuf += sizeof last_replay.pheader;
 	std::memcpy(pbuf, last_replay.comp_data, last_replay.comp_size);
-	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replaybuf, sizeof(ReplayHeader) + last_replay.comp_size);
+	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replaybuf, sizeof last_replay.pheader + last_replay.comp_size);
 	NetServer::ReSendToPlayer(players[1]);
 	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 		NetServer::ReSendToPlayer(*oit);


### PR DESCRIPTION
Require
https://github.com/Fluorohydride/ygopro-core/pull/760

# mersenne_twister_engine
C++14
26.5.3.2 Class template mersenne_twister_engine
```cpp
template<class UIntType, size_t w, size_t n, size_t m, size_t r,
UIntType a, size_t u, UIntType d, size_t s,
UIntType b, size_t t,
UIntType c, size_t l, UIntType f>
class mersenne_twister_engine {
  // engine characteristics
  static constexpr size_t word_size = w;
  static constexpr size_t state_size = n;
  static constexpr size_t shift_size = m;
  static constexpr size_t mask_bits = r;
  static constexpr UIntType xor_mask = a;
  static constexpr size_t tempering_u = u;
  static constexpr UIntType tempering_d = d;
  static constexpr size_t tempering_s = s;
  static constexpr UIntType tempering_b = b;
  static constexpr size_t tempering_t = t;
  static constexpr UIntType tempering_c = c;
  static constexpr size_t tempering_l = l;
  static constexpr UIntType initialization_multiplier = f;
  static constexpr result_type min() { return 0; }
  static constexpr result_type max() { return 2**w − 1; }
  static constexpr result_type default_seed = 5489u;

  // constructors and seeding functions
  explicit mersenne_twister_engine(result_type value = default_seed);
  template<class Sseq> explicit mersenne_twister_engine(Sseq& q);

  void seed(result_type value = default_seed);
  template<class Sseq> void seed(Sseq& q);

  // generating functions
  result_type operator()();
  void discard(unsigned long long z);
}
```
```cpp
typedef mersenne_twister_engine<uint_fast32_t,32,624,397,31,
0x9908b0df,11,0xffffffff,7,0x9d2c5680,15,0xefc60000,18,1812433253>
mt19937;
```
mt19937:
w=32, n=624


![mt19937](https://github.com/user-attachments/assets/ff93b6ed-5fe5-4b10-b56a-bc216051c1d5)


# Constructor
The state xi of a mersenne_twister_engine object x is of size n and consists of a sequence X of n values of the type delivered by x; all subscripts applied to X are to be taken modulo n. 
```cpp
explicit mersenne_twister_engine(result_type value = default_seed);
```
Briefly speaking, set X0 to `value` and calculate other initial states from X0.

```cpp
template<class Sseq> explicit mersenne_twister_engine(Sseq& q);
```
Briefly speaking, set X0~X_n-1 by `q.generate(a, a+n)`.

# Problem
If we initial `std::mt19937` with only 1 uint32_t value, the initial states has only 2^32=4,294,967,296 (about 4e9) combinations.
This is a very small sample space, so one can check every initial states in hours.
如果我們只使用 1 個 uint32_t 值初始化 `std::mt19937`，則初始狀態只有 2^32=4,294,967,296（約 4e9）種組合。
這是一個非常小的樣本空間，因此可以在幾個小時內檢查所有初始狀態。


Example:
deck[40]
The deck before shuffling.
1 critical card, `Branded Fusion`

for seed=0~0x000F'FFFF (1048576 numbers)
(1/4096 of the sample space)
Consider the top 5 cards after shuffling
```
Position 0: 130803
Position 1: 131526
Position 2: 131147
Position 3: 131613
Position 4: 131136
Position 5: 130170
Position 6: 131365
Position 7: 131196
Position 8: 130545
Position 9: 131174
Position 10: 131352
Position 11: 130985
Position 12: 130877
Position 13: 131120
Position 14: 131338
Position 15: 130480
Position 16: 131239
Position 17: 130923
Position 18: 131134
Position 19: 131362
Position 20: 130861
Position 21: 130787
Position 22: 130850
Position 23: 131349
Position 24: 130953
Position 25: 130699
Position 26: 131340
Position 27: 130346
Position 28: 131510
Position 29: 130945
Position 30: 131442
Position 31: 131368
Position 32: 131291
Position 33: 131363
Position 34: 130981
Position 35: 130823
Position 36: 131152
Position 37: 131329
Position 38: 131158
Position 39: 130848
Max: 131613, Min: 130170
Difference: 1443
```

success: appearing in the top 5 cards after shuffling
In 1048576 experiments:
deck[0]: 130803 success
deck[1]: 131526 success
...

The number is very close to 1048576/8=131072
So the PRNG and shuffling algorithm are fine.

But when I have this table, I clearly know that:
**If the seed is in 0~0x000f'ffff, putting `Branded Fusion` at deck[3] will increase the probability of drawing it in the first turn.**

This conclusion can be easily extended to 0~0xffff'ffff .
In other word, the sequence after shuffling can be manipulated to some extent.
----
這個數字非常接近 1048576/8=131072
所以 PRNG 和洗牌演算法都沒問題。

但是當我有這張表的時候，我清楚地知道：
**如果種子在 0~0x000f'ffff 之間，那麼將「Branded Fusion」放在 deck[3] 會增加第1回合抽到它的機率。**

這個結論可以很容易地擴展到 0~0xffff'ffff 之間。
換句話說，洗牌後的序列可以在一定程度上被操縱。

# Solution
Now we use 8 uint32_t number to generate `std::seed_seq`, and `std::mt19937` is initialized from `std::seed_seq`.
There are 2^256 (1.1579209e+77) initial states now.
Checking all initial states is not possible anymore.

現在我們使用 8 個 uint32_t 類型數字來產生 `std::seed_seq`，並且 `std::mt19937` 由 `std::seed_seq` 初始化。
現在共有 2^256 (1.1579209e+77) 個初始狀態。
現在無法再檢查所有初始狀態。


@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust

