### PR TITLE
add CTOS_EXTERNAL_ADDRESS

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -118,9 +118,13 @@ void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 	if (events & BEV_EVENT_CONNECTED) {
 		bool create_game = (intptr_t)ctx;
 		if(!create_game) {
-			uint16_t msgbuf[LEN_HOSTNAME];
-			int len = BufferIO::CopyCharArray(mainGame->ebJoinHost->getText(), msgbuf);
-			DuelClient::SendBufferToServer(CTOS_HOSTNAME, msgbuf, (len + 1) * sizeof(uint16_t));
+			uint16_t hostname_buf[LEN_HOSTNAME];
+			auto hostname_len = BufferIO::CopyCharArray(mainGame->ebJoinHost->getText(), hostname_buf);
+			auto hostname_msglen = (hostname_len + 1) * sizeof(uint16_t);
+			char buf[LEN_HOSTNAME * sizeof(int16_t) + sizeof(uint32_t)];
+			memset(buf, 0, sizeof(uint32_t));
+			memcpy(buf + sizeof(uint32_t), hostname_buf, hostname_msglen);
+			DuelClient::SendBufferToServer(CTOS_EXTERNAL_ADDRESS, buf, hostname_msglen + sizeof(uint32_t));
 		}
 		CTOS_PlayerInfo cspi;
 		BufferIO::CopyCharArray(mainGame->ebNickName->getText(), cspi.name);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -122,7 +122,7 @@ void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 			uint16_t hostname_buf[LEN_HOSTNAME];
 			auto hostname_len = BufferIO::CopyCharArray(mainGame->ebJoinHost->getText(), hostname_buf);
 			auto hostname_msglen = (hostname_len + 1) * sizeof(uint16_t);
-			char buf[LEN_HOSTNAME * sizeof(int16_t) + sizeof(uint32_t)];
+			char buf[LEN_HOSTNAME * sizeof(uint16_t) + sizeof(uint32_t)];
 			memset(buf, 0, sizeof(uint32_t)); // real_ip
 			memcpy(buf + sizeof(uint32_t), hostname_buf, hostname_msglen);
 			SendBufferToServer(CTOS_EXTERNAL_ADDRESS, buf, hostname_msglen + sizeof(uint32_t));

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -123,9 +123,9 @@ void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 			auto hostname_len = BufferIO::CopyCharArray(mainGame->ebJoinHost->getText(), hostname_buf);
 			auto hostname_msglen = (hostname_len + 1) * sizeof(uint16_t);
 			char buf[LEN_HOSTNAME * sizeof(int16_t) + sizeof(uint32_t)];
-			memset(buf, 0, sizeof(uint32_t));
+			memset(buf, 0, sizeof(uint32_t)); // real_ip
 			memcpy(buf + sizeof(uint32_t), hostname_buf, hostname_msglen);
-			DuelClient::SendBufferToServer(CTOS_EXTERNAL_ADDRESS, buf, hostname_msglen + sizeof(uint32_t));
+			SendBufferToServer(CTOS_EXTERNAL_ADDRESS, buf, hostname_msglen + sizeof(uint32_t));
 		}
 		CTOS_PlayerInfo cspi;
 		BufferIO::CopyCharArray(mainGame->ebNickName->getText(), cspi.name);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -117,6 +117,11 @@ void DuelClient::ClientRead(bufferevent* bev, void* ctx) {
 void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 	if (events & BEV_EVENT_CONNECTED) {
 		bool create_game = (intptr_t)ctx;
+		if(!create_game) {
+			uint16_t msgbuf[LEN_HOSTNAME];
+			int len = BufferIO::CopyCharArray(mainGame->ebJoinHost->getText(), msgbuf);
+			DuelClient::SendBufferToServer(CTOS_HOSTNAME, msgbuf, (len + 1) * sizeof(uint16_t));
+		}
 		CTOS_PlayerInfo cspi;
 		BufferIO::CopyCharArray(mainGame->ebNickName->getText(), cspi.name);
 		SendPacketToServer(CTOS_PLAYER_INFO, cspi);

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -257,7 +257,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 		// for other server & reverse proxy use only
 		/*
 		wchar_t hostname[LEN_HOSTNAME];
-		uint32_t real_ip = BufferIO::ReadInt32(pdata);
+		uint32_t real_ip = ntohl(BufferIO::ReadInt32(pdata));
 		BufferIO::CopyCharArray((uint16_t*)pdata, hostname);
 		*/
 		break;

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -253,8 +253,13 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 		BufferIO::CopyCharArray(pkt->name, dp->name);
 		break;
 	}
-	case CTOS_HOSTNAME: {
-		// for other server impl use only
+	case CTOS_EXTERNAL_ADDRESS: {
+		// for other server & reverse proxy use only
+		/*
+		wchar_t hostname[LEN_HOSTNAME];
+		uint32_t real_ip = BufferIO::ReadInt32(pdata);
+		BufferIO::CopyCharArray((uint16_t*)pdata, hostname);
+		*/
 		break;
 	}
 	case CTOS_CREATE_GAME: {

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -253,6 +253,10 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 		BufferIO::CopyCharArray(pkt->name, dp->name);
 		break;
 	}
+	case CTOS_HOSTNAME: {
+		// for other server impl use only
+		break;
+	}
 	case CTOS_CREATE_GAME: {
 		if(dp->game || duel_mode)
 			return;

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -105,7 +105,7 @@ static_assert(sizeof(CTOS_Kick) == 1, "size mismatch: CTOS_Kick");
 
 /*
 * CTOS_ExternalAddress
-* uint32_t real_ip; (IPv4 address)
+* uint32_t real_ip; (IPv4 address, BE)
 * uint16_t hostname[256]; (UTF-16 string)
 */
 

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -164,6 +164,13 @@ constexpr int LEN_CHAT_PLAYER = 1;
 constexpr int LEN_CHAT_MSG = 256;
 constexpr int SIZE_STOC_CHAT = (LEN_CHAT_PLAYER + LEN_CHAT_MSG) * sizeof(uint16_t);
 
+/*
+* STOC_HOSTNAME
+* uint16_t hostname[256]; (UTF-16 string)
+*/
+
+constexpr int LEN_HOSTNAME = 256;
+
 struct STOC_HS_PlayerEnter {
 	uint16_t name[20]{};
 	uint8_t pos{};
@@ -269,6 +276,7 @@ public:
 #define CTOS_SURRENDER		0x14	// no data
 #define CTOS_TIME_CONFIRM	0x15	// no data
 #define CTOS_CHAT			0x16	// uint16_t array
+#define CTOS_HOSTNAME	0x17	// uint16_t array
 #define CTOS_HS_TODUELIST	0x20	// no data
 #define CTOS_HS_TOOBSERVER	0x21	// no data
 #define CTOS_HS_READY		0x22	// no data

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -103,6 +103,14 @@ struct CTOS_Kick {
 check_trivially_copyable(CTOS_Kick);
 static_assert(sizeof(CTOS_Kick) == 1, "size mismatch: CTOS_Kick");
 
+/*
+* CTOS_ExternalAddress
+* uint32_t real_ip; (IPv4 address)
+* uint16_t hostname[256]; (UTF-16 string)
+*/
+
+constexpr int LEN_HOSTNAME = 256;
+
 // STOC
 struct STOC_ErrorMsg {
 	uint8_t msg{};
@@ -163,13 +171,6 @@ static_assert(sizeof(STOC_TimeLimit) == 4, "size mismatch: STOC_TimeLimit");
 constexpr int LEN_CHAT_PLAYER = 1;
 constexpr int LEN_CHAT_MSG = 256;
 constexpr int SIZE_STOC_CHAT = (LEN_CHAT_PLAYER + LEN_CHAT_MSG) * sizeof(uint16_t);
-
-/*
-* STOC_HOSTNAME
-* uint16_t hostname[256]; (UTF-16 string)
-*/
-
-constexpr int LEN_HOSTNAME = 256;
 
 struct STOC_HS_PlayerEnter {
 	uint16_t name[20]{};
@@ -276,7 +277,7 @@ public:
 #define CTOS_SURRENDER		0x14	// no data
 #define CTOS_TIME_CONFIRM	0x15	// no data
 #define CTOS_CHAT			0x16	// uint16_t array
-#define CTOS_HOSTNAME	0x17	// uint16_t array
+#define CTOS_EXTERNAL_ADDRESS	0x17	// CTOS_ExternalAddress
 #define CTOS_HS_TODUELIST	0x20	// no data
 #define CTOS_HS_TOOBSERVER	0x21	// no data
 #define CTOS_HS_READY		0x22	// no data

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -105,7 +105,7 @@ static_assert(sizeof(CTOS_Kick) == 1, "size mismatch: CTOS_Kick");
 
 /*
 * CTOS_ExternalAddress
-* uint32_t real_ip; (IPv4 address, BE)
+* uint32_t real_ip; (IPv4 address, BE, alway 0 in normal client)
 * uint16_t hostname[256]; (UTF-16 string)
 */
 


### PR DESCRIPTION
```cpp
/*
* CTOS_ExternalAddress
* uint32_t real_ip; (IPv4 address)
* uint16_t hostname[256]; (UTF-16 string)
*/
```

Identical to the `Host` and `X-Forwarded-For` header in HTTP.

Not used in YGOPro itself, but useful in some reverse proxy or something like `nginx` or `bungeecord` to route YGOPro traffic.