### PR TITLE
add config for image load background thread and multi thread

### DIFF
--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1262,12 +1262,8 @@ void Game::DrawDeckBd() {
 		driver->draw2DRectangle(Resize(805, 160, 1020, 630), 0x400000ff, 0x400000ff, 0x40000000, 0x40000000);
 		driver->draw2DRectangleOutline(Resize(804, 159, 1020, 630));
 	}
-#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
-	constexpr int MAX_RESULT = 9;
-#else
-	constexpr int MAX_RESULT = 7;
-#endif
-	for(int i = 0; i < MAX_RESULT && i + scrFilter->getPos() < (int)deckBuilder.results.size(); ++i) {
+	int max_result = mainGame->gameConf.use_image_load_background_thread ? 9 : 7;
+	for(int i = 0; i < max_result && i + scrFilter->getPos() < (int)deckBuilder.results.size(); ++i) {
 		code_pointer ptr = deckBuilder.results[i + scrFilter->getPos()];
 		if(i >= 7)
 		{

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1326,6 +1326,8 @@ void Game::LoadConfig() {
 			gameConf.use_d3d = std::strtol(valbuf, nullptr, 10) > 0;
 		} else if(!std::strcmp(strbuf, "use_image_scale")) {
 			gameConf.use_image_scale = std::strtol(valbuf, nullptr, 10) > 0;
+		} else if (!std::strcmp(strbuf, "use_image_scale_multi_thread")) {
+			gameConf.use_image_scale_multi_thread = std::strtol(valbuf, nullptr, 10) > 0;
 		} else if (!std::strcmp(strbuf, "use_image_load_background_thread")) {
 			gameConf.use_image_load_background_thread = std::strtol(valbuf, nullptr, 10) > 0;
 		} else if(!std::strcmp(strbuf, "errorlog")) {
@@ -1459,6 +1461,7 @@ void Game::SaveConfig() {
 	char linebuf[CONFIG_LINE_SIZE];
 	std::fprintf(fp, "use_d3d = %d\n", gameConf.use_d3d ? 1 : 0);
 	std::fprintf(fp, "use_image_scale = %d\n", gameConf.use_image_scale ? 1 : 0);
+	std::fprintf(fp, "use_image_scale_multi_thread = %d\n", gameConf.use_image_scale_multi_thread ? 1 : 0);
 	std::fprintf(fp, "use_image_load_background_thread = %d\n", gameConf.use_image_load_background_thread ? 1 : 0);
 	std::fprintf(fp, "antialias = %d\n", gameConf.antialias);
 	std::fprintf(fp, "errorlog = %u\n", enable_log);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1459,6 +1459,7 @@ void Game::SaveConfig() {
 	char linebuf[CONFIG_LINE_SIZE];
 	std::fprintf(fp, "use_d3d = %d\n", gameConf.use_d3d ? 1 : 0);
 	std::fprintf(fp, "use_image_scale = %d\n", gameConf.use_image_scale ? 1 : 0);
+	std::fprintf(fp, "use_image_load_background_thread = %d\n", gameConf.use_image_load_background_thread ? 1 : 0);
 	std::fprintf(fp, "antialias = %d\n", gameConf.antialias);
 	std::fprintf(fp, "errorlog = %u\n", enable_log);
 	BufferIO::CopyWideString(ebNickName->getText(), gameConf.nickname);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1326,6 +1326,8 @@ void Game::LoadConfig() {
 			gameConf.use_d3d = std::strtol(valbuf, nullptr, 10) > 0;
 		} else if(!std::strcmp(strbuf, "use_image_scale")) {
 			gameConf.use_image_scale = std::strtol(valbuf, nullptr, 10) > 0;
+		} else if (!std::strcmp(strbuf, "use_image_load_background_thread")) {
+			gameConf.use_image_load_background_thread = std::strtol(valbuf, nullptr, 10) > 0;
 		} else if(!std::strcmp(strbuf, "errorlog")) {
 			unsigned int val = std::strtol(valbuf, nullptr, 10);
 			enable_log = val & 0xff;

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -49,6 +49,7 @@ bool IsExtension(const char* filename, const char(&extension)[N]) {
 struct Config {
 	bool use_d3d{ false };
 	bool use_image_scale{ true };
+	bool use_image_load_background_thread{ false };
 	unsigned short antialias{ 0 };
 	unsigned short serverport{ 7911 };
 	unsigned char textfontsize{ 14 };

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -50,7 +50,11 @@ struct Config {
 	bool use_d3d{ false };
 	bool use_image_scale{ true };
 	bool use_image_scale_multi_thread{ true };
+#ifdef _OPENMP
 	bool use_image_load_background_thread{ false };
+#else
+	bool use_image_load_background_thread{ true };
+#endif
 	unsigned short antialias{ 0 };
 	unsigned short serverport{ 7911 };
 	unsigned char textfontsize{ 14 };

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -49,6 +49,7 @@ bool IsExtension(const char* filename, const char(&extension)[N]) {
 struct Config {
 	bool use_d3d{ false };
 	bool use_image_scale{ true };
+	bool use_image_scale_multi_thread{ true };
 	bool use_image_load_background_thread{ false };
 	unsigned short antialias{ 0 };
 	unsigned short serverport{ 7911 };

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -138,7 +138,7 @@ void imageScaleNNAA(irr::video::IImage *src, irr::video::IImage *dest) {
 	const double rx = (double)srcDim.Width / destDim.Width;
 	const double ry = (double)srcDim.Height / destDim.Height;
 
-#pragma omp parallel
+#pragma omp parallel if(mainGame->gameConf.use_image_scale_multi_thread)
 {
 	double sx, sy, minsx, maxsx, minsy, maxsy, area, ra, ga, ba, aa, pw, ph, pa;
 	irr::video::SColor pxl, npxl;

--- a/gframe/image_manager.h
+++ b/gframe/image_manager.h
@@ -1,17 +1,11 @@
 #ifndef IMAGEMANAGER_H
 #define IMAGEMANAGER_H
 
-#ifndef _OPENMP
-#define YGOPRO_USE_THUMB_LOAD_THREAD
-#endif
-
 #include "config.h"
 #include "data_manager.h"
 #include <unordered_map>
-#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 #include <queue>
 #include <mutex>
-#endif
 
 namespace ygo {
 
@@ -27,19 +21,15 @@ public:
 	irr::video::ITexture* GetBigPicture(int code, float zoom);
 	irr::video::ITexture* GetTextureThumb(int code);
 	irr::video::ITexture* GetTextureField(int code);
-#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 	static int LoadThumbThread();
-#endif
 
 	std::unordered_map<int, irr::video::ITexture*> tMap[2];
 	std::unordered_map<int, irr::video::ITexture*> tThumb;
 	std::unordered_map<int, irr::video::ITexture*> tFields;
-#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 	std::unordered_map<int, irr::video::IImage*> tThumbLoading;
 	std::queue<int> tThumbLoadingCodes;
 	std::mutex tThumbLoadingMutex;
 	bool tThumbLoadingThreadRunning;
-#endif
 	irr::IrrlichtDevice* device;
 	irr::video::IVideoDriver* driver;
 	irr::video::ITexture* tCover[4];
@@ -47,9 +37,7 @@ public:
 	irr::video::ITexture* tUnknownFit;
 	irr::video::ITexture* tUnknownThumb;
 	irr::video::ITexture* tBigPicture;
-#ifdef YGOPRO_USE_THUMB_LOAD_THREAD
 	irr::video::ITexture* tLoading;
-#endif
 	irr::video::ITexture* tAct;
 	irr::video::ITexture* tAttack;
 	irr::video::ITexture* tNegated;


### PR DESCRIPTION
* Some users have very slow CPUs or hard drives, and loading images on the main thread can cause noticeable stuttering. They may prefer to revert to the previous method, which loads images in a separate thread, even if it means giving up the optimization that hides the loading process.
* A very small number of users have experienced issues such as crashes or blue screens when using OpenMP. These users may try disabling OpenMP as a workaround.
