### PR TITLE
add back link pthread

### DIFF
--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -103,7 +103,7 @@ project "YGOPro"
         end
 
     filter "system:linux"
-        links { "GL", "X11", "Xxf86vm" }
+        links { "GL", "X11", "Xxf86vm", "dl", "pthread" }
         linkoptions { "-fopenmp" }
         if USE_AUDIO and AUDIO_LIB == "irrklang" then
             links { "IrrKlang" }


### PR DESCRIPTION
removed in https://github.com/Fluorohydride/ygopro/pull/2815

Some Linux distributions still support glibc versions earlier than 2.34, so we should support them as well.

As of now, linking to pthread on glibc 2.34 and later doesn't appear to have any side effects. It may take a few more years before glibc stops providing an empty libpthread.
