### PR TITLE
use function template

### DIFF
--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -10,9 +10,6 @@ public:
 	static int32_t ReadInt32(unsigned char*& p) {
 		return buffer_read<int32_t>(p);
 	}
-	static uint8_t ReadUInt8(unsigned char*& p) {
-		return buffer_read<uint8_t>(p);
-	}
 	static void WriteInt32(unsigned char*& p, int32_t val) {
 		buffer_write<int32_t>(p, val);
 	}
@@ -23,6 +20,9 @@ public:
 	}
 	static char ReadInt8(unsigned char*& p) {
 		return buffer_read<char>(p);
+	}
+	static unsigned char ReadUInt8(unsigned char*& p) {
+		return buffer_read<unsigned char>(p);
 	}
 	static void WriteInt16(unsigned char*& p, short val) {
 		buffer_write<int16_t>(p, val);

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -7,20 +7,31 @@
 
 class BufferIO {
 public:
-	static int ReadInt32(unsigned char*& p) {
+	static int32_t ReadInt32(unsigned char*& p) {
 		return buffer_read<int32_t>(p);
 	}
+	static uint16_t ReadUInt16(unsigned char*& p) {
+		return buffer_read<uint16_t>(p);
+	}
+	static uint8_t ReadUInt8(unsigned char*& p) {
+		return buffer_read<uint8_t>(p);
+	}
+	static void WriteInt32(unsigned char*& p, int32_t val) {
+		buffer_write<int32_t>(p, val);
+	}
+	static void WriteUInt16(unsigned char*& p, uint16_t val) {
+		buffer_write<uint16_t>(p, val);
+	}
+	static void WriteUInt8(unsigned char*& p, uint8_t val) {
+		buffer_write<uint8_t>(p, val);
+	}
+
+	// for compatibility
 	static short ReadInt16(unsigned char*& p) {
 		return buffer_read<int16_t>(p);
 	}
 	static char ReadInt8(unsigned char*& p) {
 		return buffer_read<char>(p);
-	}
-	static unsigned char ReadUInt8(unsigned char*& p) {
-		return buffer_read<unsigned char>(p);
-	}
-	static void WriteInt32(unsigned char*& p, int val) {
-		buffer_write<int32_t>(p, val);
 	}
 	static void WriteInt16(unsigned char*& p, short val) {
 		buffer_write<int16_t>(p, val);

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -16,9 +16,6 @@ public:
 	static void WriteInt32(unsigned char*& p, int32_t val) {
 		buffer_write<int32_t>(p, val);
 	}
-	static void WriteUInt8(unsigned char*& p, uint8_t val) {
-		buffer_write<uint8_t>(p, val);
-	}
 
 	// for compatibility
 	static short ReadInt16(unsigned char*& p) {

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -27,18 +27,23 @@ public:
 	}
 
 	// for compatibility
+	[[deprecated]]
 	static short ReadInt16(unsigned char*& p) {
 		return Read<int16_t>(p);
 	}
+	[[deprecated]]
 	static char ReadInt8(unsigned char*& p) {
 		return Read<char>(p);
 	}
+	[[deprecated]]
 	static unsigned char ReadUInt8(unsigned char*& p) {
 		return Read<unsigned char>(p);
 	}
+	[[deprecated]]
 	static void WriteInt16(unsigned char*& p, short val) {
 		Write<int16_t>(p, val);
 	}
+	[[deprecated]]
 	static void WriteInt8(unsigned char*& p, char val) {
 		Write<char>(p, val);
 	}

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -19,9 +19,6 @@ public:
 		std::memcpy(p, &value, sizeof(T));
 		p += sizeof(T);
 	}
-	static void WriteInt32(unsigned char*& p, int32_t val) {
-		Write<int32_t>(p, val);
-	}
 
 	// for compatibility
 	[[deprecated]]
@@ -39,6 +36,10 @@ public:
 	[[deprecated]]
 	static unsigned char ReadUInt8(unsigned char*& p) {
 		return Read<unsigned char>(p);
+	}
+	[[deprecated]]
+	static void WriteInt32(unsigned char*& p, int32_t val) {
+		Write<int32_t>(p, val);
 	}
 	[[deprecated]]
 	static void WriteInt16(unsigned char*& p, short val) {

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -16,9 +16,6 @@ public:
 	static void WriteInt32(unsigned char*& p, int32_t val) {
 		buffer_write<int32_t>(p, val);
 	}
-	static void WriteUInt16(unsigned char*& p, uint16_t val) {
-		buffer_write<uint16_t>(p, val);
-	}
 	static void WriteUInt8(unsigned char*& p, uint8_t val) {
 		buffer_write<uint8_t>(p, val);
 	}

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -2,8 +2,8 @@
 #define BUFFERIO_H
 
 #include <cstdint>
+#include <cstring>
 #include <cwchar>
-#include "../ocgcore/buffer.h"
 
 class BufferIO {
 public:

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -23,7 +23,7 @@ public:
 		return Read<int32_t>(p);
 	}
 	static void WriteInt32(unsigned char*& p, int32_t val) {
-		buffer_write<int32_t>(p, val);
+		Write<int32_t>(p, val);
 	}
 
 	// for compatibility
@@ -37,10 +37,10 @@ public:
 		return Read<unsigned char>(p);
 	}
 	static void WriteInt16(unsigned char*& p, short val) {
-		buffer_write<int16_t>(p, val);
+		Write<int16_t>(p, val);
 	}
 	static void WriteInt8(unsigned char*& p, char val) {
-		buffer_write<char>(p, val);
+		Write<char>(p, val);
 	}
 	/**
 	* @brief Copy a C-style string to another C-style string.

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -10,9 +10,6 @@ public:
 	static int32_t ReadInt32(unsigned char*& p) {
 		return buffer_read<int32_t>(p);
 	}
-	static uint16_t ReadUInt16(unsigned char*& p) {
-		return buffer_read<uint16_t>(p);
-	}
 	static uint8_t ReadUInt8(unsigned char*& p) {
 		return buffer_read<uint8_t>(p);
 	}

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -19,14 +19,15 @@ public:
 		std::memcpy(p, &value, sizeof(T));
 		p += sizeof(T);
 	}
-	static int32_t ReadInt32(unsigned char*& p) {
-		return Read<int32_t>(p);
-	}
 	static void WriteInt32(unsigned char*& p, int32_t val) {
 		Write<int32_t>(p, val);
 	}
 
 	// for compatibility
+	[[deprecated]]
+	static int32_t ReadInt32(unsigned char*& p) {
+		return Read<int32_t>(p);
+	}
 	[[deprecated]]
 	static short ReadInt16(unsigned char*& p) {
 		return Read<int16_t>(p);

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -20,7 +20,7 @@ public:
 		p += sizeof(T);
 	}
 	static int32_t ReadInt32(unsigned char*& p) {
-		return buffer_read<int32_t>(p);
+		return Read<int32_t>(p);
 	}
 	static void WriteInt32(unsigned char*& p, int32_t val) {
 		buffer_write<int32_t>(p, val);
@@ -28,13 +28,13 @@ public:
 
 	// for compatibility
 	static short ReadInt16(unsigned char*& p) {
-		return buffer_read<int16_t>(p);
+		return Read<int16_t>(p);
 	}
 	static char ReadInt8(unsigned char*& p) {
-		return buffer_read<char>(p);
+		return Read<char>(p);
 	}
 	static unsigned char ReadUInt8(unsigned char*& p) {
-		return buffer_read<unsigned char>(p);
+		return Read<unsigned char>(p);
 	}
 	static void WriteInt16(unsigned char*& p, short val) {
 		buffer_write<int16_t>(p, val);

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -7,6 +7,18 @@
 
 class BufferIO {
 public:
+	template<typename T>
+	static T Read(unsigned char*& p) {
+		T ret{};
+		std::memcpy(&ret, p, sizeof(T));
+		p += sizeof(T);
+		return ret;
+	}
+	template<typename T>
+	static void Write(unsigned char*& p, T value) {
+		std::memcpy(p, &value, sizeof(T));
+		p += sizeof(T);
+	}
 	static int32_t ReadInt32(unsigned char*& p) {
 		return buffer_read<int32_t>(p);
 	}

--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -145,8 +145,8 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 	if(flag & QUERY_COUNTERS) {
 		int count = BufferIO::ReadInt32(buf);
 		for(int i = 0; i < count; ++i) {
-			int ctype = BufferIO::ReadInt16(buf);
-			int ccount = BufferIO::ReadInt16(buf);
+			int ctype = BufferIO::ReadUInt16(buf);
+			int ccount = BufferIO::ReadUInt16(buf);
 			counters[ctype] = ccount;
 		}
 	}

--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -112,10 +112,10 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 	if(flag & QUERY_REASON_CARD)
 		buf += 4;
 	if(flag & QUERY_EQUIP_CARD) {
-		int c = BufferIO::ReadUInt8(buf);
-		unsigned int l = BufferIO::ReadUInt8(buf);
-		int s = BufferIO::ReadUInt8(buf);
-		BufferIO::ReadUInt8(buf);
+		int c = buffer_read<uint8_t>(buf);
+		unsigned int l = buffer_read<uint8_t>(buf);
+		int s = buffer_read<uint8_t>(buf);
+		buffer_read<uint8_t>(buf);
 		ClientCard* ecard = mainGame->dField.GetCard(mainGame->LocalPlayer(c), l, s);
 		if (ecard) {
 			equipTarget = ecard;
@@ -125,10 +125,10 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 	if(flag & QUERY_TARGET_CARD) {
 		int count = BufferIO::ReadInt32(buf);
 		for(int i = 0; i < count; ++i) {
-			int c = BufferIO::ReadUInt8(buf);
-			unsigned int l = BufferIO::ReadUInt8(buf);
-			int s = BufferIO::ReadUInt8(buf);
-			BufferIO::ReadUInt8(buf);
+			int c = buffer_read<uint8_t>(buf);
+			unsigned int l = buffer_read<uint8_t>(buf);
+			int s = buffer_read<uint8_t>(buf);
+			buffer_read<uint8_t>(buf);
 			ClientCard* tcard = mainGame->dField.GetCard(mainGame->LocalPlayer(c), l, s);
 			if (tcard) {
 				cardTarget.insert(tcard);

--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -39,13 +39,13 @@ void ClientCard::SetCode(unsigned int x) {
 		code = x;
 }
 void ClientCard::UpdateInfo(unsigned char* buf) {
-	int flag = BufferIO::ReadInt32(buf);
+	int flag = BufferIO::Read<int32_t>(buf);
 	if (flag == 0) {
 		ClearData();
 		return;
 	}
 	if(flag & QUERY_CODE) {
-		int pdata = BufferIO::ReadInt32(buf);
+		int pdata = BufferIO::Read<int32_t>(buf);
 		if (!pdata)
 			ClearData();
 		if((location == LOCATION_HAND) && ((unsigned int)pdata != code)) {
@@ -55,7 +55,7 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 			code = pdata;
 	}
 	if(flag & QUERY_POSITION) {
-		int pdata = (BufferIO::ReadInt32(buf) >> 24) & 0xff;
+		int pdata = (BufferIO::Read<int32_t>(buf) >> 24) & 0xff;
 		if((location & (LOCATION_EXTRA | LOCATION_REMOVED)) && pdata != position) {
 			position = pdata;
 			mainGame->dField.MoveCard(this, 1);
@@ -63,29 +63,29 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 			position = pdata;
 	}
 	if(flag & QUERY_ALIAS)
-		alias = BufferIO::ReadInt32(buf);
+		alias = BufferIO::Read<int32_t>(buf);
 	if(flag & QUERY_TYPE)
-		type = BufferIO::ReadInt32(buf);
+		type = BufferIO::Read<int32_t>(buf);
 	if(flag & QUERY_LEVEL) {
-		int pdata = BufferIO::ReadInt32(buf);
+		int pdata = BufferIO::Read<int32_t>(buf);
 		if(level != (unsigned int)pdata) {
 			level = pdata;
 			myswprintf(lvstring, L"L%d", level);
 		}
 	}
 	if(flag & QUERY_RANK) {
-		int pdata = BufferIO::ReadInt32(buf);
+		int pdata = BufferIO::Read<int32_t>(buf);
 		if(pdata && rank != (unsigned int)pdata) {
 			rank = pdata;
 			myswprintf(lvstring, L"R%d", rank);
 		}
 	}
 	if(flag & QUERY_ATTRIBUTE)
-		attribute = BufferIO::ReadInt32(buf);
+		attribute = BufferIO::Read<int32_t>(buf);
 	if(flag & QUERY_RACE)
-		race = BufferIO::ReadInt32(buf);
+		race = BufferIO::Read<int32_t>(buf);
 	if(flag & QUERY_ATTACK) {
-		attack = BufferIO::ReadInt32(buf);
+		attack = BufferIO::Read<int32_t>(buf);
 		if(attack < 0) {
 			atkstring[0] = '?';
 			atkstring[1] = 0;
@@ -93,7 +93,7 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 			myswprintf(atkstring, L"%d", attack);
 	}
 	if(flag & QUERY_DEFENSE) {
-		defense = BufferIO::ReadInt32(buf);
+		defense = BufferIO::Read<int32_t>(buf);
 		if(type & TYPE_LINK) {
 			defstring[0] = '-';
 			defstring[1] = 0;
@@ -104,11 +104,11 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 			myswprintf(defstring, L"%d", defense);
 	}
 	if(flag & QUERY_BASE_ATTACK)
-		base_attack = BufferIO::ReadInt32(buf);
+		base_attack = BufferIO::Read<int32_t>(buf);
 	if(flag & QUERY_BASE_DEFENSE)
-		base_defense = BufferIO::ReadInt32(buf);
+		base_defense = BufferIO::Read<int32_t>(buf);
 	if(flag & QUERY_REASON)
-		reason = BufferIO::ReadInt32(buf);
+		reason = BufferIO::Read<int32_t>(buf);
 	if(flag & QUERY_REASON_CARD)
 		buf += 4;
 	if(flag & QUERY_EQUIP_CARD) {
@@ -123,7 +123,7 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 		}
 	}
 	if(flag & QUERY_TARGET_CARD) {
-		int count = BufferIO::ReadInt32(buf);
+		int count = BufferIO::Read<int32_t>(buf);
 		for(int i = 0; i < count; ++i) {
 			int c = BufferIO::Read<uint8_t>(buf);
 			unsigned int l = BufferIO::Read<uint8_t>(buf);
@@ -137,13 +137,13 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 		}
 	}
 	if(flag & QUERY_OVERLAY_CARD) {
-		int count = BufferIO::ReadInt32(buf);
+		int count = BufferIO::Read<int32_t>(buf);
 		for(int i = 0; i < count; ++i) {
-			overlayed[i]->SetCode(BufferIO::ReadInt32(buf));
+			overlayed[i]->SetCode(BufferIO::Read<int32_t>(buf));
 		}
 	}
 	if(flag & QUERY_COUNTERS) {
-		int count = BufferIO::ReadInt32(buf);
+		int count = BufferIO::Read<int32_t>(buf);
 		for(int i = 0; i < count; ++i) {
 			int ctype = BufferIO::Read<uint16_t>(buf);
 			int ccount = BufferIO::Read<uint16_t>(buf);
@@ -151,24 +151,24 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 		}
 	}
 	if(flag & QUERY_OWNER)
-		owner = BufferIO::ReadInt32(buf);
+		owner = BufferIO::Read<int32_t>(buf);
 	if(flag & QUERY_STATUS)
-		status = BufferIO::ReadInt32(buf);
+		status = BufferIO::Read<int32_t>(buf);
 	if(flag & QUERY_LSCALE) {
-		lscale = BufferIO::ReadInt32(buf);
+		lscale = BufferIO::Read<int32_t>(buf);
 		myswprintf(lscstring, L"%d", lscale);
 	}
 	if(flag & QUERY_RSCALE) {
-		rscale = BufferIO::ReadInt32(buf);
+		rscale = BufferIO::Read<int32_t>(buf);
 		myswprintf(rscstring, L"%d", rscale);
 	}
 	if(flag & QUERY_LINK) {
-		int pdata = BufferIO::ReadInt32(buf);
+		int pdata = BufferIO::Read<int32_t>(buf);
 		if (link != (unsigned int)pdata) {
 			link = pdata;
 		}
 		myswprintf(linkstring, L"L\x2012%d", link);
-		pdata = BufferIO::ReadInt32(buf);
+		pdata = BufferIO::Read<int32_t>(buf);
 		if (link_marker != (unsigned int)pdata) {
 			link_marker = pdata;
 		}

--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -145,8 +145,8 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 	if(flag & QUERY_COUNTERS) {
 		int count = BufferIO::ReadInt32(buf);
 		for(int i = 0; i < count; ++i) {
-			int ctype = BufferIO::ReadUInt16(buf);
-			int ccount = BufferIO::ReadUInt16(buf);
+			int ctype = buffer_read<uint16_t>(buf);
+			int ccount = buffer_read<uint16_t>(buf);
 			counters[ctype] = ccount;
 		}
 	}

--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -112,10 +112,10 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 	if(flag & QUERY_REASON_CARD)
 		buf += 4;
 	if(flag & QUERY_EQUIP_CARD) {
-		int c = buffer_read<uint8_t>(buf);
-		unsigned int l = buffer_read<uint8_t>(buf);
-		int s = buffer_read<uint8_t>(buf);
-		buffer_read<uint8_t>(buf);
+		int c = BufferIO::Read<uint8_t>(buf);
+		unsigned int l = BufferIO::Read<uint8_t>(buf);
+		int s = BufferIO::Read<uint8_t>(buf);
+		BufferIO::Read<uint8_t>(buf);
 		ClientCard* ecard = mainGame->dField.GetCard(mainGame->LocalPlayer(c), l, s);
 		if (ecard) {
 			equipTarget = ecard;
@@ -125,10 +125,10 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 	if(flag & QUERY_TARGET_CARD) {
 		int count = BufferIO::ReadInt32(buf);
 		for(int i = 0; i < count; ++i) {
-			int c = buffer_read<uint8_t>(buf);
-			unsigned int l = buffer_read<uint8_t>(buf);
-			int s = buffer_read<uint8_t>(buf);
-			buffer_read<uint8_t>(buf);
+			int c = BufferIO::Read<uint8_t>(buf);
+			unsigned int l = BufferIO::Read<uint8_t>(buf);
+			int s = BufferIO::Read<uint8_t>(buf);
+			BufferIO::Read<uint8_t>(buf);
 			ClientCard* tcard = mainGame->dField.GetCard(mainGame->LocalPlayer(c), l, s);
 			if (tcard) {
 				cardTarget.insert(tcard);
@@ -145,8 +145,8 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 	if(flag & QUERY_COUNTERS) {
 		int count = BufferIO::ReadInt32(buf);
 		for(int i = 0; i < count; ++i) {
-			int ctype = buffer_read<uint16_t>(buf);
-			int ccount = buffer_read<uint16_t>(buf);
+			int ctype = BufferIO::Read<uint16_t>(buf);
+			int ccount = BufferIO::Read<uint16_t>(buf);
 			counters[ctype] = ccount;
 		}
 	}

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -317,7 +317,7 @@ ClientCard* ClientField::RemoveCard(int controler, int location, int sequence) {
 }
 void ClientField::UpdateCard(int controler, int location, int sequence, unsigned char* data) {
 	ClientCard* pcard = GetCard(controler, location, sequence);
-	int len = BufferIO::ReadInt32(data);
+	int len = BufferIO::Read<int32_t>(data);
 	if (pcard && len > LEN_HEADER)
 		pcard->UpdateInfo(data);
 }
@@ -350,7 +350,7 @@ void ClientField::UpdateFieldCard(int controler, int location, unsigned char* da
 		return;
 	int len;
 	for(auto cit = lst->begin(); cit != lst->end(); ++cit) {
-		len = BufferIO::ReadInt32(data);
+		len = BufferIO::Read<int32_t>(data);
 		if(len > LEN_HEADER)
 			(*cit)->UpdateInfo(data);
 		data += len - 4;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -698,14 +698,14 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				mainGame->ClearCardInfo();
 				unsigned char deckbuf[1024];
 				auto pdeck = deckbuf;
-				BufferIO::WriteInt32(pdeck, deckManager.current_deck.main.size() + deckManager.current_deck.extra.size());
-				BufferIO::WriteInt32(pdeck, deckManager.current_deck.side.size());
+				BufferIO::Write<int32_t>(pdeck, deckManager.current_deck.main.size() + deckManager.current_deck.extra.size());
+				BufferIO::Write<int32_t>(pdeck, deckManager.current_deck.side.size());
 				for(size_t i = 0; i < deckManager.current_deck.main.size(); ++i)
-					BufferIO::WriteInt32(pdeck, deckManager.current_deck.main[i]->first);
+					BufferIO::Write<int32_t>(pdeck, deckManager.current_deck.main[i]->first);
 				for(size_t i = 0; i < deckManager.current_deck.extra.size(); ++i)
-					BufferIO::WriteInt32(pdeck, deckManager.current_deck.extra[i]->first);
+					BufferIO::Write<int32_t>(pdeck, deckManager.current_deck.extra[i]->first);
 				for(size_t i = 0; i < deckManager.current_deck.side.size(); ++i)
-					BufferIO::WriteInt32(pdeck, deckManager.current_deck.side[i]->first);
+					BufferIO::Write<int32_t>(pdeck, deckManager.current_deck.side[i]->first);
 				DuelClient::SendBufferToServer(CTOS_UPDATE_DECK, deckbuf, pdeck - deckbuf);
 				break;
 			}

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -249,7 +249,7 @@ int DuelClient::ClientThread() {
 }
 void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 	unsigned char* pdata = data;
-	unsigned char pktType = BufferIO::ReadUInt8(pdata);
+	unsigned char pktType = buffer_read<uint8_t>(pdata);
 	switch(pktType) {
 	case STOC_GAME_MSG: {
 		if (len < 1 + (int)sizeof(unsigned char))
@@ -952,7 +952,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	unsigned char* pbuf = msg;
 	wchar_t textBuffer[256];
-	mainGame->dInfo.curMsg = BufferIO::ReadUInt8(pbuf);
+	mainGame->dInfo.curMsg = buffer_read<uint8_t>(pbuf);
 	if(mainGame->dInfo.curMsg != MSG_RETRY) {
 		std::memcpy(last_successful_msg, msg, len);
 		last_successful_msg_length = len;
@@ -986,7 +986,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_RETRY: {
 		if(last_successful_msg_length) {
 			auto p = last_successful_msg;
-			auto last_msg = BufferIO::ReadUInt8(p);
+			auto last_msg = buffer_read<uint8_t>(p);
 			int err_desc = 1421;
 			switch(last_msg) {
 			case MSG_ANNOUNCE_CARD:
@@ -1071,8 +1071,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_HINT: {
-		int type = BufferIO::ReadUInt8(pbuf);
-		int player = BufferIO::ReadUInt8(pbuf);
+		int type = buffer_read<uint8_t>(pbuf);
+		int player = buffer_read<uint8_t>(pbuf);
 		int data = BufferIO::ReadInt32(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
@@ -1206,8 +1206,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_WIN: {
 		mainGame->dInfo.isFinished = true;
-		int player = BufferIO::ReadUInt8(pbuf);
-		int type = BufferIO::ReadUInt8(pbuf);
+		int player = buffer_read<uint8_t>(pbuf);
+		int type = buffer_read<uint8_t>(pbuf);
 		mainGame->showcarddif = 110;
 		mainGame->showcardp = 0;
 		mainGame->dInfo.vic_string = L"";
@@ -1258,7 +1258,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->gMutex.lock();
 		mainGame->dField.Clear();
 		mainGame->dInfo.isInDuel = true;
-		int playertype = BufferIO::ReadUInt8(pbuf);
+		int playertype = buffer_read<uint8_t>(pbuf);
 		mainGame->dInfo.isFirst =  (playertype & 0xf) ? false : true;
 		if(playertype & 0xf0)
 			mainGame->dInfo.player_type = 7;
@@ -1268,7 +1268,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			else
 				mainGame->dInfo.tag_player[0] = true;
 		}
-		mainGame->dInfo.duel_rule = BufferIO::ReadUInt8(pbuf);
+		mainGame->dInfo.duel_rule = buffer_read<uint8_t>(pbuf);
 		mainGame->dInfo.lp[mainGame->LocalPlayer(0)] = BufferIO::ReadInt32(pbuf);
 		mainGame->dInfo.lp[mainGame->LocalPlayer(1)] = BufferIO::ReadInt32(pbuf);
 		myswprintf(mainGame->dInfo.strLP[0], L"%d", mainGame->dInfo.lp[0]);
@@ -1295,36 +1295,36 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_UPDATE_DATA: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int location = BufferIO::ReadUInt8(pbuf);
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int location = buffer_read<uint8_t>(pbuf);
 		mainGame->gMutex.lock();
 		mainGame->dField.UpdateFieldCard(player, location, pbuf);
 		mainGame->gMutex.unlock();
 		return true;
 	}
 	case MSG_UPDATE_CARD: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int loc = BufferIO::ReadUInt8(pbuf);
-		int seq = BufferIO::ReadUInt8(pbuf);
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int loc = buffer_read<uint8_t>(pbuf);
+		int seq = buffer_read<uint8_t>(pbuf);
 		mainGame->gMutex.lock();
 		mainGame->dField.UpdateCard(player, loc, seq, pbuf);
 		mainGame->gMutex.unlock();
 		break;
 	}
 	case MSG_SELECT_BATTLECMD: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
 		int desc, count, con, seq/*, diratt*/;
 		unsigned int code, loc;
 		ClientCard* pcard;
 		mainGame->dField.activatable_cards.clear();
 		mainGame->dField.activatable_descs.clear();
 		mainGame->dField.conti_cards.clear();
-		count = BufferIO::ReadUInt8(pbuf);
+		count = buffer_read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			loc = BufferIO::ReadUInt8(pbuf);
-			seq = BufferIO::ReadUInt8(pbuf);
+			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			loc = buffer_read<uint8_t>(pbuf);
+			seq = buffer_read<uint8_t>(pbuf);
 			desc = BufferIO::ReadInt32(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			int flag = 0;
@@ -1349,24 +1349,24 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			}
 		}
 		mainGame->dField.attackable_cards.clear();
-		count = BufferIO::ReadUInt8(pbuf);
+		count = buffer_read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			/*code = */BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			loc = BufferIO::ReadUInt8(pbuf);
-			seq = BufferIO::ReadUInt8(pbuf);
-			/*diratt = */BufferIO::ReadUInt8(pbuf);
+			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			loc = buffer_read<uint8_t>(pbuf);
+			seq = buffer_read<uint8_t>(pbuf);
+			/*diratt = */buffer_read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.attackable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_ATTACK;
 		}
 		mainGame->gMutex.lock();
-		if(BufferIO::ReadUInt8(pbuf)) {
+		if(buffer_read<uint8_t>(pbuf)) {
 			mainGame->btnM2->setVisible(true);
 			mainGame->btnM2->setEnabled(true);
 			mainGame->btnM2->setPressed(false);
 		}
-		if(BufferIO::ReadUInt8(pbuf)) {
+		if(buffer_read<uint8_t>(pbuf)) {
 			mainGame->btnEP->setVisible(true);
 			mainGame->btnEP->setEnabled(true);
 			mainGame->btnEP->setPressed(false);
@@ -1375,28 +1375,28 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_IDLECMD: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
 		int desc, count, con, seq;
 		unsigned int code, loc;
 		ClientCard* pcard;
 		mainGame->dField.summonable_cards.clear();
-		count = BufferIO::ReadUInt8(pbuf);
+		count = buffer_read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			loc = BufferIO::ReadUInt8(pbuf);
-			seq = BufferIO::ReadUInt8(pbuf);
+			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			loc = buffer_read<uint8_t>(pbuf);
+			seq = buffer_read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.summonable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_SUMMON;
 		}
 		mainGame->dField.spsummonable_cards.clear();
-		count = BufferIO::ReadUInt8(pbuf);
+		count = buffer_read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			loc = BufferIO::ReadUInt8(pbuf);
-			seq = BufferIO::ReadUInt8(pbuf);
+			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			loc = buffer_read<uint8_t>(pbuf);
+			seq = buffer_read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.spsummonable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_SPSUMMON;
@@ -1416,34 +1416,34 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			}
 		}
 		mainGame->dField.reposable_cards.clear();
-		count = BufferIO::ReadUInt8(pbuf);
+		count = buffer_read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			loc = BufferIO::ReadUInt8(pbuf);
-			seq = BufferIO::ReadUInt8(pbuf);
+			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			loc = buffer_read<uint8_t>(pbuf);
+			seq = buffer_read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.reposable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_REPOS;
 		}
 		mainGame->dField.msetable_cards.clear();
-		count = BufferIO::ReadUInt8(pbuf);
+		count = buffer_read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			loc = BufferIO::ReadUInt8(pbuf);
-			seq = BufferIO::ReadUInt8(pbuf);
+			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			loc = buffer_read<uint8_t>(pbuf);
+			seq = buffer_read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.msetable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_MSET;
 		}
 		mainGame->dField.ssetable_cards.clear();
-		count = BufferIO::ReadUInt8(pbuf);
+		count = buffer_read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			loc = BufferIO::ReadUInt8(pbuf);
-			seq = BufferIO::ReadUInt8(pbuf);
+			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			loc = buffer_read<uint8_t>(pbuf);
+			seq = buffer_read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.ssetable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_SSET;
@@ -1451,12 +1451,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.activatable_cards.clear();
 		mainGame->dField.activatable_descs.clear();
 		mainGame->dField.conti_cards.clear();
-		count = BufferIO::ReadUInt8(pbuf);
+		count = buffer_read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			loc = BufferIO::ReadUInt8(pbuf);
-			seq = BufferIO::ReadUInt8(pbuf);
+			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			loc = buffer_read<uint8_t>(pbuf);
+			seq = buffer_read<uint8_t>(pbuf);
 			desc = BufferIO::ReadInt32(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			int flag = 0;
@@ -1480,17 +1480,17 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					mainGame->dField.extra_act[con] = true;
 			}
 		}
-		if(BufferIO::ReadUInt8(pbuf)) {
+		if(buffer_read<uint8_t>(pbuf)) {
 			mainGame->btnBP->setVisible(true);
 			mainGame->btnBP->setEnabled(true);
 			mainGame->btnBP->setPressed(false);
 		}
-		if(BufferIO::ReadUInt8(pbuf)) {
+		if(buffer_read<uint8_t>(pbuf)) {
 			mainGame->btnEP->setVisible(true);
 			mainGame->btnEP->setEnabled(true);
 			mainGame->btnEP->setPressed(false);
 		}
-		if (BufferIO::ReadUInt8(pbuf)) {
+		if (buffer_read<uint8_t>(pbuf)) {
 			mainGame->btnShuffle->setVisible(true);
 		} else {
 			mainGame->btnShuffle->setVisible(false);
@@ -1498,15 +1498,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_EFFECTYN: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l = BufferIO::ReadUInt8(pbuf);
-		int s = BufferIO::ReadUInt8(pbuf);
+		int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l = buffer_read<uint8_t>(pbuf);
+		int s = buffer_read<uint8_t>(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 		if (pcard->code != code)
 			pcard->SetCode(code);
-		BufferIO::ReadUInt8(pbuf);
+		buffer_read<uint8_t>(pbuf);
 		if(l != LOCATION_DECK) {
 			pcard->is_highlighting = true;
 			mainGame->dField.highlighting_card = pcard;
@@ -1532,7 +1532,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_YESNO: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
 		int desc = BufferIO::ReadInt32(pbuf);
 		mainGame->dField.highlighting_card = 0;
 		mainGame->gMutex.lock();
@@ -1542,8 +1542,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_OPTION: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt8(pbuf);
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
+		int count = buffer_read<uint8_t>(pbuf);
 		mainGame->dField.select_options.clear();
 		for (int i = 0; i < count; ++i)
 			mainGame->dField.select_options.push_back(BufferIO::ReadInt32(pbuf));
@@ -1552,11 +1552,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_CARD: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
-		mainGame->dField.select_cancelable = BufferIO::ReadUInt8(pbuf) != 0;
-		mainGame->dField.select_min = BufferIO::ReadUInt8(pbuf);
-		mainGame->dField.select_max = BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt8(pbuf);
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
+		mainGame->dField.select_cancelable = buffer_read<uint8_t>(pbuf) != 0;
+		mainGame->dField.select_min = buffer_read<uint8_t>(pbuf);
+		mainGame->dField.select_max = buffer_read<uint8_t>(pbuf);
+		int count = buffer_read<uint8_t>(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
 		int c, s, ss;
@@ -1570,10 +1570,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			l = BufferIO::ReadUInt8(pbuf);
-			s = BufferIO::ReadUInt8(pbuf);
-			ss = BufferIO::ReadUInt8(pbuf);
+			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			l = buffer_read<uint8_t>(pbuf);
+			s = buffer_read<uint8_t>(pbuf);
+			ss = buffer_read<uint8_t>(pbuf);
 			if (l & LOCATION_OVERLAY)
 				pcard = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
 			else
@@ -1616,13 +1616,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_UNSELECT_CARD: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
-		bool finishable = BufferIO::ReadUInt8(pbuf) != 0;
-		bool cancelable = BufferIO::ReadUInt8(pbuf) != 0;
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
+		bool finishable = buffer_read<uint8_t>(pbuf) != 0;
+		bool cancelable = buffer_read<uint8_t>(pbuf) != 0;
 		mainGame->dField.select_cancelable = finishable || cancelable;
-		mainGame->dField.select_min = BufferIO::ReadUInt8(pbuf);
-		mainGame->dField.select_max = BufferIO::ReadUInt8(pbuf);
-		int count1 = BufferIO::ReadUInt8(pbuf);
+		mainGame->dField.select_min = buffer_read<uint8_t>(pbuf);
+		mainGame->dField.select_max = buffer_read<uint8_t>(pbuf);
+		int count1 = buffer_read<uint8_t>(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
 		int c, s, ss;
@@ -1635,10 +1635,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pcard;
 		for (int i = 0; i < count1; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			l = BufferIO::ReadUInt8(pbuf);
-			s = BufferIO::ReadUInt8(pbuf);
-			ss = BufferIO::ReadUInt8(pbuf);
+			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			l = buffer_read<uint8_t>(pbuf);
+			s = buffer_read<uint8_t>(pbuf);
+			ss = buffer_read<uint8_t>(pbuf);
 			if (l & LOCATION_OVERLAY)
 				pcard = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
 			else
@@ -1656,13 +1656,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					panelmode = true;
 			}
 		}
-		int count2 = BufferIO::ReadUInt8(pbuf);
+		int count2 = buffer_read<uint8_t>(pbuf);
 		for (int i = count1; i < count1 + count2; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			l = BufferIO::ReadUInt8(pbuf);
-			s = BufferIO::ReadUInt8(pbuf);
-			ss = BufferIO::ReadUInt8(pbuf);
+			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			l = buffer_read<uint8_t>(pbuf);
+			s = buffer_read<uint8_t>(pbuf);
+			ss = buffer_read<uint8_t>(pbuf);
 			if (l & LOCATION_OVERLAY)
 				pcard = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
 			else
@@ -1731,10 +1731,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			int forced = BufferIO::ReadUInt8(pbuf);
 			flag |= forced << 8;
 			code = BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			l = BufferIO::ReadUInt8(pbuf);
-			s = BufferIO::ReadUInt8(pbuf);
-			ss = BufferIO::ReadUInt8(pbuf);
+			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			l = buffer_read<uint8_t>(pbuf);
+			s = buffer_read<uint8_t>(pbuf);
+			ss = buffer_read<uint8_t>(pbuf);
 			desc = BufferIO::ReadInt32(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s, ss);
 			mainGame->dField.activatable_cards.push_back(pcard);
@@ -1818,8 +1818,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SELECT_PLACE:
 	case MSG_SELECT_DISFIELD: {
-		int selecting_player = BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt8(pbuf);
+		int selecting_player = buffer_read<uint8_t>(pbuf);
+		int count = buffer_read<uint8_t>(pbuf);
 		mainGame->dField.select_min = count > 0 ? count : 1;
 		mainGame->dField.select_ready = false;
 		mainGame->dField.select_cancelable = count == 0;
@@ -1904,9 +1904,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_POSITION: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
 		unsigned int code = (unsigned int)BufferIO::ReadInt32(pbuf);
-		unsigned int positions = BufferIO::ReadUInt8(pbuf);
+		unsigned int positions = buffer_read<uint8_t>(pbuf);
 		if (positions == 0x1 || positions == 0x2 || positions == 0x4 || positions == 0x8) {
 			SetResponseI(positions);
 			return true;
@@ -1947,11 +1947,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_TRIBUTE: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
-		mainGame->dField.select_cancelable = BufferIO::ReadUInt8(pbuf) != 0;
-		mainGame->dField.select_min = BufferIO::ReadUInt8(pbuf);
-		mainGame->dField.select_max = BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt8(pbuf);
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
+		mainGame->dField.select_cancelable = buffer_read<uint8_t>(pbuf) != 0;
+		mainGame->dField.select_min = buffer_read<uint8_t>(pbuf);
+		mainGame->dField.select_max = buffer_read<uint8_t>(pbuf);
+		int count = buffer_read<uint8_t>(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
 		mainGame->dField.selectsum_all.clear();
@@ -1963,10 +1963,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.select_ready = false;
 		for (int i = 0; i < count; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			l = BufferIO::ReadUInt8(pbuf);
-			s = BufferIO::ReadUInt8(pbuf);
-			t = BufferIO::ReadUInt8(pbuf);
+			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			l = buffer_read<uint8_t>(pbuf);
+			s = buffer_read<uint8_t>(pbuf);
+			t = buffer_read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
 			if (code && pcard->code != code)
 				pcard->SetCode(code);
@@ -1992,19 +1992,19 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_COUNTER: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
 		mainGame->dField.select_counter_type = buffer_read<uint16_t>(pbuf);
 		mainGame->dField.select_counter_count = buffer_read<uint16_t>(pbuf);
-		int count = BufferIO::ReadUInt8(pbuf);
+		int count = buffer_read<uint8_t>(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		int c, s, t/*, code*/;
 		unsigned int l;
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
 			/*code = */BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			l = BufferIO::ReadUInt8(pbuf);
-			s = BufferIO::ReadUInt8(pbuf);
+			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			l = buffer_read<uint8_t>(pbuf);
+			s = buffer_read<uint8_t>(pbuf);
 			t = buffer_read<uint16_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
 			mainGame->dField.selectable_cards.push_back(pcard);
@@ -2019,21 +2019,21 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_SUM: {
-		mainGame->dField.select_mode = BufferIO::ReadUInt8(pbuf);
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
+		mainGame->dField.select_mode = buffer_read<uint8_t>(pbuf);
+		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
 		mainGame->dField.select_sumval = BufferIO::ReadInt32(pbuf);
-		mainGame->dField.select_min = BufferIO::ReadUInt8(pbuf);
-		mainGame->dField.select_max = BufferIO::ReadUInt8(pbuf);
-		mainGame->dField.must_select_count = BufferIO::ReadUInt8(pbuf);
+		mainGame->dField.select_min = buffer_read<uint8_t>(pbuf);
+		mainGame->dField.select_max = buffer_read<uint8_t>(pbuf);
+		mainGame->dField.must_select_count = buffer_read<uint8_t>(pbuf);
 		mainGame->dField.selectsum_all.clear();
 		mainGame->dField.selected_cards.clear();
 		mainGame->dField.selectsum_cards.clear();
 		mainGame->dField.select_panalmode = false;
 		for (int i = 0; i < mainGame->dField.must_select_count; ++i) {
 			unsigned int code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			unsigned int l = BufferIO::ReadUInt8(pbuf);
-			int s = BufferIO::ReadUInt8(pbuf);
+			int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			unsigned int l = buffer_read<uint8_t>(pbuf);
+			int s = buffer_read<uint8_t>(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 			if (code != 0 && pcard->code != code)
 				pcard->SetCode(code);
@@ -2041,12 +2041,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			pcard->select_seq = 0;
 			mainGame->dField.selected_cards.push_back(pcard);
 		}
-		int count = BufferIO::ReadUInt8(pbuf);
+		int count = buffer_read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			unsigned int code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			unsigned int l = BufferIO::ReadUInt8(pbuf);
-			int s = BufferIO::ReadUInt8(pbuf);
+			int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			unsigned int l = buffer_read<uint8_t>(pbuf);
+			int s = buffer_read<uint8_t>(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 			if (code != 0 && pcard->code != code)
 				pcard->SetCode(code);
@@ -2062,8 +2062,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return mainGame->dField.ShowSelectSum(mainGame->dField.select_panalmode);
 	}
 	case MSG_SORT_CARD: {
-		/*int player = */BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt8(pbuf);
+		/*int player = */buffer_read<uint8_t>(pbuf);
+		int count = buffer_read<uint8_t>(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
 		mainGame->dField.sort_list.clear();
@@ -2072,9 +2072,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			l = BufferIO::ReadUInt8(pbuf);
-			s = BufferIO::ReadUInt8(pbuf);
+			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			l = buffer_read<uint8_t>(pbuf);
+			s = buffer_read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
 			if (code != 0 && pcard->code != code)
 				pcard->SetCode(code);
@@ -2088,8 +2088,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_CONFIRM_DECKTOP: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int count = BufferIO::ReadUInt8(pbuf);
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int count = buffer_read<uint8_t>(pbuf);
 		unsigned int code;
 		ClientCard* pcard;
 		mainGame->dField.selectable_cards.clear();
@@ -2126,8 +2126,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CONFIRM_EXTRATOP: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int count = BufferIO::ReadUInt8(pbuf);
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int count = buffer_read<uint8_t>(pbuf);
 		unsigned int code;
 		ClientCard* pcard;
 		mainGame->dField.selectable_cards.clear();
@@ -2180,9 +2180,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->AddLog(textBuffer);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			l = BufferIO::ReadUInt8(pbuf);
-			s = BufferIO::ReadUInt8(pbuf);
+			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			l = buffer_read<uint8_t>(pbuf);
+			s = buffer_read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
 			if (code != 0)
 				pcard->SetCode(code);
@@ -2265,7 +2265,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_SHUFFLE_DECK: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
 		if(mainGame->dField.deck[player].size() < 2)
 			return true;
 		bool rev = mainGame->dField.deck_reversed;
@@ -2304,8 +2304,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_SHUFFLE_HAND: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int count = BufferIO::ReadUInt8(pbuf);
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int count = buffer_read<uint8_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			if(count > 1)
 				soundManager.PlaySoundEffect(SOUND_SHUFFLE);
@@ -2347,8 +2347,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_SHUFFLE_EXTRA: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int count = BufferIO::ReadUInt8(pbuf);
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int count = buffer_read<uint8_t>(pbuf);
 		if((mainGame->dField.extra[player].size() - mainGame->dField.extra_p_count[player]) < 2)
 			return true;
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
@@ -2376,11 +2376,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_REFRESH_DECK: {
-		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
+		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
 		return true;
 	}
 	case MSG_SWAP_GRAVE_DECK: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			mainGame->dField.grave[player].swap(mainGame->dField.deck[player]);
 			for (auto cit = mainGame->dField.grave[player].begin(); cit != mainGame->dField.grave[player].end(); ++cit)
@@ -2434,8 +2434,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_DECK_TOP: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int seq = BufferIO::ReadUInt8(pbuf);
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int seq = buffer_read<uint8_t>(pbuf);
 		unsigned int code = BufferIO::ReadInt32(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(player, LOCATION_DECK, mainGame->dField.deck[player].size() - 1 - seq);
 		pcard->SetCode(code & 0x7fffffff);
@@ -2448,8 +2448,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SHUFFLE_SET_CARD: {
 		std::vector<ClientCard*>* lst = 0;
-		unsigned int loc = BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt8(pbuf);
+		unsigned int loc = buffer_read<uint8_t>(pbuf);
+		int count = buffer_read<uint8_t>(pbuf);
 		if(loc == LOCATION_MZONE)
 			lst = mainGame->dField.mzone;
 		else
@@ -2459,10 +2459,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int c, s, ps;
 		unsigned int l;
 		for (int i = 0; i < count; ++i) {
-			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			l = BufferIO::ReadUInt8(pbuf);
-			s = BufferIO::ReadUInt8(pbuf);
-			BufferIO::ReadUInt8(pbuf);
+			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			l = buffer_read<uint8_t>(pbuf);
+			s = buffer_read<uint8_t>(pbuf);
+			buffer_read<uint8_t>(pbuf);
 			mc[i] = lst[c][s];
 			mc[i]->SetCode(0);
 			if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
@@ -2475,10 +2475,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping)
 			mainGame->WaitFrameSignal(20);
 		for (int i = 0; i < count; ++i) {
-			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			l = BufferIO::ReadUInt8(pbuf);
-			s = BufferIO::ReadUInt8(pbuf);
-			BufferIO::ReadUInt8(pbuf);
+			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			l = buffer_read<uint8_t>(pbuf);
+			s = buffer_read<uint8_t>(pbuf);
+			buffer_read<uint8_t>(pbuf);
 			ps = mc[i]->sequence;
 			if (l > 0) {
 				swp = lst[c][s];
@@ -2500,7 +2500,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_NEW_TURN: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
 		mainGame->dInfo.turn++;
 		if(!mainGame->dInfo.isReplay && mainGame->dInfo.player_type < 7) {
 			mainGame->dField.tag_surrender = false;
@@ -2586,14 +2586,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_MOVE: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		int pc = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int pl = BufferIO::ReadUInt8(pbuf);
-		int ps = BufferIO::ReadUInt8(pbuf);
-		unsigned int pp = BufferIO::ReadUInt8(pbuf);
-		int cc = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int cl = BufferIO::ReadUInt8(pbuf);
-		int cs = BufferIO::ReadUInt8(pbuf);
-		unsigned int cp = BufferIO::ReadUInt8(pbuf);
+		int pc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int pl = buffer_read<uint8_t>(pbuf);
+		int ps = buffer_read<uint8_t>(pbuf);
+		unsigned int pp = buffer_read<uint8_t>(pbuf);
+		int cc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int cl = buffer_read<uint8_t>(pbuf);
+		int cs = buffer_read<uint8_t>(pbuf);
+		unsigned int cp = buffer_read<uint8_t>(pbuf);
 		int reason = BufferIO::ReadInt32(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			if(cl & LOCATION_REMOVED && pl != cl)
@@ -2802,11 +2802,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_POS_CHANGE: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		int cc = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int cl = BufferIO::ReadUInt8(pbuf);
-		int cs = BufferIO::ReadUInt8(pbuf);
-		unsigned int pp = BufferIO::ReadUInt8(pbuf);
-		unsigned int cp = BufferIO::ReadUInt8(pbuf);
+		int cc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int cl = buffer_read<uint8_t>(pbuf);
+		int cs = buffer_read<uint8_t>(pbuf);
+		unsigned int pp = buffer_read<uint8_t>(pbuf);
+		unsigned int cp = buffer_read<uint8_t>(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(cc, cl, cs);
 		if((pp & POS_FACEUP) && (cp & POS_FACEDOWN)) {
 			pcard->counters.clear();
@@ -2824,10 +2824,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SET: {
 		/*int code = */BufferIO::ReadInt32(pbuf);
-		/*int cc = mainGame->LocalPlayer*/(BufferIO::ReadUInt8(pbuf));
-		/*int cl = */BufferIO::ReadUInt8(pbuf);
-		/*int cs = */BufferIO::ReadUInt8(pbuf);
-		/*int cp = */BufferIO::ReadUInt8(pbuf);
+		/*int cc = mainGame->LocalPlayer*/(buffer_read<uint8_t>(pbuf));
+		/*int cl = */buffer_read<uint8_t>(pbuf);
+		/*int cs = */buffer_read<uint8_t>(pbuf);
+		/*int cp = */buffer_read<uint8_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping)
 			soundManager.PlaySoundEffect(SOUND_SET);
 		myswprintf(event_string, dataManager.GetSysString(1601));
@@ -2835,15 +2835,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SWAP: {
 		/*int code1 = */BufferIO::ReadInt32(pbuf);
-		int c1 = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l1 = BufferIO::ReadUInt8(pbuf);
-		int s1 = BufferIO::ReadUInt8(pbuf);
-		/*int p1 = */BufferIO::ReadUInt8(pbuf);
+		int c1 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l1 = buffer_read<uint8_t>(pbuf);
+		int s1 = buffer_read<uint8_t>(pbuf);
+		/*int p1 = */buffer_read<uint8_t>(pbuf);
 		/*int code2 = */BufferIO::ReadInt32(pbuf);
-		int c2 = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l2 = BufferIO::ReadUInt8(pbuf);
-		int s2 = BufferIO::ReadUInt8(pbuf);
-		/*int p2 = */BufferIO::ReadUInt8(pbuf);
+		int c2 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l2 = buffer_read<uint8_t>(pbuf);
+		int s2 = buffer_read<uint8_t>(pbuf);
+		/*int p2 = */buffer_read<uint8_t>(pbuf);
 		myswprintf(event_string, dataManager.GetSysString(1602));
 		ClientCard* pc1 = mainGame->dField.GetCard(c1, l1, s1);
 		ClientCard* pc2 = mainGame->dField.GetCard(c2, l2, s2);
@@ -2878,10 +2878,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SUMMONING: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		/*int cc = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		/*int cl = */BufferIO::ReadUInt8(pbuf);
-		/*int cs = */BufferIO::ReadUInt8(pbuf);
-		/*int cp = */BufferIO::ReadUInt8(pbuf);
+		/*int cc = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		/*int cl = */buffer_read<uint8_t>(pbuf);
+		/*int cs = */buffer_read<uint8_t>(pbuf);
+		/*int cp = */buffer_read<uint8_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			soundManager.PlaySoundEffect(SOUND_SUMMON);
 			myswprintf(event_string, dataManager.GetSysString(1603), dataManager.GetName(code));
@@ -2901,10 +2901,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SPSUMMONING: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		/*int cc = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		/*int cl = */BufferIO::ReadUInt8(pbuf);
-		/*int cs = */BufferIO::ReadUInt8(pbuf);
-		/*int cp = */BufferIO::ReadUInt8(pbuf);
+		/*int cc = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		/*int cl = */buffer_read<uint8_t>(pbuf);
+		/*int cs = */buffer_read<uint8_t>(pbuf);
+		/*int cp = */buffer_read<uint8_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			CardData cd;
 			if(dataManager.GetData(code, &cd) && (cd.type & TYPE_TOKEN))
@@ -2927,10 +2927,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_FLIPSUMMONING: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		int cc = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int cl = BufferIO::ReadUInt8(pbuf);
-		int cs = BufferIO::ReadUInt8(pbuf);
-		unsigned int cp = BufferIO::ReadUInt8(pbuf);
+		int cc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int cl = buffer_read<uint8_t>(pbuf);
+		int cs = buffer_read<uint8_t>(pbuf);
+		unsigned int cp = buffer_read<uint8_t>(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(cc, cl, cs);
 		pcard->SetCode(code);
 		pcard->position = cp;
@@ -2955,15 +2955,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_CHAINING: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		int pcc = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int pcl = BufferIO::ReadUInt8(pbuf);
-		int pcs = BufferIO::ReadUInt8(pbuf);
-		int subs = BufferIO::ReadUInt8(pbuf);
-		int cc = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int cl = BufferIO::ReadUInt8(pbuf);
-		int cs = BufferIO::ReadUInt8(pbuf);
+		int pcc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int pcl = buffer_read<uint8_t>(pbuf);
+		int pcs = buffer_read<uint8_t>(pbuf);
+		int subs = buffer_read<uint8_t>(pbuf);
+		int cc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int cl = buffer_read<uint8_t>(pbuf);
+		int cs = buffer_read<uint8_t>(pbuf);
 		int desc = BufferIO::ReadInt32(pbuf);
-		/*int ct = */BufferIO::ReadUInt8(pbuf);
+		/*int ct = */buffer_read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		soundManager.PlaySoundEffect(SOUND_ACTIVATE);
@@ -3014,7 +3014,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CHAINED: {
-		int ct = BufferIO::ReadUInt8(pbuf);
+		int ct = buffer_read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		myswprintf(event_string, dataManager.GetSysString(1609), dataManager.GetName(mainGame->dField.current_chain.code));
@@ -3027,7 +3027,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CHAIN_SOLVING: {
-		int ct = BufferIO::ReadUInt8(pbuf);
+		int ct = buffer_read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		if(mainGame->dField.chains.size() > 1 || mainGame->gameConf.draw_single_chain) {
@@ -3044,7 +3044,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CHAIN_SOLVED: {
-		/*int ct = */BufferIO::ReadUInt8(pbuf);
+		/*int ct = */buffer_read<uint8_t>(pbuf);
 		return true;
 	}
 	case MSG_CHAIN_END: {
@@ -3058,7 +3058,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_CHAIN_NEGATED:
 	case MSG_CHAIN_DISABLED: {
-		int ct = BufferIO::ReadUInt8(pbuf);
+		int ct = buffer_read<uint8_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			soundManager.PlaySoundEffect(SOUND_NEGATE);
 			mainGame->showcardcode = mainGame->dField.chains[ct - 1].code;
@@ -3073,8 +3073,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_RANDOM_SELECTED: {
-		/*int player = */BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt8(pbuf);
+		/*int player = */buffer_read<uint8_t>(pbuf);
+		int count = buffer_read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			pbuf += count * 4;
 			return true;
@@ -3082,10 +3082,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		soundManager.PlaySoundEffect(SOUND_DICE);
 		ClientCard* pcards[10];
 		for (int i = 0; i < count; ++i) {
-			int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			unsigned int l = BufferIO::ReadUInt8(pbuf);
-			int s = BufferIO::ReadUInt8(pbuf);
-			int ss = BufferIO::ReadUInt8(pbuf);
+			int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			unsigned int l = buffer_read<uint8_t>(pbuf);
+			int s = buffer_read<uint8_t>(pbuf);
+			int ss = buffer_read<uint8_t>(pbuf);
 			if (l & LOCATION_OVERLAY)
 				pcards[i] = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
 			else
@@ -3099,16 +3099,16 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_BECOME_TARGET: {
 		//soundManager.PlaySoundEffect(SOUND_TARGET);
-		int count = BufferIO::ReadUInt8(pbuf);
+		int count = buffer_read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			pbuf += count * 4;
 			return true;
 		}
 		for (int i = 0; i < count; ++i) {
-			int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			unsigned int l = BufferIO::ReadUInt8(pbuf);
-			int s = BufferIO::ReadUInt8(pbuf);
-			/*int ss = */BufferIO::ReadUInt8(pbuf);
+			int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			unsigned int l = buffer_read<uint8_t>(pbuf);
+			int s = buffer_read<uint8_t>(pbuf);
+			/*int ss = */buffer_read<uint8_t>(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 			pcard->is_highlighting = true;
 			mainGame->dField.current_chain.target.insert(pcard);
@@ -3137,8 +3137,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_DRAW: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int count = BufferIO::ReadUInt8(pbuf);
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int count = buffer_read<uint8_t>(pbuf);
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
 			unsigned int code = BufferIO::ReadInt32(pbuf);
@@ -3171,7 +3171,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_DAMAGE: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
 		int val = BufferIO::ReadInt32(pbuf);
 		int final = mainGame->dInfo.lp[player] - val;
 		if (final < 0)
@@ -3202,7 +3202,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_RECOVER: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
 		int val = BufferIO::ReadInt32(pbuf);
 		int final = mainGame->dInfo.lp[player] + val;
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
@@ -3231,14 +3231,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_EQUIP: {
-		int c1 = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l1 = BufferIO::ReadUInt8(pbuf);
-		int s1 = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
-		int c2 = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l2 = BufferIO::ReadUInt8(pbuf);
-		int s2 = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
+		int c1 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l1 = buffer_read<uint8_t>(pbuf);
+		int s1 = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
+		int c2 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l2 = buffer_read<uint8_t>(pbuf);
+		int s2 = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
 		ClientCard* pc1 = mainGame->dField.GetCard(c1, l1, s1);
 		ClientCard* pc2 = mainGame->dField.GetCard(c2, l2, s2);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
@@ -3265,7 +3265,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_LPUPDATE: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
 		int val = BufferIO::ReadInt32(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			mainGame->dInfo.lp[player] = val;
@@ -3283,10 +3283,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_UNEQUIP: {
-		int c1 = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l1 = BufferIO::ReadUInt8(pbuf);
-		int s1 = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
+		int c1 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l1 = buffer_read<uint8_t>(pbuf);
+		int s1 = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c1, l1, s1);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			pc->equipTarget->equipped.erase(pc);
@@ -3304,14 +3304,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CARD_TARGET: {
-		int c1 = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l1 = BufferIO::ReadUInt8(pbuf);
-		int s1 = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
-		int c2 = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l2 = BufferIO::ReadUInt8(pbuf);
-		int s2 = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
+		int c1 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l1 = buffer_read<uint8_t>(pbuf);
+		int s1 = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
+		int c2 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l2 = buffer_read<uint8_t>(pbuf);
+		int s2 = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
 		ClientCard* pc1 = mainGame->dField.GetCard(c1, l1, s1);
 		ClientCard* pc2 = mainGame->dField.GetCard(c2, l2, s2);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
@@ -3330,14 +3330,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		break;
 	}
 	case MSG_CANCEL_TARGET: {
-		int c1 = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l1 = BufferIO::ReadUInt8(pbuf);
-		int s1 = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
-		int c2 = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l2 = BufferIO::ReadUInt8(pbuf);
-		int s2 = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
+		int c1 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l1 = buffer_read<uint8_t>(pbuf);
+		int s1 = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
+		int c2 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l2 = buffer_read<uint8_t>(pbuf);
+		int s2 = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
 		ClientCard* pc1 = mainGame->dField.GetCard(c1, l1, s1);
 		ClientCard* pc2 = mainGame->dField.GetCard(c2, l2, s2);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
@@ -3356,7 +3356,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		break;
 	}
 	case MSG_PAY_LPCOST: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
 		int cost = BufferIO::ReadInt32(pbuf);
 		int final = mainGame->dInfo.lp[player] - cost;
 		if (final < 0)
@@ -3384,9 +3384,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_ADD_COUNTER: {
 		int type = buffer_read<uint16_t>(pbuf);
-		int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l = BufferIO::ReadUInt8(pbuf);
-		int s = BufferIO::ReadUInt8(pbuf);
+		int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l = buffer_read<uint8_t>(pbuf);
+		int s = buffer_read<uint8_t>(pbuf);
 		int count = buffer_read<uint16_t>(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c, l, s);
 		if (pc->counters.count(type))
@@ -3407,9 +3407,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_REMOVE_COUNTER: {
 		int type = buffer_read<uint16_t>(pbuf);
-		int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l = BufferIO::ReadUInt8(pbuf);
-		int s = BufferIO::ReadUInt8(pbuf);
+		int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l = buffer_read<uint8_t>(pbuf);
+		int s = buffer_read<uint8_t>(pbuf);
 		int count = buffer_read<uint16_t>(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c, l, s);
 		pc->counters[type] -= count;
@@ -3429,15 +3429,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_ATTACK: {
-		int ca = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int la = BufferIO::ReadUInt8(pbuf);
-		int sa = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
+		int ca = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int la = buffer_read<uint8_t>(pbuf);
+		int sa = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
 		mainGame->dField.attacker = mainGame->dField.GetCard(ca, la, sa);
-		int cd = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int ld = BufferIO::ReadUInt8(pbuf);
-		int sd = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
+		int cd = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int ld = buffer_read<uint8_t>(pbuf);
+		int sd = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		float sy;
@@ -3480,20 +3480,20 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_BATTLE: {
-		int ca = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int la = BufferIO::ReadUInt8(pbuf);
-		int sa = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
+		int ca = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int la = buffer_read<uint8_t>(pbuf);
+		int sa = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
 		int aatk = BufferIO::ReadInt32(pbuf);
 		int adef = BufferIO::ReadInt32(pbuf);
-		/*int da = */BufferIO::ReadUInt8(pbuf);
-		int cd = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int ld = BufferIO::ReadUInt8(pbuf);
-		int sd = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
+		/*int da = */buffer_read<uint8_t>(pbuf);
+		int cd = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int ld = buffer_read<uint8_t>(pbuf);
+		int sd = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
 		int datk = BufferIO::ReadInt32(pbuf);
 		int ddef = BufferIO::ReadInt32(pbuf);
-		/*int dd = */BufferIO::ReadUInt8(pbuf);
+		/*int dd = */buffer_read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		mainGame->gMutex.lock();
@@ -3538,12 +3538,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_TOSS_COIN: {
-		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int count = BufferIO::ReadUInt8(pbuf);
+		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int count = buffer_read<uint8_t>(pbuf);
 		wchar_t* pwbuf = textBuffer;
 		BufferIO::CopyWStrRef(dataManager.GetSysString(1623), pwbuf, 256);
 		for (int i = 0; i < count; ++i) {
-			int res = BufferIO::ReadUInt8(pbuf);
+			int res = buffer_read<uint8_t>(pbuf);
 			*pwbuf++ = L'[';
 			BufferIO::CopyWStrRef(dataManager.GetSysString(res ? 60 : 61), pwbuf, 256);
 			*pwbuf++ = L']';
@@ -3561,12 +3561,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_TOSS_DICE: {
-		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int count = BufferIO::ReadUInt8(pbuf);
+		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int count = buffer_read<uint8_t>(pbuf);
 		wchar_t* pwbuf = textBuffer;
 		BufferIO::CopyWStrRef(dataManager.GetSysString(1624), pwbuf, 256);
 		for (int i = 0; i < count; ++i) {
-			int res = BufferIO::ReadUInt8(pbuf);
+			int res = buffer_read<uint8_t>(pbuf);
 			*pwbuf++ = L'[';
 			*pwbuf++ = L'0' + res;
 			*pwbuf++ = L']';
@@ -3584,7 +3584,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_ROCK_PAPER_SCISSORS: {
-		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
+		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		mainGame->gMutex.lock();
@@ -3593,7 +3593,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_HAND_RES: {
-		int res = BufferIO::ReadUInt8(pbuf);
+		int res = buffer_read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		mainGame->stHintMsg->setVisible(false);
@@ -3610,8 +3610,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_ANNOUNCE_RACE: {
-		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		mainGame->dField.announce_count = BufferIO::ReadUInt8(pbuf);
+		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		mainGame->dField.announce_count = buffer_read<uint8_t>(pbuf);
 		int available = BufferIO::ReadInt32(pbuf);
 		for(int i = 0, filter = 0x1; i < RACES_COUNT; ++i, filter <<= 1) {
 			mainGame->chkRace[i]->setChecked(false);
@@ -3630,8 +3630,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_ANNOUNCE_ATTRIB: {
-		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		mainGame->dField.announce_count = BufferIO::ReadUInt8(pbuf);
+		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		mainGame->dField.announce_count = buffer_read<uint8_t>(pbuf);
 		int available = BufferIO::ReadInt32(pbuf);
 		for(int i = 0, filter = 0x1; i < 7; ++i, filter <<= 1) {
 			mainGame->chkAttribute[i]->setChecked(false);
@@ -3650,8 +3650,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_ANNOUNCE_CARD: {
-		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int count = BufferIO::ReadUInt8(pbuf);
+		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int count = buffer_read<uint8_t>(pbuf);
 		mainGame->dField.declare_opcodes.clear();
 		for (int i = 0; i < count; ++i)
 			mainGame->dField.declare_opcodes.push_back(buffer_read<uint32_t>(pbuf));
@@ -3668,8 +3668,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_ANNOUNCE_NUMBER: {
-		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int count = BufferIO::ReadUInt8(pbuf);
+		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int count = buffer_read<uint8_t>(pbuf);
 		mainGame->gMutex.lock();
 		mainGame->cbANNumber->clear();
 		bool quickmode = count <= 12;
@@ -3720,11 +3720,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_CARD_HINT: {
-		int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		unsigned int l = BufferIO::ReadUInt8(pbuf);
-		int s = BufferIO::ReadUInt8(pbuf);
-		BufferIO::ReadUInt8(pbuf);
-		int chtype = BufferIO::ReadUInt8(pbuf);
+		int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		unsigned int l = buffer_read<uint8_t>(pbuf);
+		int s = buffer_read<uint8_t>(pbuf);
+		buffer_read<uint8_t>(pbuf);
+		int chtype = buffer_read<uint8_t>(pbuf);
 		int value = BufferIO::ReadInt32(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 		if(!pcard)
@@ -3757,8 +3757,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_PLAYER_HINT: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int chtype = BufferIO::ReadUInt8(pbuf);
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int chtype = buffer_read<uint8_t>(pbuf);
 		int value = BufferIO::ReadInt32(pbuf);
 		auto& player_desc_hints = mainGame->dField.player_desc_hints[player];
 		if(value == CARD_QUESTION && player == 0) {
@@ -3782,11 +3782,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_TAG_SWAP: {
-		int player = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		size_t mcount = (size_t)BufferIO::ReadUInt8(pbuf);
-		size_t ecount = (size_t)BufferIO::ReadUInt8(pbuf);
-		size_t pcount = (size_t)BufferIO::ReadUInt8(pbuf);
-		size_t hcount = (size_t)BufferIO::ReadUInt8(pbuf);
+		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		size_t mcount = (size_t)buffer_read<uint8_t>(pbuf);
+		size_t ecount = (size_t)buffer_read<uint8_t>(pbuf);
+		size_t pcount = (size_t)buffer_read<uint8_t>(pbuf);
+		size_t hcount = (size_t)buffer_read<uint8_t>(pbuf);
 		int topcode = BufferIO::ReadInt32(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			for (auto cit = mainGame->dField.deck[player].begin(); cit != mainGame->dField.deck[player].end(); ++cit) {
@@ -3899,19 +3899,19 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->gMutex.lock();
 		}
 		mainGame->dField.Clear();
-		mainGame->dInfo.duel_rule = BufferIO::ReadUInt8(pbuf);
+		mainGame->dInfo.duel_rule = buffer_read<uint8_t>(pbuf);
 		int val = 0;
 		for(int i = 0; i < 2; ++i) {
 			int p = mainGame->LocalPlayer(i);
 			mainGame->dInfo.lp[p] = BufferIO::ReadInt32(pbuf);
 			myswprintf(mainGame->dInfo.strLP[p], L"%d", mainGame->dInfo.lp[p]);
 			for(int seq = 0; seq < 7; ++seq) {
-				val = BufferIO::ReadUInt8(pbuf);
+				val = buffer_read<uint8_t>(pbuf);
 				if(val) {
 					ClientCard* ccard = new ClientCard;
 					mainGame->dField.AddCard(ccard, p, LOCATION_MZONE, seq);
-					ccard->position = BufferIO::ReadUInt8(pbuf);
-					val = BufferIO::ReadUInt8(pbuf);
+					ccard->position = buffer_read<uint8_t>(pbuf);
+					val = buffer_read<uint8_t>(pbuf);
 					if(val) {
 						for(int xyz = 0; xyz < val; ++xyz) {
 							ClientCard* xcard = new ClientCard;
@@ -3927,52 +3927,52 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				}
 			}
 			for(int seq = 0; seq < 8; ++seq) {
-				val = BufferIO::ReadUInt8(pbuf);
+				val = buffer_read<uint8_t>(pbuf);
 				if(val) {
 					ClientCard* ccard = new ClientCard;
 					mainGame->dField.AddCard(ccard, p, LOCATION_SZONE, seq);
-					ccard->position = BufferIO::ReadUInt8(pbuf);
+					ccard->position = buffer_read<uint8_t>(pbuf);
 				}
 			}
-			val = BufferIO::ReadUInt8(pbuf);
+			val = buffer_read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
 				ClientCard* ccard = new ClientCard;
 				mainGame->dField.AddCard(ccard, p, LOCATION_DECK, seq);
 			}
-			val = BufferIO::ReadUInt8(pbuf);
+			val = buffer_read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
 				ClientCard* ccard = new ClientCard;
 				mainGame->dField.AddCard(ccard, p, LOCATION_HAND, seq);
 			}
-			val = BufferIO::ReadUInt8(pbuf);
+			val = buffer_read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
 				ClientCard* ccard = new ClientCard;
 				mainGame->dField.AddCard(ccard, p, LOCATION_GRAVE, seq);
 			}
-			val = BufferIO::ReadUInt8(pbuf);
+			val = buffer_read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
 				ClientCard* ccard = new ClientCard;
 				mainGame->dField.AddCard(ccard, p, LOCATION_REMOVED, seq);
 			}
-			val = BufferIO::ReadUInt8(pbuf);
+			val = buffer_read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
 				ClientCard* ccard = new ClientCard;
 				mainGame->dField.AddCard(ccard, p, LOCATION_EXTRA, seq);
 			}
-			val = BufferIO::ReadUInt8(pbuf);
+			val = buffer_read<uint8_t>(pbuf);
 			mainGame->dField.extra_p_count[p] = val;
 		}
 		mainGame->dField.RefreshAllCards();
-		val = BufferIO::ReadUInt8(pbuf); //chains
+		val = buffer_read<uint8_t>(pbuf); //chains
 		for(int i = 0; i < val; ++i) {
 			unsigned int code = BufferIO::ReadInt32(pbuf);
-			int pcc = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			unsigned int pcl = BufferIO::ReadUInt8(pbuf);
-			int pcs = BufferIO::ReadUInt8(pbuf);
-			int subs = BufferIO::ReadUInt8(pbuf);
-			int cc = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-			unsigned int cl = BufferIO::ReadUInt8(pbuf);
-			int cs = BufferIO::ReadUInt8(pbuf);
+			int pcc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			unsigned int pcl = buffer_read<uint8_t>(pbuf);
+			int pcs = buffer_read<uint8_t>(pbuf);
+			int subs = buffer_read<uint8_t>(pbuf);
+			int cc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+			unsigned int cl = buffer_read<uint8_t>(pbuf);
+			int cs = buffer_read<uint8_t>(pbuf);
 			int desc = BufferIO::ReadInt32(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(pcc, pcl, pcs, subs);
 			mainGame->dField.current_chain.chain_card = pcard;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1273,11 +1273,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dInfo.lp[mainGame->LocalPlayer(1)] = BufferIO::ReadInt32(pbuf);
 		myswprintf(mainGame->dInfo.strLP[0], L"%d", mainGame->dInfo.lp[0]);
 		myswprintf(mainGame->dInfo.strLP[1], L"%d", mainGame->dInfo.lp[1]);
-		int deckc = BufferIO::ReadInt16(pbuf);
-		int extrac = BufferIO::ReadInt16(pbuf);
+		int deckc = BufferIO::ReadUInt16(pbuf);
+		int extrac = BufferIO::ReadUInt16(pbuf);
 		mainGame->dField.Initial(mainGame->LocalPlayer(0), deckc, extrac);
-		deckc = BufferIO::ReadInt16(pbuf);
-		extrac = BufferIO::ReadInt16(pbuf);
+		deckc = BufferIO::ReadUInt16(pbuf);
+		extrac = BufferIO::ReadUInt16(pbuf);
 		mainGame->dField.Initial(mainGame->LocalPlayer(1), deckc, extrac);
 		mainGame->dInfo.turn = 0;
 		mainGame->dInfo.is_shuffling = false;
@@ -1993,8 +1993,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SELECT_COUNTER: {
 		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
-		mainGame->dField.select_counter_type = BufferIO::ReadInt16(pbuf);
-		mainGame->dField.select_counter_count = BufferIO::ReadInt16(pbuf);
+		mainGame->dField.select_counter_type = BufferIO::ReadUInt16(pbuf);
+		mainGame->dField.select_counter_count = BufferIO::ReadUInt16(pbuf);
 		int count = BufferIO::ReadUInt8(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		int c, s, t/*, code*/;
@@ -2005,7 +2005,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 			l = BufferIO::ReadUInt8(pbuf);
 			s = BufferIO::ReadUInt8(pbuf);
-			t = BufferIO::ReadInt16(pbuf);
+			t = BufferIO::ReadUInt16(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
 			mainGame->dField.selectable_cards.push_back(pcard);
 			pcard->opParam = (t << 16) | t;
@@ -2540,7 +2540,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_NEW_PHASE: {
-		unsigned short phase = BufferIO::ReadInt16(pbuf);
+		unsigned short phase = BufferIO::ReadUInt16(pbuf);
 		mainGame->btnPhaseStatus->setVisible(false);
 		mainGame->btnBP->setVisible(false);
 		mainGame->btnM2->setVisible(false);
@@ -3383,11 +3383,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_ADD_COUNTER: {
-		int type = BufferIO::ReadInt16(pbuf);
+		int type = BufferIO::ReadUInt16(pbuf);
 		int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		unsigned int l = BufferIO::ReadUInt8(pbuf);
 		int s = BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadInt16(pbuf);
+		int count = BufferIO::ReadUInt16(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c, l, s);
 		if (pc->counters.count(type))
 			pc->counters[type] += count;
@@ -3406,11 +3406,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_REMOVE_COUNTER: {
-		int type = BufferIO::ReadInt16(pbuf);
+		int type = BufferIO::ReadUInt16(pbuf);
 		int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		unsigned int l = BufferIO::ReadUInt8(pbuf);
 		int s = BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadInt16(pbuf);
+		int count = BufferIO::ReadUInt16(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c, l, s);
 		pc->counters[type] -= count;
 		if (pc->counters[type] <= 0)

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -793,7 +793,8 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 			return;
 		uint16_t chat_player_type = BufferIO::Read<uint16_t>(pdata);
 		uint16_t chat_msg[LEN_CHAT_MSG];
-		buffer_read_block(pdata, chat_msg, chat_msg_size);
+		std::memcpy(chat_msg, pdata, chat_msg_size);
+		pdata += chat_msg_size;
 		const int chat_msg_len = chat_msg_size / sizeof(uint16_t);
 		if (chat_msg[chat_msg_len - 1] != 0)
 			return;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -249,7 +249,7 @@ int DuelClient::ClientThread() {
 }
 void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 	unsigned char* pdata = data;
-	unsigned char pktType = buffer_read<uint8_t>(pdata);
+	unsigned char pktType = BufferIO::Read<uint8_t>(pdata);
 	switch(pktType) {
 	case STOC_GAME_MSG: {
 		if (len < 1 + (int)sizeof(unsigned char))
@@ -791,7 +791,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		const int chat_msg_size = len - 1 - sizeof(uint16_t);
 		if (chat_msg_size % sizeof(uint16_t))
 			return;
-		uint16_t chat_player_type = buffer_read<uint16_t>(pdata);
+		uint16_t chat_player_type = BufferIO::Read<uint16_t>(pdata);
 		uint16_t chat_msg[LEN_CHAT_MSG];
 		buffer_read_block(pdata, chat_msg, chat_msg_size);
 		const int chat_msg_len = chat_msg_size / sizeof(uint16_t);
@@ -952,7 +952,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	unsigned char* pbuf = msg;
 	wchar_t textBuffer[256];
-	mainGame->dInfo.curMsg = buffer_read<uint8_t>(pbuf);
+	mainGame->dInfo.curMsg = BufferIO::Read<uint8_t>(pbuf);
 	if(mainGame->dInfo.curMsg != MSG_RETRY) {
 		std::memcpy(last_successful_msg, msg, len);
 		last_successful_msg_length = len;
@@ -986,7 +986,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_RETRY: {
 		if(last_successful_msg_length) {
 			auto p = last_successful_msg;
-			auto last_msg = buffer_read<uint8_t>(p);
+			auto last_msg = BufferIO::Read<uint8_t>(p);
 			int err_desc = 1421;
 			switch(last_msg) {
 			case MSG_ANNOUNCE_CARD:
@@ -1071,8 +1071,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_HINT: {
-		int type = buffer_read<uint8_t>(pbuf);
-		int player = buffer_read<uint8_t>(pbuf);
+		int type = BufferIO::Read<uint8_t>(pbuf);
+		int player = BufferIO::Read<uint8_t>(pbuf);
 		int data = BufferIO::ReadInt32(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
@@ -1206,8 +1206,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_WIN: {
 		mainGame->dInfo.isFinished = true;
-		int player = buffer_read<uint8_t>(pbuf);
-		int type = buffer_read<uint8_t>(pbuf);
+		int player = BufferIO::Read<uint8_t>(pbuf);
+		int type = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->showcarddif = 110;
 		mainGame->showcardp = 0;
 		mainGame->dInfo.vic_string = L"";
@@ -1258,7 +1258,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->gMutex.lock();
 		mainGame->dField.Clear();
 		mainGame->dInfo.isInDuel = true;
-		int playertype = buffer_read<uint8_t>(pbuf);
+		int playertype = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dInfo.isFirst =  (playertype & 0xf) ? false : true;
 		if(playertype & 0xf0)
 			mainGame->dInfo.player_type = 7;
@@ -1268,16 +1268,16 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			else
 				mainGame->dInfo.tag_player[0] = true;
 		}
-		mainGame->dInfo.duel_rule = buffer_read<uint8_t>(pbuf);
+		mainGame->dInfo.duel_rule = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dInfo.lp[mainGame->LocalPlayer(0)] = BufferIO::ReadInt32(pbuf);
 		mainGame->dInfo.lp[mainGame->LocalPlayer(1)] = BufferIO::ReadInt32(pbuf);
 		myswprintf(mainGame->dInfo.strLP[0], L"%d", mainGame->dInfo.lp[0]);
 		myswprintf(mainGame->dInfo.strLP[1], L"%d", mainGame->dInfo.lp[1]);
-		int deckc = buffer_read<uint16_t>(pbuf);
-		int extrac = buffer_read<uint16_t>(pbuf);
+		int deckc = BufferIO::Read<uint16_t>(pbuf);
+		int extrac = BufferIO::Read<uint16_t>(pbuf);
 		mainGame->dField.Initial(mainGame->LocalPlayer(0), deckc, extrac);
-		deckc = buffer_read<uint16_t>(pbuf);
-		extrac = buffer_read<uint16_t>(pbuf);
+		deckc = BufferIO::Read<uint16_t>(pbuf);
+		extrac = BufferIO::Read<uint16_t>(pbuf);
 		mainGame->dField.Initial(mainGame->LocalPlayer(1), deckc, extrac);
 		mainGame->dInfo.turn = 0;
 		mainGame->dInfo.is_shuffling = false;
@@ -1295,36 +1295,36 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_UPDATE_DATA: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int location = buffer_read<uint8_t>(pbuf);
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int location = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->gMutex.lock();
 		mainGame->dField.UpdateFieldCard(player, location, pbuf);
 		mainGame->gMutex.unlock();
 		return true;
 	}
 	case MSG_UPDATE_CARD: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int loc = buffer_read<uint8_t>(pbuf);
-		int seq = buffer_read<uint8_t>(pbuf);
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int loc = BufferIO::Read<uint8_t>(pbuf);
+		int seq = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->gMutex.lock();
 		mainGame->dField.UpdateCard(player, loc, seq, pbuf);
 		mainGame->gMutex.unlock();
 		break;
 	}
 	case MSG_SELECT_BATTLECMD: {
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
 		int desc, count, con, seq/*, diratt*/;
 		unsigned int code, loc;
 		ClientCard* pcard;
 		mainGame->dField.activatable_cards.clear();
 		mainGame->dField.activatable_descs.clear();
 		mainGame->dField.conti_cards.clear();
-		count = buffer_read<uint8_t>(pbuf);
+		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			loc = buffer_read<uint8_t>(pbuf);
-			seq = buffer_read<uint8_t>(pbuf);
+			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			loc = BufferIO::Read<uint8_t>(pbuf);
+			seq = BufferIO::Read<uint8_t>(pbuf);
 			desc = BufferIO::ReadInt32(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			int flag = 0;
@@ -1349,24 +1349,24 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			}
 		}
 		mainGame->dField.attackable_cards.clear();
-		count = buffer_read<uint8_t>(pbuf);
+		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			/*code = */BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			loc = buffer_read<uint8_t>(pbuf);
-			seq = buffer_read<uint8_t>(pbuf);
-			/*diratt = */buffer_read<uint8_t>(pbuf);
+			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			loc = BufferIO::Read<uint8_t>(pbuf);
+			seq = BufferIO::Read<uint8_t>(pbuf);
+			/*diratt = */BufferIO::Read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.attackable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_ATTACK;
 		}
 		mainGame->gMutex.lock();
-		if(buffer_read<uint8_t>(pbuf)) {
+		if(BufferIO::Read<uint8_t>(pbuf)) {
 			mainGame->btnM2->setVisible(true);
 			mainGame->btnM2->setEnabled(true);
 			mainGame->btnM2->setPressed(false);
 		}
-		if(buffer_read<uint8_t>(pbuf)) {
+		if(BufferIO::Read<uint8_t>(pbuf)) {
 			mainGame->btnEP->setVisible(true);
 			mainGame->btnEP->setEnabled(true);
 			mainGame->btnEP->setPressed(false);
@@ -1375,28 +1375,28 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_IDLECMD: {
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
 		int desc, count, con, seq;
 		unsigned int code, loc;
 		ClientCard* pcard;
 		mainGame->dField.summonable_cards.clear();
-		count = buffer_read<uint8_t>(pbuf);
+		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			loc = buffer_read<uint8_t>(pbuf);
-			seq = buffer_read<uint8_t>(pbuf);
+			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			loc = BufferIO::Read<uint8_t>(pbuf);
+			seq = BufferIO::Read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.summonable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_SUMMON;
 		}
 		mainGame->dField.spsummonable_cards.clear();
-		count = buffer_read<uint8_t>(pbuf);
+		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			loc = buffer_read<uint8_t>(pbuf);
-			seq = buffer_read<uint8_t>(pbuf);
+			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			loc = BufferIO::Read<uint8_t>(pbuf);
+			seq = BufferIO::Read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.spsummonable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_SPSUMMON;
@@ -1416,34 +1416,34 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			}
 		}
 		mainGame->dField.reposable_cards.clear();
-		count = buffer_read<uint8_t>(pbuf);
+		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			loc = buffer_read<uint8_t>(pbuf);
-			seq = buffer_read<uint8_t>(pbuf);
+			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			loc = BufferIO::Read<uint8_t>(pbuf);
+			seq = BufferIO::Read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.reposable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_REPOS;
 		}
 		mainGame->dField.msetable_cards.clear();
-		count = buffer_read<uint8_t>(pbuf);
+		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			loc = buffer_read<uint8_t>(pbuf);
-			seq = buffer_read<uint8_t>(pbuf);
+			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			loc = BufferIO::Read<uint8_t>(pbuf);
+			seq = BufferIO::Read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.msetable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_MSET;
 		}
 		mainGame->dField.ssetable_cards.clear();
-		count = buffer_read<uint8_t>(pbuf);
+		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			loc = buffer_read<uint8_t>(pbuf);
-			seq = buffer_read<uint8_t>(pbuf);
+			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			loc = BufferIO::Read<uint8_t>(pbuf);
+			seq = BufferIO::Read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			mainGame->dField.ssetable_cards.push_back(pcard);
 			pcard->cmdFlag |= COMMAND_SSET;
@@ -1451,12 +1451,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.activatable_cards.clear();
 		mainGame->dField.activatable_descs.clear();
 		mainGame->dField.conti_cards.clear();
-		count = buffer_read<uint8_t>(pbuf);
+		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			con = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			loc = buffer_read<uint8_t>(pbuf);
-			seq = buffer_read<uint8_t>(pbuf);
+			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			loc = BufferIO::Read<uint8_t>(pbuf);
+			seq = BufferIO::Read<uint8_t>(pbuf);
 			desc = BufferIO::ReadInt32(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			int flag = 0;
@@ -1480,17 +1480,17 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					mainGame->dField.extra_act[con] = true;
 			}
 		}
-		if(buffer_read<uint8_t>(pbuf)) {
+		if(BufferIO::Read<uint8_t>(pbuf)) {
 			mainGame->btnBP->setVisible(true);
 			mainGame->btnBP->setEnabled(true);
 			mainGame->btnBP->setPressed(false);
 		}
-		if(buffer_read<uint8_t>(pbuf)) {
+		if(BufferIO::Read<uint8_t>(pbuf)) {
 			mainGame->btnEP->setVisible(true);
 			mainGame->btnEP->setEnabled(true);
 			mainGame->btnEP->setPressed(false);
 		}
-		if (buffer_read<uint8_t>(pbuf)) {
+		if (BufferIO::Read<uint8_t>(pbuf)) {
 			mainGame->btnShuffle->setVisible(true);
 		} else {
 			mainGame->btnShuffle->setVisible(false);
@@ -1498,15 +1498,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_EFFECTYN: {
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l = buffer_read<uint8_t>(pbuf);
-		int s = buffer_read<uint8_t>(pbuf);
+		int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l = BufferIO::Read<uint8_t>(pbuf);
+		int s = BufferIO::Read<uint8_t>(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 		if (pcard->code != code)
 			pcard->SetCode(code);
-		buffer_read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
 		if(l != LOCATION_DECK) {
 			pcard->is_highlighting = true;
 			mainGame->dField.highlighting_card = pcard;
@@ -1532,7 +1532,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_YESNO: {
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
 		int desc = BufferIO::ReadInt32(pbuf);
 		mainGame->dField.highlighting_card = 0;
 		mainGame->gMutex.lock();
@@ -1542,8 +1542,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_OPTION: {
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
-		int count = buffer_read<uint8_t>(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.select_options.clear();
 		for (int i = 0; i < count; ++i)
 			mainGame->dField.select_options.push_back(BufferIO::ReadInt32(pbuf));
@@ -1552,11 +1552,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_CARD: {
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
-		mainGame->dField.select_cancelable = buffer_read<uint8_t>(pbuf) != 0;
-		mainGame->dField.select_min = buffer_read<uint8_t>(pbuf);
-		mainGame->dField.select_max = buffer_read<uint8_t>(pbuf);
-		int count = buffer_read<uint8_t>(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
+		mainGame->dField.select_cancelable = BufferIO::Read<uint8_t>(pbuf) != 0;
+		mainGame->dField.select_min = BufferIO::Read<uint8_t>(pbuf);
+		mainGame->dField.select_max = BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
 		int c, s, ss;
@@ -1570,10 +1570,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			l = buffer_read<uint8_t>(pbuf);
-			s = buffer_read<uint8_t>(pbuf);
-			ss = buffer_read<uint8_t>(pbuf);
+			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			l = BufferIO::Read<uint8_t>(pbuf);
+			s = BufferIO::Read<uint8_t>(pbuf);
+			ss = BufferIO::Read<uint8_t>(pbuf);
 			if (l & LOCATION_OVERLAY)
 				pcard = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
 			else
@@ -1616,13 +1616,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_UNSELECT_CARD: {
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
-		bool finishable = buffer_read<uint8_t>(pbuf) != 0;
-		bool cancelable = buffer_read<uint8_t>(pbuf) != 0;
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
+		bool finishable = BufferIO::Read<uint8_t>(pbuf) != 0;
+		bool cancelable = BufferIO::Read<uint8_t>(pbuf) != 0;
 		mainGame->dField.select_cancelable = finishable || cancelable;
-		mainGame->dField.select_min = buffer_read<uint8_t>(pbuf);
-		mainGame->dField.select_max = buffer_read<uint8_t>(pbuf);
-		int count1 = buffer_read<uint8_t>(pbuf);
+		mainGame->dField.select_min = BufferIO::Read<uint8_t>(pbuf);
+		mainGame->dField.select_max = BufferIO::Read<uint8_t>(pbuf);
+		int count1 = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
 		int c, s, ss;
@@ -1635,10 +1635,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pcard;
 		for (int i = 0; i < count1; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			l = buffer_read<uint8_t>(pbuf);
-			s = buffer_read<uint8_t>(pbuf);
-			ss = buffer_read<uint8_t>(pbuf);
+			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			l = BufferIO::Read<uint8_t>(pbuf);
+			s = BufferIO::Read<uint8_t>(pbuf);
+			ss = BufferIO::Read<uint8_t>(pbuf);
 			if (l & LOCATION_OVERLAY)
 				pcard = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
 			else
@@ -1656,13 +1656,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 					panelmode = true;
 			}
 		}
-		int count2 = buffer_read<uint8_t>(pbuf);
+		int count2 = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = count1; i < count1 + count2; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			l = buffer_read<uint8_t>(pbuf);
-			s = buffer_read<uint8_t>(pbuf);
-			ss = buffer_read<uint8_t>(pbuf);
+			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			l = BufferIO::Read<uint8_t>(pbuf);
+			s = BufferIO::Read<uint8_t>(pbuf);
+			ss = BufferIO::Read<uint8_t>(pbuf);
 			if (l & LOCATION_OVERLAY)
 				pcard = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
 			else
@@ -1731,10 +1731,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			int forced = BufferIO::ReadUInt8(pbuf);
 			flag |= forced << 8;
 			code = BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			l = buffer_read<uint8_t>(pbuf);
-			s = buffer_read<uint8_t>(pbuf);
-			ss = buffer_read<uint8_t>(pbuf);
+			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			l = BufferIO::Read<uint8_t>(pbuf);
+			s = BufferIO::Read<uint8_t>(pbuf);
+			ss = BufferIO::Read<uint8_t>(pbuf);
 			desc = BufferIO::ReadInt32(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s, ss);
 			mainGame->dField.activatable_cards.push_back(pcard);
@@ -1818,8 +1818,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SELECT_PLACE:
 	case MSG_SELECT_DISFIELD: {
-		int selecting_player = buffer_read<uint8_t>(pbuf);
-		int count = buffer_read<uint8_t>(pbuf);
+		int selecting_player = BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.select_min = count > 0 ? count : 1;
 		mainGame->dField.select_ready = false;
 		mainGame->dField.select_cancelable = count == 0;
@@ -1904,9 +1904,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_POSITION: {
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
 		unsigned int code = (unsigned int)BufferIO::ReadInt32(pbuf);
-		unsigned int positions = buffer_read<uint8_t>(pbuf);
+		unsigned int positions = BufferIO::Read<uint8_t>(pbuf);
 		if (positions == 0x1 || positions == 0x2 || positions == 0x4 || positions == 0x8) {
 			SetResponseI(positions);
 			return true;
@@ -1947,11 +1947,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_TRIBUTE: {
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
-		mainGame->dField.select_cancelable = buffer_read<uint8_t>(pbuf) != 0;
-		mainGame->dField.select_min = buffer_read<uint8_t>(pbuf);
-		mainGame->dField.select_max = buffer_read<uint8_t>(pbuf);
-		int count = buffer_read<uint8_t>(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
+		mainGame->dField.select_cancelable = BufferIO::Read<uint8_t>(pbuf) != 0;
+		mainGame->dField.select_min = BufferIO::Read<uint8_t>(pbuf);
+		mainGame->dField.select_max = BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
 		mainGame->dField.selectsum_all.clear();
@@ -1963,10 +1963,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.select_ready = false;
 		for (int i = 0; i < count; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			l = buffer_read<uint8_t>(pbuf);
-			s = buffer_read<uint8_t>(pbuf);
-			t = buffer_read<uint8_t>(pbuf);
+			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			l = BufferIO::Read<uint8_t>(pbuf);
+			s = BufferIO::Read<uint8_t>(pbuf);
+			t = BufferIO::Read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
 			if (code && pcard->code != code)
 				pcard->SetCode(code);
@@ -1992,20 +1992,20 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_COUNTER: {
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
-		mainGame->dField.select_counter_type = buffer_read<uint16_t>(pbuf);
-		mainGame->dField.select_counter_count = buffer_read<uint16_t>(pbuf);
-		int count = buffer_read<uint8_t>(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
+		mainGame->dField.select_counter_type = BufferIO::Read<uint16_t>(pbuf);
+		mainGame->dField.select_counter_count = BufferIO::Read<uint16_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		int c, s, t/*, code*/;
 		unsigned int l;
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
 			/*code = */BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			l = buffer_read<uint8_t>(pbuf);
-			s = buffer_read<uint8_t>(pbuf);
-			t = buffer_read<uint16_t>(pbuf);
+			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			l = BufferIO::Read<uint8_t>(pbuf);
+			s = BufferIO::Read<uint8_t>(pbuf);
+			t = BufferIO::Read<uint16_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
 			mainGame->dField.selectable_cards.push_back(pcard);
 			pcard->opParam = (t << 16) | t;
@@ -2019,21 +2019,21 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_SUM: {
-		mainGame->dField.select_mode = buffer_read<uint8_t>(pbuf);
-		/*int selecting_player = */buffer_read<uint8_t>(pbuf);
+		mainGame->dField.select_mode = BufferIO::Read<uint8_t>(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.select_sumval = BufferIO::ReadInt32(pbuf);
-		mainGame->dField.select_min = buffer_read<uint8_t>(pbuf);
-		mainGame->dField.select_max = buffer_read<uint8_t>(pbuf);
-		mainGame->dField.must_select_count = buffer_read<uint8_t>(pbuf);
+		mainGame->dField.select_min = BufferIO::Read<uint8_t>(pbuf);
+		mainGame->dField.select_max = BufferIO::Read<uint8_t>(pbuf);
+		mainGame->dField.must_select_count = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.selectsum_all.clear();
 		mainGame->dField.selected_cards.clear();
 		mainGame->dField.selectsum_cards.clear();
 		mainGame->dField.select_panalmode = false;
 		for (int i = 0; i < mainGame->dField.must_select_count; ++i) {
 			unsigned int code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			unsigned int l = buffer_read<uint8_t>(pbuf);
-			int s = buffer_read<uint8_t>(pbuf);
+			int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			unsigned int l = BufferIO::Read<uint8_t>(pbuf);
+			int s = BufferIO::Read<uint8_t>(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 			if (code != 0 && pcard->code != code)
 				pcard->SetCode(code);
@@ -2041,12 +2041,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			pcard->select_seq = 0;
 			mainGame->dField.selected_cards.push_back(pcard);
 		}
-		int count = buffer_read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
 			unsigned int code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			unsigned int l = buffer_read<uint8_t>(pbuf);
-			int s = buffer_read<uint8_t>(pbuf);
+			int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			unsigned int l = BufferIO::Read<uint8_t>(pbuf);
+			int s = BufferIO::Read<uint8_t>(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 			if (code != 0 && pcard->code != code)
 				pcard->SetCode(code);
@@ -2062,8 +2062,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return mainGame->dField.ShowSelectSum(mainGame->dField.select_panalmode);
 	}
 	case MSG_SORT_CARD: {
-		/*int player = */buffer_read<uint8_t>(pbuf);
-		int count = buffer_read<uint8_t>(pbuf);
+		/*int player = */BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		mainGame->dField.selected_cards.clear();
 		mainGame->dField.sort_list.clear();
@@ -2072,9 +2072,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
 			code = (unsigned int)BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			l = buffer_read<uint8_t>(pbuf);
-			s = buffer_read<uint8_t>(pbuf);
+			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			l = BufferIO::Read<uint8_t>(pbuf);
+			s = BufferIO::Read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
 			if (code != 0 && pcard->code != code)
 				pcard->SetCode(code);
@@ -2088,8 +2088,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_CONFIRM_DECKTOP: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int count = buffer_read<uint8_t>(pbuf);
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		unsigned int code;
 		ClientCard* pcard;
 		mainGame->dField.selectable_cards.clear();
@@ -2126,8 +2126,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CONFIRM_EXTRATOP: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int count = buffer_read<uint8_t>(pbuf);
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		unsigned int code;
 		ClientCard* pcard;
 		mainGame->dField.selectable_cards.clear();
@@ -2180,9 +2180,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->AddLog(textBuffer);
 		for (int i = 0; i < count; ++i) {
 			code = BufferIO::ReadInt32(pbuf);
-			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			l = buffer_read<uint8_t>(pbuf);
-			s = buffer_read<uint8_t>(pbuf);
+			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			l = BufferIO::Read<uint8_t>(pbuf);
+			s = BufferIO::Read<uint8_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
 			if (code != 0)
 				pcard->SetCode(code);
@@ -2265,7 +2265,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_SHUFFLE_DECK: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		if(mainGame->dField.deck[player].size() < 2)
 			return true;
 		bool rev = mainGame->dField.deck_reversed;
@@ -2304,8 +2304,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_SHUFFLE_HAND: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int count = buffer_read<uint8_t>(pbuf);
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			if(count > 1)
 				soundManager.PlaySoundEffect(SOUND_SHUFFLE);
@@ -2347,8 +2347,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_SHUFFLE_EXTRA: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int count = buffer_read<uint8_t>(pbuf);
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		if((mainGame->dField.extra[player].size() - mainGame->dField.extra_p_count[player]) < 2)
 			return true;
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
@@ -2376,11 +2376,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_REFRESH_DECK: {
-		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		return true;
 	}
 	case MSG_SWAP_GRAVE_DECK: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			mainGame->dField.grave[player].swap(mainGame->dField.deck[player]);
 			for (auto cit = mainGame->dField.grave[player].begin(); cit != mainGame->dField.grave[player].end(); ++cit)
@@ -2434,8 +2434,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_DECK_TOP: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int seq = buffer_read<uint8_t>(pbuf);
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int seq = BufferIO::Read<uint8_t>(pbuf);
 		unsigned int code = BufferIO::ReadInt32(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(player, LOCATION_DECK, mainGame->dField.deck[player].size() - 1 - seq);
 		pcard->SetCode(code & 0x7fffffff);
@@ -2448,8 +2448,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SHUFFLE_SET_CARD: {
 		std::vector<ClientCard*>* lst = 0;
-		unsigned int loc = buffer_read<uint8_t>(pbuf);
-		int count = buffer_read<uint8_t>(pbuf);
+		unsigned int loc = BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		if(loc == LOCATION_MZONE)
 			lst = mainGame->dField.mzone;
 		else
@@ -2459,10 +2459,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int c, s, ps;
 		unsigned int l;
 		for (int i = 0; i < count; ++i) {
-			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			l = buffer_read<uint8_t>(pbuf);
-			s = buffer_read<uint8_t>(pbuf);
-			buffer_read<uint8_t>(pbuf);
+			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			l = BufferIO::Read<uint8_t>(pbuf);
+			s = BufferIO::Read<uint8_t>(pbuf);
+			BufferIO::Read<uint8_t>(pbuf);
 			mc[i] = lst[c][s];
 			mc[i]->SetCode(0);
 			if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
@@ -2475,10 +2475,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping)
 			mainGame->WaitFrameSignal(20);
 		for (int i = 0; i < count; ++i) {
-			c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			l = buffer_read<uint8_t>(pbuf);
-			s = buffer_read<uint8_t>(pbuf);
-			buffer_read<uint8_t>(pbuf);
+			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			l = BufferIO::Read<uint8_t>(pbuf);
+			s = BufferIO::Read<uint8_t>(pbuf);
+			BufferIO::Read<uint8_t>(pbuf);
 			ps = mc[i]->sequence;
 			if (l > 0) {
 				swp = lst[c][s];
@@ -2500,7 +2500,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_NEW_TURN: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		mainGame->dInfo.turn++;
 		if(!mainGame->dInfo.isReplay && mainGame->dInfo.player_type < 7) {
 			mainGame->dField.tag_surrender = false;
@@ -2540,7 +2540,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_NEW_PHASE: {
-		unsigned short phase = buffer_read<uint16_t>(pbuf);
+		unsigned short phase = BufferIO::Read<uint16_t>(pbuf);
 		mainGame->btnPhaseStatus->setVisible(false);
 		mainGame->btnBP->setVisible(false);
 		mainGame->btnM2->setVisible(false);
@@ -2586,14 +2586,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_MOVE: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		int pc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int pl = buffer_read<uint8_t>(pbuf);
-		int ps = buffer_read<uint8_t>(pbuf);
-		unsigned int pp = buffer_read<uint8_t>(pbuf);
-		int cc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int cl = buffer_read<uint8_t>(pbuf);
-		int cs = buffer_read<uint8_t>(pbuf);
-		unsigned int cp = buffer_read<uint8_t>(pbuf);
+		int pc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int pl = BufferIO::Read<uint8_t>(pbuf);
+		int ps = BufferIO::Read<uint8_t>(pbuf);
+		unsigned int pp = BufferIO::Read<uint8_t>(pbuf);
+		int cc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
+		int cs = BufferIO::Read<uint8_t>(pbuf);
+		unsigned int cp = BufferIO::Read<uint8_t>(pbuf);
 		int reason = BufferIO::ReadInt32(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			if(cl & LOCATION_REMOVED && pl != cl)
@@ -2802,11 +2802,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_POS_CHANGE: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		int cc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int cl = buffer_read<uint8_t>(pbuf);
-		int cs = buffer_read<uint8_t>(pbuf);
-		unsigned int pp = buffer_read<uint8_t>(pbuf);
-		unsigned int cp = buffer_read<uint8_t>(pbuf);
+		int cc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
+		int cs = BufferIO::Read<uint8_t>(pbuf);
+		unsigned int pp = BufferIO::Read<uint8_t>(pbuf);
+		unsigned int cp = BufferIO::Read<uint8_t>(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(cc, cl, cs);
 		if((pp & POS_FACEUP) && (cp & POS_FACEDOWN)) {
 			pcard->counters.clear();
@@ -2824,10 +2824,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SET: {
 		/*int code = */BufferIO::ReadInt32(pbuf);
-		/*int cc = mainGame->LocalPlayer*/(buffer_read<uint8_t>(pbuf));
-		/*int cl = */buffer_read<uint8_t>(pbuf);
-		/*int cs = */buffer_read<uint8_t>(pbuf);
-		/*int cp = */buffer_read<uint8_t>(pbuf);
+		/*int cc = mainGame->LocalPlayer*/(BufferIO::Read<uint8_t>(pbuf));
+		/*int cl = */BufferIO::Read<uint8_t>(pbuf);
+		/*int cs = */BufferIO::Read<uint8_t>(pbuf);
+		/*int cp = */BufferIO::Read<uint8_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping)
 			soundManager.PlaySoundEffect(SOUND_SET);
 		myswprintf(event_string, dataManager.GetSysString(1601));
@@ -2835,15 +2835,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SWAP: {
 		/*int code1 = */BufferIO::ReadInt32(pbuf);
-		int c1 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l1 = buffer_read<uint8_t>(pbuf);
-		int s1 = buffer_read<uint8_t>(pbuf);
-		/*int p1 = */buffer_read<uint8_t>(pbuf);
+		int c1 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l1 = BufferIO::Read<uint8_t>(pbuf);
+		int s1 = BufferIO::Read<uint8_t>(pbuf);
+		/*int p1 = */BufferIO::Read<uint8_t>(pbuf);
 		/*int code2 = */BufferIO::ReadInt32(pbuf);
-		int c2 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l2 = buffer_read<uint8_t>(pbuf);
-		int s2 = buffer_read<uint8_t>(pbuf);
-		/*int p2 = */buffer_read<uint8_t>(pbuf);
+		int c2 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l2 = BufferIO::Read<uint8_t>(pbuf);
+		int s2 = BufferIO::Read<uint8_t>(pbuf);
+		/*int p2 = */BufferIO::Read<uint8_t>(pbuf);
 		myswprintf(event_string, dataManager.GetSysString(1602));
 		ClientCard* pc1 = mainGame->dField.GetCard(c1, l1, s1);
 		ClientCard* pc2 = mainGame->dField.GetCard(c2, l2, s2);
@@ -2878,10 +2878,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SUMMONING: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		/*int cc = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		/*int cl = */buffer_read<uint8_t>(pbuf);
-		/*int cs = */buffer_read<uint8_t>(pbuf);
-		/*int cp = */buffer_read<uint8_t>(pbuf);
+		/*int cc = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		/*int cl = */BufferIO::Read<uint8_t>(pbuf);
+		/*int cs = */BufferIO::Read<uint8_t>(pbuf);
+		/*int cp = */BufferIO::Read<uint8_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			soundManager.PlaySoundEffect(SOUND_SUMMON);
 			myswprintf(event_string, dataManager.GetSysString(1603), dataManager.GetName(code));
@@ -2901,10 +2901,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SPSUMMONING: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		/*int cc = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		/*int cl = */buffer_read<uint8_t>(pbuf);
-		/*int cs = */buffer_read<uint8_t>(pbuf);
-		/*int cp = */buffer_read<uint8_t>(pbuf);
+		/*int cc = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		/*int cl = */BufferIO::Read<uint8_t>(pbuf);
+		/*int cs = */BufferIO::Read<uint8_t>(pbuf);
+		/*int cp = */BufferIO::Read<uint8_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			CardData cd;
 			if(dataManager.GetData(code, &cd) && (cd.type & TYPE_TOKEN))
@@ -2927,10 +2927,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_FLIPSUMMONING: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		int cc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int cl = buffer_read<uint8_t>(pbuf);
-		int cs = buffer_read<uint8_t>(pbuf);
-		unsigned int cp = buffer_read<uint8_t>(pbuf);
+		int cc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
+		int cs = BufferIO::Read<uint8_t>(pbuf);
+		unsigned int cp = BufferIO::Read<uint8_t>(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(cc, cl, cs);
 		pcard->SetCode(code);
 		pcard->position = cp;
@@ -2955,15 +2955,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_CHAINING: {
 		unsigned int code = BufferIO::ReadInt32(pbuf);
-		int pcc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int pcl = buffer_read<uint8_t>(pbuf);
-		int pcs = buffer_read<uint8_t>(pbuf);
-		int subs = buffer_read<uint8_t>(pbuf);
-		int cc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int cl = buffer_read<uint8_t>(pbuf);
-		int cs = buffer_read<uint8_t>(pbuf);
+		int pcc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int pcl = BufferIO::Read<uint8_t>(pbuf);
+		int pcs = BufferIO::Read<uint8_t>(pbuf);
+		int subs = BufferIO::Read<uint8_t>(pbuf);
+		int cc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
+		int cs = BufferIO::Read<uint8_t>(pbuf);
 		int desc = BufferIO::ReadInt32(pbuf);
-		/*int ct = */buffer_read<uint8_t>(pbuf);
+		/*int ct = */BufferIO::Read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		soundManager.PlaySoundEffect(SOUND_ACTIVATE);
@@ -3014,7 +3014,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CHAINED: {
-		int ct = buffer_read<uint8_t>(pbuf);
+		int ct = BufferIO::Read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		myswprintf(event_string, dataManager.GetSysString(1609), dataManager.GetName(mainGame->dField.current_chain.code));
@@ -3027,7 +3027,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CHAIN_SOLVING: {
-		int ct = buffer_read<uint8_t>(pbuf);
+		int ct = BufferIO::Read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		if(mainGame->dField.chains.size() > 1 || mainGame->gameConf.draw_single_chain) {
@@ -3044,7 +3044,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CHAIN_SOLVED: {
-		/*int ct = */buffer_read<uint8_t>(pbuf);
+		/*int ct = */BufferIO::Read<uint8_t>(pbuf);
 		return true;
 	}
 	case MSG_CHAIN_END: {
@@ -3058,7 +3058,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_CHAIN_NEGATED:
 	case MSG_CHAIN_DISABLED: {
-		int ct = buffer_read<uint8_t>(pbuf);
+		int ct = BufferIO::Read<uint8_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			soundManager.PlaySoundEffect(SOUND_NEGATE);
 			mainGame->showcardcode = mainGame->dField.chains[ct - 1].code;
@@ -3073,8 +3073,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_RANDOM_SELECTED: {
-		/*int player = */buffer_read<uint8_t>(pbuf);
-		int count = buffer_read<uint8_t>(pbuf);
+		/*int player = */BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			pbuf += count * 4;
 			return true;
@@ -3082,10 +3082,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		soundManager.PlaySoundEffect(SOUND_DICE);
 		ClientCard* pcards[10];
 		for (int i = 0; i < count; ++i) {
-			int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			unsigned int l = buffer_read<uint8_t>(pbuf);
-			int s = buffer_read<uint8_t>(pbuf);
-			int ss = buffer_read<uint8_t>(pbuf);
+			int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			unsigned int l = BufferIO::Read<uint8_t>(pbuf);
+			int s = BufferIO::Read<uint8_t>(pbuf);
+			int ss = BufferIO::Read<uint8_t>(pbuf);
 			if (l & LOCATION_OVERLAY)
 				pcards[i] = mainGame->dField.GetCard(c, l & 0x7f, s)->overlayed[ss];
 			else
@@ -3099,16 +3099,16 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_BECOME_TARGET: {
 		//soundManager.PlaySoundEffect(SOUND_TARGET);
-		int count = buffer_read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			pbuf += count * 4;
 			return true;
 		}
 		for (int i = 0; i < count; ++i) {
-			int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			unsigned int l = buffer_read<uint8_t>(pbuf);
-			int s = buffer_read<uint8_t>(pbuf);
-			/*int ss = */buffer_read<uint8_t>(pbuf);
+			int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			unsigned int l = BufferIO::Read<uint8_t>(pbuf);
+			int s = BufferIO::Read<uint8_t>(pbuf);
+			/*int ss = */BufferIO::Read<uint8_t>(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 			pcard->is_highlighting = true;
 			mainGame->dField.current_chain.target.insert(pcard);
@@ -3137,8 +3137,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_DRAW: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int count = buffer_read<uint8_t>(pbuf);
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
 			unsigned int code = BufferIO::ReadInt32(pbuf);
@@ -3171,7 +3171,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_DAMAGE: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		int val = BufferIO::ReadInt32(pbuf);
 		int final = mainGame->dInfo.lp[player] - val;
 		if (final < 0)
@@ -3202,7 +3202,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_RECOVER: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		int val = BufferIO::ReadInt32(pbuf);
 		int final = mainGame->dInfo.lp[player] + val;
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
@@ -3231,14 +3231,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_EQUIP: {
-		int c1 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l1 = buffer_read<uint8_t>(pbuf);
-		int s1 = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
-		int c2 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l2 = buffer_read<uint8_t>(pbuf);
-		int s2 = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
+		int c1 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l1 = BufferIO::Read<uint8_t>(pbuf);
+		int s1 = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
+		int c2 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l2 = BufferIO::Read<uint8_t>(pbuf);
+		int s2 = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
 		ClientCard* pc1 = mainGame->dField.GetCard(c1, l1, s1);
 		ClientCard* pc2 = mainGame->dField.GetCard(c2, l2, s2);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
@@ -3265,7 +3265,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_LPUPDATE: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		int val = BufferIO::ReadInt32(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			mainGame->dInfo.lp[player] = val;
@@ -3283,10 +3283,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_UNEQUIP: {
-		int c1 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l1 = buffer_read<uint8_t>(pbuf);
-		int s1 = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
+		int c1 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l1 = BufferIO::Read<uint8_t>(pbuf);
+		int s1 = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c1, l1, s1);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			pc->equipTarget->equipped.erase(pc);
@@ -3304,14 +3304,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CARD_TARGET: {
-		int c1 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l1 = buffer_read<uint8_t>(pbuf);
-		int s1 = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
-		int c2 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l2 = buffer_read<uint8_t>(pbuf);
-		int s2 = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
+		int c1 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l1 = BufferIO::Read<uint8_t>(pbuf);
+		int s1 = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
+		int c2 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l2 = BufferIO::Read<uint8_t>(pbuf);
+		int s2 = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
 		ClientCard* pc1 = mainGame->dField.GetCard(c1, l1, s1);
 		ClientCard* pc2 = mainGame->dField.GetCard(c2, l2, s2);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
@@ -3330,14 +3330,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		break;
 	}
 	case MSG_CANCEL_TARGET: {
-		int c1 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l1 = buffer_read<uint8_t>(pbuf);
-		int s1 = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
-		int c2 = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l2 = buffer_read<uint8_t>(pbuf);
-		int s2 = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
+		int c1 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l1 = BufferIO::Read<uint8_t>(pbuf);
+		int s1 = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
+		int c2 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l2 = BufferIO::Read<uint8_t>(pbuf);
+		int s2 = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
 		ClientCard* pc1 = mainGame->dField.GetCard(c1, l1, s1);
 		ClientCard* pc2 = mainGame->dField.GetCard(c2, l2, s2);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
@@ -3356,7 +3356,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		break;
 	}
 	case MSG_PAY_LPCOST: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		int cost = BufferIO::ReadInt32(pbuf);
 		int final = mainGame->dInfo.lp[player] - cost;
 		if (final < 0)
@@ -3383,11 +3383,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_ADD_COUNTER: {
-		int type = buffer_read<uint16_t>(pbuf);
-		int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l = buffer_read<uint8_t>(pbuf);
-		int s = buffer_read<uint8_t>(pbuf);
-		int count = buffer_read<uint16_t>(pbuf);
+		int type = BufferIO::Read<uint16_t>(pbuf);
+		int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l = BufferIO::Read<uint8_t>(pbuf);
+		int s = BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint16_t>(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c, l, s);
 		if (pc->counters.count(type))
 			pc->counters[type] += count;
@@ -3406,11 +3406,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_REMOVE_COUNTER: {
-		int type = buffer_read<uint16_t>(pbuf);
-		int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l = buffer_read<uint8_t>(pbuf);
-		int s = buffer_read<uint8_t>(pbuf);
-		int count = buffer_read<uint16_t>(pbuf);
+		int type = BufferIO::Read<uint16_t>(pbuf);
+		int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l = BufferIO::Read<uint8_t>(pbuf);
+		int s = BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint16_t>(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c, l, s);
 		pc->counters[type] -= count;
 		if (pc->counters[type] <= 0)
@@ -3429,15 +3429,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_ATTACK: {
-		int ca = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int la = buffer_read<uint8_t>(pbuf);
-		int sa = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
+		int ca = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int la = BufferIO::Read<uint8_t>(pbuf);
+		int sa = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.attacker = mainGame->dField.GetCard(ca, la, sa);
-		int cd = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int ld = buffer_read<uint8_t>(pbuf);
-		int sd = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
+		int cd = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int ld = BufferIO::Read<uint8_t>(pbuf);
+		int sd = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		float sy;
@@ -3480,20 +3480,20 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_BATTLE: {
-		int ca = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int la = buffer_read<uint8_t>(pbuf);
-		int sa = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
+		int ca = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int la = BufferIO::Read<uint8_t>(pbuf);
+		int sa = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
 		int aatk = BufferIO::ReadInt32(pbuf);
 		int adef = BufferIO::ReadInt32(pbuf);
-		/*int da = */buffer_read<uint8_t>(pbuf);
-		int cd = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int ld = buffer_read<uint8_t>(pbuf);
-		int sd = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
+		/*int da = */BufferIO::Read<uint8_t>(pbuf);
+		int cd = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int ld = BufferIO::Read<uint8_t>(pbuf);
+		int sd = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
 		int datk = BufferIO::ReadInt32(pbuf);
 		int ddef = BufferIO::ReadInt32(pbuf);
-		/*int dd = */buffer_read<uint8_t>(pbuf);
+		/*int dd = */BufferIO::Read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		mainGame->gMutex.lock();
@@ -3538,12 +3538,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_TOSS_COIN: {
-		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int count = buffer_read<uint8_t>(pbuf);
+		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		wchar_t* pwbuf = textBuffer;
 		BufferIO::CopyWStrRef(dataManager.GetSysString(1623), pwbuf, 256);
 		for (int i = 0; i < count; ++i) {
-			int res = buffer_read<uint8_t>(pbuf);
+			int res = BufferIO::Read<uint8_t>(pbuf);
 			*pwbuf++ = L'[';
 			BufferIO::CopyWStrRef(dataManager.GetSysString(res ? 60 : 61), pwbuf, 256);
 			*pwbuf++ = L']';
@@ -3561,12 +3561,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_TOSS_DICE: {
-		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int count = buffer_read<uint8_t>(pbuf);
+		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		wchar_t* pwbuf = textBuffer;
 		BufferIO::CopyWStrRef(dataManager.GetSysString(1624), pwbuf, 256);
 		for (int i = 0; i < count; ++i) {
-			int res = buffer_read<uint8_t>(pbuf);
+			int res = BufferIO::Read<uint8_t>(pbuf);
 			*pwbuf++ = L'[';
 			*pwbuf++ = L'0' + res;
 			*pwbuf++ = L']';
@@ -3584,7 +3584,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_ROCK_PAPER_SCISSORS: {
-		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
+		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		mainGame->gMutex.lock();
@@ -3593,7 +3593,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_HAND_RES: {
-		int res = buffer_read<uint8_t>(pbuf);
+		int res = BufferIO::Read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		mainGame->stHintMsg->setVisible(false);
@@ -3610,8 +3610,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_ANNOUNCE_RACE: {
-		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		mainGame->dField.announce_count = buffer_read<uint8_t>(pbuf);
+		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		mainGame->dField.announce_count = BufferIO::Read<uint8_t>(pbuf);
 		int available = BufferIO::ReadInt32(pbuf);
 		for(int i = 0, filter = 0x1; i < RACES_COUNT; ++i, filter <<= 1) {
 			mainGame->chkRace[i]->setChecked(false);
@@ -3630,8 +3630,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_ANNOUNCE_ATTRIB: {
-		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		mainGame->dField.announce_count = buffer_read<uint8_t>(pbuf);
+		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		mainGame->dField.announce_count = BufferIO::Read<uint8_t>(pbuf);
 		int available = BufferIO::ReadInt32(pbuf);
 		for(int i = 0, filter = 0x1; i < 7; ++i, filter <<= 1) {
 			mainGame->chkAttribute[i]->setChecked(false);
@@ -3650,11 +3650,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_ANNOUNCE_CARD: {
-		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int count = buffer_read<uint8_t>(pbuf);
+		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.declare_opcodes.clear();
 		for (int i = 0; i < count; ++i)
-			mainGame->dField.declare_opcodes.push_back(buffer_read<uint32_t>(pbuf));
+			mainGame->dField.declare_opcodes.push_back(BufferIO::Read<uint32_t>(pbuf));
 		if(select_hint)
 			myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
 		else myswprintf(textBuffer, dataManager.GetSysString(564));
@@ -3668,8 +3668,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_ANNOUNCE_NUMBER: {
-		/*int player = */mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int count = buffer_read<uint8_t>(pbuf);
+		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->gMutex.lock();
 		mainGame->cbANNumber->clear();
 		bool quickmode = count <= 12;
@@ -3720,11 +3720,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_CARD_HINT: {
-		int c = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		unsigned int l = buffer_read<uint8_t>(pbuf);
-		int s = buffer_read<uint8_t>(pbuf);
-		buffer_read<uint8_t>(pbuf);
-		int chtype = buffer_read<uint8_t>(pbuf);
+		int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		unsigned int l = BufferIO::Read<uint8_t>(pbuf);
+		int s = BufferIO::Read<uint8_t>(pbuf);
+		BufferIO::Read<uint8_t>(pbuf);
+		int chtype = BufferIO::Read<uint8_t>(pbuf);
 		int value = BufferIO::ReadInt32(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 		if(!pcard)
@@ -3757,8 +3757,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_PLAYER_HINT: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		int chtype = buffer_read<uint8_t>(pbuf);
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int chtype = BufferIO::Read<uint8_t>(pbuf);
 		int value = BufferIO::ReadInt32(pbuf);
 		auto& player_desc_hints = mainGame->dField.player_desc_hints[player];
 		if(value == CARD_QUESTION && player == 0) {
@@ -3782,11 +3782,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_TAG_SWAP: {
-		int player = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-		size_t mcount = (size_t)buffer_read<uint8_t>(pbuf);
-		size_t ecount = (size_t)buffer_read<uint8_t>(pbuf);
-		size_t pcount = (size_t)buffer_read<uint8_t>(pbuf);
-		size_t hcount = (size_t)buffer_read<uint8_t>(pbuf);
+		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		size_t mcount = (size_t)BufferIO::Read<uint8_t>(pbuf);
+		size_t ecount = (size_t)BufferIO::Read<uint8_t>(pbuf);
+		size_t pcount = (size_t)BufferIO::Read<uint8_t>(pbuf);
+		size_t hcount = (size_t)BufferIO::Read<uint8_t>(pbuf);
 		int topcode = BufferIO::ReadInt32(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			for (auto cit = mainGame->dField.deck[player].begin(); cit != mainGame->dField.deck[player].end(); ++cit) {
@@ -3899,19 +3899,19 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->gMutex.lock();
 		}
 		mainGame->dField.Clear();
-		mainGame->dInfo.duel_rule = buffer_read<uint8_t>(pbuf);
+		mainGame->dInfo.duel_rule = BufferIO::Read<uint8_t>(pbuf);
 		int val = 0;
 		for(int i = 0; i < 2; ++i) {
 			int p = mainGame->LocalPlayer(i);
 			mainGame->dInfo.lp[p] = BufferIO::ReadInt32(pbuf);
 			myswprintf(mainGame->dInfo.strLP[p], L"%d", mainGame->dInfo.lp[p]);
 			for(int seq = 0; seq < 7; ++seq) {
-				val = buffer_read<uint8_t>(pbuf);
+				val = BufferIO::Read<uint8_t>(pbuf);
 				if(val) {
 					ClientCard* ccard = new ClientCard;
 					mainGame->dField.AddCard(ccard, p, LOCATION_MZONE, seq);
-					ccard->position = buffer_read<uint8_t>(pbuf);
-					val = buffer_read<uint8_t>(pbuf);
+					ccard->position = BufferIO::Read<uint8_t>(pbuf);
+					val = BufferIO::Read<uint8_t>(pbuf);
 					if(val) {
 						for(int xyz = 0; xyz < val; ++xyz) {
 							ClientCard* xcard = new ClientCard;
@@ -3927,52 +3927,52 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				}
 			}
 			for(int seq = 0; seq < 8; ++seq) {
-				val = buffer_read<uint8_t>(pbuf);
+				val = BufferIO::Read<uint8_t>(pbuf);
 				if(val) {
 					ClientCard* ccard = new ClientCard;
 					mainGame->dField.AddCard(ccard, p, LOCATION_SZONE, seq);
-					ccard->position = buffer_read<uint8_t>(pbuf);
+					ccard->position = BufferIO::Read<uint8_t>(pbuf);
 				}
 			}
-			val = buffer_read<uint8_t>(pbuf);
+			val = BufferIO::Read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
 				ClientCard* ccard = new ClientCard;
 				mainGame->dField.AddCard(ccard, p, LOCATION_DECK, seq);
 			}
-			val = buffer_read<uint8_t>(pbuf);
+			val = BufferIO::Read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
 				ClientCard* ccard = new ClientCard;
 				mainGame->dField.AddCard(ccard, p, LOCATION_HAND, seq);
 			}
-			val = buffer_read<uint8_t>(pbuf);
+			val = BufferIO::Read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
 				ClientCard* ccard = new ClientCard;
 				mainGame->dField.AddCard(ccard, p, LOCATION_GRAVE, seq);
 			}
-			val = buffer_read<uint8_t>(pbuf);
+			val = BufferIO::Read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
 				ClientCard* ccard = new ClientCard;
 				mainGame->dField.AddCard(ccard, p, LOCATION_REMOVED, seq);
 			}
-			val = buffer_read<uint8_t>(pbuf);
+			val = BufferIO::Read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
 				ClientCard* ccard = new ClientCard;
 				mainGame->dField.AddCard(ccard, p, LOCATION_EXTRA, seq);
 			}
-			val = buffer_read<uint8_t>(pbuf);
+			val = BufferIO::Read<uint8_t>(pbuf);
 			mainGame->dField.extra_p_count[p] = val;
 		}
 		mainGame->dField.RefreshAllCards();
-		val = buffer_read<uint8_t>(pbuf); //chains
+		val = BufferIO::Read<uint8_t>(pbuf); //chains
 		for(int i = 0; i < val; ++i) {
 			unsigned int code = BufferIO::ReadInt32(pbuf);
-			int pcc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			unsigned int pcl = buffer_read<uint8_t>(pbuf);
-			int pcs = buffer_read<uint8_t>(pbuf);
-			int subs = buffer_read<uint8_t>(pbuf);
-			int cc = mainGame->LocalPlayer(buffer_read<uint8_t>(pbuf));
-			unsigned int cl = buffer_read<uint8_t>(pbuf);
-			int cs = buffer_read<uint8_t>(pbuf);
+			int pcc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			unsigned int pcl = BufferIO::Read<uint8_t>(pbuf);
+			int pcs = BufferIO::Read<uint8_t>(pbuf);
+			int subs = BufferIO::Read<uint8_t>(pbuf);
+			int cc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+			unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
+			int cs = BufferIO::Read<uint8_t>(pbuf);
 			int desc = BufferIO::ReadInt32(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(pcc, pcl, pcs, subs);
 			mainGame->dField.current_chain.chain_card = pcard;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -438,13 +438,13 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		if (len < 1 + (int)sizeof(int16_t) * 6)
 			return;
 		mainGame->gMutex.lock();
-		int deckc = BufferIO::ReadInt16(pdata);
-		int extrac = BufferIO::ReadInt16(pdata);
-		int sidec = BufferIO::ReadInt16(pdata);
+		int deckc = BufferIO::Read<uint16_t>(pdata);
+		int extrac = BufferIO::Read<uint16_t>(pdata);
+		int sidec = BufferIO::Read<uint16_t>(pdata);
 		mainGame->dField.Initial(0, deckc, extrac, sidec);
-		deckc = BufferIO::ReadInt16(pdata);
-		extrac = BufferIO::ReadInt16(pdata);
-		sidec = BufferIO::ReadInt16(pdata);
+		deckc = BufferIO::Read<uint16_t>(pdata);
+		extrac = BufferIO::Read<uint16_t>(pdata);
+		sidec = BufferIO::Read<uint16_t>(pdata);
 		mainGame->dField.Initial(1, deckc, extrac, sidec);
 		mainGame->gMutex.unlock();
 		break;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1712,9 +1712,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return false;
 	}
 	case MSG_SELECT_CHAIN: {
-		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt8(pbuf);
-		int specount = BufferIO::ReadUInt8(pbuf);
+		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
+		int specount = BufferIO::Read<uint8_t>(pbuf);
 		/*int hint0 = */BufferIO::ReadInt32(pbuf);
 		/*int hint1 = */BufferIO::ReadInt32(pbuf);
 		int c, s, ss, desc;
@@ -1728,8 +1728,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.activatable_descs.clear();
 		mainGame->dField.conti_cards.clear();
 		for (int i = 0; i < count; ++i) {
-			int flag = BufferIO::ReadUInt8(pbuf);
-			int forced = BufferIO::ReadUInt8(pbuf);
+			int flag = BufferIO::Read<uint8_t>(pbuf);
+			int forced = BufferIO::Read<uint8_t>(pbuf);
 			flag |= forced << 8;
 			code = BufferIO::ReadInt32(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
@@ -2164,9 +2164,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CONFIRM_CARDS: {
-		/*int player = */mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
-		int skip_panel = BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt8(pbuf);
+		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+		int skip_panel = BufferIO::Read<uint8_t>(pbuf);
+		int count = BufferIO::Read<uint8_t>(pbuf);
 		int c, s;
 		unsigned int code, l;
 		std::vector<ClientCard*> field_confirm;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1273,11 +1273,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dInfo.lp[mainGame->LocalPlayer(1)] = BufferIO::ReadInt32(pbuf);
 		myswprintf(mainGame->dInfo.strLP[0], L"%d", mainGame->dInfo.lp[0]);
 		myswprintf(mainGame->dInfo.strLP[1], L"%d", mainGame->dInfo.lp[1]);
-		int deckc = BufferIO::ReadUInt16(pbuf);
-		int extrac = BufferIO::ReadUInt16(pbuf);
+		int deckc = buffer_read<uint16_t>(pbuf);
+		int extrac = buffer_read<uint16_t>(pbuf);
 		mainGame->dField.Initial(mainGame->LocalPlayer(0), deckc, extrac);
-		deckc = BufferIO::ReadUInt16(pbuf);
-		extrac = BufferIO::ReadUInt16(pbuf);
+		deckc = buffer_read<uint16_t>(pbuf);
+		extrac = buffer_read<uint16_t>(pbuf);
 		mainGame->dField.Initial(mainGame->LocalPlayer(1), deckc, extrac);
 		mainGame->dInfo.turn = 0;
 		mainGame->dInfo.is_shuffling = false;
@@ -1993,8 +1993,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SELECT_COUNTER: {
 		/*int selecting_player = */BufferIO::ReadUInt8(pbuf);
-		mainGame->dField.select_counter_type = BufferIO::ReadUInt16(pbuf);
-		mainGame->dField.select_counter_count = BufferIO::ReadUInt16(pbuf);
+		mainGame->dField.select_counter_type = buffer_read<uint16_t>(pbuf);
+		mainGame->dField.select_counter_count = buffer_read<uint16_t>(pbuf);
 		int count = BufferIO::ReadUInt8(pbuf);
 		mainGame->dField.selectable_cards.clear();
 		int c, s, t/*, code*/;
@@ -2005,7 +2005,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 			l = BufferIO::ReadUInt8(pbuf);
 			s = BufferIO::ReadUInt8(pbuf);
-			t = BufferIO::ReadUInt16(pbuf);
+			t = buffer_read<uint16_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s);
 			mainGame->dField.selectable_cards.push_back(pcard);
 			pcard->opParam = (t << 16) | t;
@@ -2540,7 +2540,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_NEW_PHASE: {
-		unsigned short phase = BufferIO::ReadUInt16(pbuf);
+		unsigned short phase = buffer_read<uint16_t>(pbuf);
 		mainGame->btnPhaseStatus->setVisible(false);
 		mainGame->btnBP->setVisible(false);
 		mainGame->btnM2->setVisible(false);
@@ -3383,11 +3383,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_ADD_COUNTER: {
-		int type = BufferIO::ReadUInt16(pbuf);
+		int type = buffer_read<uint16_t>(pbuf);
 		int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		unsigned int l = BufferIO::ReadUInt8(pbuf);
 		int s = BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt16(pbuf);
+		int count = buffer_read<uint16_t>(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c, l, s);
 		if (pc->counters.count(type))
 			pc->counters[type] += count;
@@ -3406,11 +3406,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_REMOVE_COUNTER: {
-		int type = BufferIO::ReadUInt16(pbuf);
+		int type = buffer_read<uint16_t>(pbuf);
 		int c = mainGame->LocalPlayer(BufferIO::ReadUInt8(pbuf));
 		unsigned int l = BufferIO::ReadUInt8(pbuf);
 		int s = BufferIO::ReadUInt8(pbuf);
-		int count = BufferIO::ReadUInt16(pbuf);
+		int count = buffer_read<uint16_t>(pbuf);
 		ClientCard* pc = mainGame->dField.GetCard(c, l, s);
 		pc->counters[type] -= count;
 		if (pc->counters[type] <= 0)

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1715,8 +1715,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
 		int count = BufferIO::Read<uint8_t>(pbuf);
 		int specount = BufferIO::Read<uint8_t>(pbuf);
-		/*int hint0 = */BufferIO::ReadInt32(pbuf);
-		/*int hint1 = */BufferIO::ReadInt32(pbuf);
+		/*int hint0 = */BufferIO::Read<int32_t>(pbuf);
+		/*int hint1 = */BufferIO::Read<int32_t>(pbuf);
 		int c, s, ss, desc;
 		unsigned int code,l;
 		ClientCard* pcard;
@@ -1731,7 +1731,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			int flag = BufferIO::Read<uint8_t>(pbuf);
 			int forced = BufferIO::Read<uint8_t>(pbuf);
 			flag |= forced << 8;
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			l = BufferIO::Read<uint8_t>(pbuf);
 			s = BufferIO::Read<uint8_t>(pbuf);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1074,7 +1074,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_HINT: {
 		int type = BufferIO::Read<uint8_t>(pbuf);
 		int player = BufferIO::Read<uint8_t>(pbuf);
-		int data = BufferIO::ReadInt32(pbuf);
+		int data = BufferIO::Read<int32_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
 		switch (type) {
@@ -1270,8 +1270,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				mainGame->dInfo.tag_player[0] = true;
 		}
 		mainGame->dInfo.duel_rule = BufferIO::Read<uint8_t>(pbuf);
-		mainGame->dInfo.lp[mainGame->LocalPlayer(0)] = BufferIO::ReadInt32(pbuf);
-		mainGame->dInfo.lp[mainGame->LocalPlayer(1)] = BufferIO::ReadInt32(pbuf);
+		mainGame->dInfo.lp[mainGame->LocalPlayer(0)] = BufferIO::Read<int32_t>(pbuf);
+		mainGame->dInfo.lp[mainGame->LocalPlayer(1)] = BufferIO::Read<int32_t>(pbuf);
 		myswprintf(mainGame->dInfo.strLP[0], L"%d", mainGame->dInfo.lp[0]);
 		myswprintf(mainGame->dInfo.strLP[1], L"%d", mainGame->dInfo.lp[1]);
 		int deckc = BufferIO::Read<uint16_t>(pbuf);
@@ -1322,11 +1322,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.conti_cards.clear();
 		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			loc = BufferIO::Read<uint8_t>(pbuf);
 			seq = BufferIO::Read<uint8_t>(pbuf);
-			desc = BufferIO::ReadInt32(pbuf);
+			desc = BufferIO::Read<int32_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			int flag = 0;
 			if(code & 0x80000000) {
@@ -1352,7 +1352,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.attackable_cards.clear();
 		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
-			/*code = */BufferIO::ReadInt32(pbuf);
+			/*code = */BufferIO::Read<int32_t>(pbuf);
 			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			loc = BufferIO::Read<uint8_t>(pbuf);
 			seq = BufferIO::Read<uint8_t>(pbuf);
@@ -1383,7 +1383,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.summonable_cards.clear();
 		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			loc = BufferIO::Read<uint8_t>(pbuf);
 			seq = BufferIO::Read<uint8_t>(pbuf);
@@ -1394,7 +1394,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.spsummonable_cards.clear();
 		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			loc = BufferIO::Read<uint8_t>(pbuf);
 			seq = BufferIO::Read<uint8_t>(pbuf);
@@ -1419,7 +1419,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.reposable_cards.clear();
 		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			loc = BufferIO::Read<uint8_t>(pbuf);
 			seq = BufferIO::Read<uint8_t>(pbuf);
@@ -1430,7 +1430,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.msetable_cards.clear();
 		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			loc = BufferIO::Read<uint8_t>(pbuf);
 			seq = BufferIO::Read<uint8_t>(pbuf);
@@ -1441,7 +1441,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.ssetable_cards.clear();
 		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			loc = BufferIO::Read<uint8_t>(pbuf);
 			seq = BufferIO::Read<uint8_t>(pbuf);
@@ -1454,11 +1454,11 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.conti_cards.clear();
 		count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			con = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			loc = BufferIO::Read<uint8_t>(pbuf);
 			seq = BufferIO::Read<uint8_t>(pbuf);
-			desc = BufferIO::ReadInt32(pbuf);
+			desc = BufferIO::Read<int32_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
 			int flag = 0;
 			if(code & 0x80000000) {
@@ -1500,7 +1500,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SELECT_EFFECTYN: {
 		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
-		unsigned int code = BufferIO::ReadInt32(pbuf);
+		unsigned int code = BufferIO::Read<int32_t>(pbuf);
 		int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		unsigned int l = BufferIO::Read<uint8_t>(pbuf);
 		int s = BufferIO::Read<uint8_t>(pbuf);
@@ -1512,7 +1512,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			pcard->is_highlighting = true;
 			mainGame->dField.highlighting_card = pcard;
 		}
-		int desc = BufferIO::ReadInt32(pbuf);
+		int desc = BufferIO::Read<int32_t>(pbuf);
 		if(desc == 0) {
 			wchar_t ynbuf[256];
 			myswprintf(ynbuf, dataManager.GetSysString(200), dataManager.FormatLocation(l, s), dataManager.GetName(code));
@@ -1534,7 +1534,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SELECT_YESNO: {
 		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
-		int desc = BufferIO::ReadInt32(pbuf);
+		int desc = BufferIO::Read<int32_t>(pbuf);
 		mainGame->dField.highlighting_card = 0;
 		mainGame->gMutex.lock();
 		mainGame->SetStaticText(mainGame->stQMessage, 310, mainGame->guiFont, dataManager.GetDesc(desc));
@@ -1547,7 +1547,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int count = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.select_options.clear();
 		for (int i = 0; i < count; ++i)
-			mainGame->dField.select_options.push_back(BufferIO::ReadInt32(pbuf));
+			mainGame->dField.select_options.push_back(BufferIO::Read<int32_t>(pbuf));
 		mainGame->dField.ShowSelectOption(select_hint);
 		select_hint = 0;
 		return false;
@@ -1570,7 +1570,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.select_ready = select_ready;
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			l = BufferIO::Read<uint8_t>(pbuf);
 			s = BufferIO::Read<uint8_t>(pbuf);
@@ -1635,7 +1635,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.select_ready = false;
 		ClientCard* pcard;
 		for (int i = 0; i < count1; ++i) {
-			code = (unsigned int)BufferIO::ReadInt32(pbuf);
+			code = (unsigned int)BufferIO::Read<int32_t>(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			l = BufferIO::Read<uint8_t>(pbuf);
 			s = BufferIO::Read<uint8_t>(pbuf);
@@ -1659,7 +1659,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		}
 		int count2 = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = count1; i < count1 + count2; ++i) {
-			code = (unsigned int)BufferIO::ReadInt32(pbuf);
+			code = (unsigned int)BufferIO::Read<int32_t>(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			l = BufferIO::Read<uint8_t>(pbuf);
 			s = BufferIO::Read<uint8_t>(pbuf);
@@ -1736,7 +1736,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			l = BufferIO::Read<uint8_t>(pbuf);
 			s = BufferIO::Read<uint8_t>(pbuf);
 			ss = BufferIO::Read<uint8_t>(pbuf);
-			desc = BufferIO::ReadInt32(pbuf);
+			desc = BufferIO::Read<int32_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s, ss);
 			mainGame->dField.activatable_cards.push_back(pcard);
 			mainGame->dField.activatable_descs.push_back(std::make_pair(desc, flag));
@@ -1824,7 +1824,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.select_min = count > 0 ? count : 1;
 		mainGame->dField.select_ready = false;
 		mainGame->dField.select_cancelable = count == 0;
-		mainGame->dField.selectable_field = ~BufferIO::ReadInt32(pbuf);
+		mainGame->dField.selectable_field = ~BufferIO::Read<int32_t>(pbuf);
 		if(selecting_player == mainGame->LocalPlayer(1))
 			mainGame->dField.selectable_field = (mainGame->dField.selectable_field >> 16) | (mainGame->dField.selectable_field << 16);
 		mainGame->dField.selected_field = 0;
@@ -1906,7 +1906,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_SELECT_POSITION: {
 		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
-		unsigned int code = (unsigned int)BufferIO::ReadInt32(pbuf);
+		unsigned int code = (unsigned int)BufferIO::Read<int32_t>(pbuf);
 		unsigned int positions = BufferIO::Read<uint8_t>(pbuf);
 		if (positions == 0x1 || positions == 0x2 || positions == 0x4 || positions == 0x8) {
 			SetResponseI(positions);
@@ -1963,7 +1963,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pcard;
 		mainGame->dField.select_ready = false;
 		for (int i = 0; i < count; ++i) {
-			code = (unsigned int)BufferIO::ReadInt32(pbuf);
+			code = (unsigned int)BufferIO::Read<int32_t>(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			l = BufferIO::Read<uint8_t>(pbuf);
 			s = BufferIO::Read<uint8_t>(pbuf);
@@ -2002,7 +2002,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		unsigned int l;
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
-			/*code = */BufferIO::ReadInt32(pbuf);
+			/*code = */BufferIO::Read<int32_t>(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			l = BufferIO::Read<uint8_t>(pbuf);
 			s = BufferIO::Read<uint8_t>(pbuf);
@@ -2022,7 +2022,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_SELECT_SUM: {
 		mainGame->dField.select_mode = BufferIO::Read<uint8_t>(pbuf);
 		/*int selecting_player = */BufferIO::Read<uint8_t>(pbuf);
-		mainGame->dField.select_sumval = BufferIO::ReadInt32(pbuf);
+		mainGame->dField.select_sumval = BufferIO::Read<int32_t>(pbuf);
 		mainGame->dField.select_min = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.select_max = BufferIO::Read<uint8_t>(pbuf);
 		mainGame->dField.must_select_count = BufferIO::Read<uint8_t>(pbuf);
@@ -2031,27 +2031,27 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.selectsum_cards.clear();
 		mainGame->dField.select_panalmode = false;
 		for (int i = 0; i < mainGame->dField.must_select_count; ++i) {
-			unsigned int code = (unsigned int)BufferIO::ReadInt32(pbuf);
+			unsigned int code = (unsigned int)BufferIO::Read<int32_t>(pbuf);
 			int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			unsigned int l = BufferIO::Read<uint8_t>(pbuf);
 			int s = BufferIO::Read<uint8_t>(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 			if (code != 0 && pcard->code != code)
 				pcard->SetCode(code);
-			pcard->opParam = BufferIO::ReadInt32(pbuf);
+			pcard->opParam = BufferIO::Read<int32_t>(pbuf);
 			pcard->select_seq = 0;
 			mainGame->dField.selected_cards.push_back(pcard);
 		}
 		int count = BufferIO::Read<uint8_t>(pbuf);
 		for (int i = 0; i < count; ++i) {
-			unsigned int code = (unsigned int)BufferIO::ReadInt32(pbuf);
+			unsigned int code = (unsigned int)BufferIO::Read<int32_t>(pbuf);
 			int c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			unsigned int l = BufferIO::Read<uint8_t>(pbuf);
 			int s = BufferIO::Read<uint8_t>(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 			if (code != 0 && pcard->code != code)
 				pcard->SetCode(code);
-			pcard->opParam = BufferIO::ReadInt32(pbuf);
+			pcard->opParam = BufferIO::Read<int32_t>(pbuf);
 			pcard->select_seq = i;
 			mainGame->dField.selectsum_all.push_back(pcard);
 			if ((l & 0xe) == 0)
@@ -2072,7 +2072,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		unsigned int code, l;
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
-			code = (unsigned int)BufferIO::ReadInt32(pbuf);
+			code = (unsigned int)BufferIO::Read<int32_t>(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			l = BufferIO::Read<uint8_t>(pbuf);
 			s = BufferIO::Read<uint8_t>(pbuf);
@@ -2095,7 +2095,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pcard;
 		mainGame->dField.selectable_cards.clear();
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			pbuf += 3;
 			pcard = *(mainGame->dField.deck[player].rbegin() + i);
 			if (code != 0)
@@ -2133,7 +2133,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		ClientCard* pcard;
 		mainGame->dField.selectable_cards.clear();
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			pbuf += 3;
 			pcard = *(mainGame->dField.extra[player].rbegin() + i + mainGame->dField.extra_p_count[player]);
 			if (code != 0)
@@ -2180,7 +2180,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		myswprintf(textBuffer, dataManager.GetSysString(208), count);
 		mainGame->AddLog(textBuffer);
 		for (int i = 0; i < count; ++i) {
-			code = BufferIO::ReadInt32(pbuf);
+			code = BufferIO::Read<int32_t>(pbuf);
 			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			l = BufferIO::Read<uint8_t>(pbuf);
 			s = BufferIO::Read<uint8_t>(pbuf);
@@ -2335,7 +2335,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			mainGame->WaitFrameSignal(11);
 		}
 		for(auto cit = mainGame->dField.hand[player].begin(); cit != mainGame->dField.hand[player].end(); ++cit) {
-			(*cit)->SetCode(BufferIO::ReadInt32(pbuf));
+			(*cit)->SetCode(BufferIO::Read<int32_t>(pbuf));
 			(*cit)->desc_hints.clear();
 		}
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
@@ -2373,7 +2373,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		}
 		for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit)
 			if(!((*cit)->position & POS_FACEUP))
-				(*cit)->SetCode(BufferIO::ReadInt32(pbuf));
+				(*cit)->SetCode(BufferIO::Read<int32_t>(pbuf));
 		return true;
 	}
 	case MSG_REFRESH_DECK: {
@@ -2437,7 +2437,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_DECK_TOP: {
 		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		int seq = BufferIO::Read<uint8_t>(pbuf);
-		unsigned int code = BufferIO::ReadInt32(pbuf);
+		unsigned int code = BufferIO::Read<int32_t>(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(player, LOCATION_DECK, mainGame->dField.deck[player].size() - 1 - seq);
 		pcard->SetCode(code & 0x7fffffff);
 		bool rev = (code & 0x80000000) != 0;
@@ -2586,7 +2586,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_MOVE: {
-		unsigned int code = BufferIO::ReadInt32(pbuf);
+		unsigned int code = BufferIO::Read<int32_t>(pbuf);
 		int pc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		unsigned int pl = BufferIO::Read<uint8_t>(pbuf);
 		int ps = BufferIO::Read<uint8_t>(pbuf);
@@ -2595,7 +2595,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
 		int cs = BufferIO::Read<uint8_t>(pbuf);
 		unsigned int cp = BufferIO::Read<uint8_t>(pbuf);
-		int reason = BufferIO::ReadInt32(pbuf);
+		int reason = BufferIO::Read<int32_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			if(cl & LOCATION_REMOVED && pl != cl)
 				soundManager.PlaySoundEffect(SOUND_BANISHED);
@@ -2802,7 +2802,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_POS_CHANGE: {
-		unsigned int code = BufferIO::ReadInt32(pbuf);
+		unsigned int code = BufferIO::Read<int32_t>(pbuf);
 		int cc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
 		int cs = BufferIO::Read<uint8_t>(pbuf);
@@ -2824,7 +2824,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_SET: {
-		/*int code = */BufferIO::ReadInt32(pbuf);
+		/*int code = */BufferIO::Read<int32_t>(pbuf);
 		/*int cc = mainGame->LocalPlayer*/(BufferIO::Read<uint8_t>(pbuf));
 		/*int cl = */BufferIO::Read<uint8_t>(pbuf);
 		/*int cs = */BufferIO::Read<uint8_t>(pbuf);
@@ -2835,12 +2835,12 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_SWAP: {
-		/*int code1 = */BufferIO::ReadInt32(pbuf);
+		/*int code1 = */BufferIO::Read<int32_t>(pbuf);
 		int c1 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		unsigned int l1 = BufferIO::Read<uint8_t>(pbuf);
 		int s1 = BufferIO::Read<uint8_t>(pbuf);
 		/*int p1 = */BufferIO::Read<uint8_t>(pbuf);
-		/*int code2 = */BufferIO::ReadInt32(pbuf);
+		/*int code2 = */BufferIO::Read<int32_t>(pbuf);
 		int c2 = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		unsigned int l2 = BufferIO::Read<uint8_t>(pbuf);
 		int s2 = BufferIO::Read<uint8_t>(pbuf);
@@ -2871,14 +2871,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_FIELD_DISABLED: {
-		unsigned int disabled = BufferIO::ReadInt32(pbuf);
+		unsigned int disabled = BufferIO::Read<int32_t>(pbuf);
 		if (!mainGame->dInfo.isFirst)
 			disabled = (disabled >> 16) | (disabled << 16);
 		mainGame->dField.disabled_field = disabled;
 		return true;
 	}
 	case MSG_SUMMONING: {
-		unsigned int code = BufferIO::ReadInt32(pbuf);
+		unsigned int code = BufferIO::Read<int32_t>(pbuf);
 		/*int cc = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		/*int cl = */BufferIO::Read<uint8_t>(pbuf);
 		/*int cs = */BufferIO::Read<uint8_t>(pbuf);
@@ -2901,7 +2901,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_SPSUMMONING: {
-		unsigned int code = BufferIO::ReadInt32(pbuf);
+		unsigned int code = BufferIO::Read<int32_t>(pbuf);
 		/*int cc = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		/*int cl = */BufferIO::Read<uint8_t>(pbuf);
 		/*int cs = */BufferIO::Read<uint8_t>(pbuf);
@@ -2927,7 +2927,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_FLIPSUMMONING: {
-		unsigned int code = BufferIO::ReadInt32(pbuf);
+		unsigned int code = BufferIO::Read<int32_t>(pbuf);
 		int cc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
 		int cs = BufferIO::Read<uint8_t>(pbuf);
@@ -2955,7 +2955,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_CHAINING: {
-		unsigned int code = BufferIO::ReadInt32(pbuf);
+		unsigned int code = BufferIO::Read<int32_t>(pbuf);
 		int pcc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		unsigned int pcl = BufferIO::Read<uint8_t>(pbuf);
 		int pcs = BufferIO::Read<uint8_t>(pbuf);
@@ -2963,7 +2963,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int cc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
 		int cs = BufferIO::Read<uint8_t>(pbuf);
-		int desc = BufferIO::ReadInt32(pbuf);
+		int desc = BufferIO::Read<int32_t>(pbuf);
 		/*int ct = */BufferIO::Read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
@@ -3142,7 +3142,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int count = BufferIO::Read<uint8_t>(pbuf);
 		ClientCard* pcard;
 		for (int i = 0; i < count; ++i) {
-			unsigned int code = BufferIO::ReadInt32(pbuf);
+			unsigned int code = BufferIO::Read<int32_t>(pbuf);
 			pcard = mainGame->dField.GetCard(player, LOCATION_DECK, mainGame->dField.deck[player].size() - 1 - i);
 			if(!mainGame->dField.deck_reversed || code)
 				pcard->SetCode(code & 0x7fffffff);
@@ -3173,7 +3173,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_DAMAGE: {
 		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
-		int val = BufferIO::ReadInt32(pbuf);
+		int val = BufferIO::Read<int32_t>(pbuf);
 		int final = mainGame->dInfo.lp[player] - val;
 		if (final < 0)
 			final = 0;
@@ -3204,7 +3204,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_RECOVER: {
 		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
-		int val = BufferIO::ReadInt32(pbuf);
+		int val = BufferIO::Read<int32_t>(pbuf);
 		int final = mainGame->dInfo.lp[player] + val;
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			mainGame->dInfo.lp[player] = final;
@@ -3267,7 +3267,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_LPUPDATE: {
 		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
-		int val = BufferIO::ReadInt32(pbuf);
+		int val = BufferIO::Read<int32_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping) {
 			mainGame->dInfo.lp[player] = val;
 			myswprintf(mainGame->dInfo.strLP[player], L"%d", mainGame->dInfo.lp[player]);
@@ -3358,7 +3358,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	}
 	case MSG_PAY_LPCOST: {
 		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
-		int cost = BufferIO::ReadInt32(pbuf);
+		int cost = BufferIO::Read<int32_t>(pbuf);
 		int final = mainGame->dInfo.lp[player] - cost;
 		if (final < 0)
 			final = 0;
@@ -3485,15 +3485,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		unsigned int la = BufferIO::Read<uint8_t>(pbuf);
 		int sa = BufferIO::Read<uint8_t>(pbuf);
 		BufferIO::Read<uint8_t>(pbuf);
-		int aatk = BufferIO::ReadInt32(pbuf);
-		int adef = BufferIO::ReadInt32(pbuf);
+		int aatk = BufferIO::Read<int32_t>(pbuf);
+		int adef = BufferIO::Read<int32_t>(pbuf);
 		/*int da = */BufferIO::Read<uint8_t>(pbuf);
 		int cd = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		unsigned int ld = BufferIO::Read<uint8_t>(pbuf);
 		int sd = BufferIO::Read<uint8_t>(pbuf);
 		BufferIO::Read<uint8_t>(pbuf);
-		int datk = BufferIO::ReadInt32(pbuf);
-		int ddef = BufferIO::ReadInt32(pbuf);
+		int datk = BufferIO::Read<int32_t>(pbuf);
+		int ddef = BufferIO::Read<int32_t>(pbuf);
 		/*int dd = */BufferIO::Read<uint8_t>(pbuf);
 		if(mainGame->dInfo.isReplay && mainGame->dInfo.isReplaySkiping)
 			return true;
@@ -3532,8 +3532,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_MISSED_EFFECT: {
-		BufferIO::ReadInt32(pbuf);
-		unsigned int code = BufferIO::ReadInt32(pbuf);
+		BufferIO::Read<int32_t>(pbuf);
+		unsigned int code = BufferIO::Read<int32_t>(pbuf);
 		myswprintf(textBuffer, dataManager.GetSysString(1622), dataManager.GetName(code));
 		mainGame->AddLog(textBuffer, code);
 		return true;
@@ -3613,7 +3613,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_ANNOUNCE_RACE: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		mainGame->dField.announce_count = BufferIO::Read<uint8_t>(pbuf);
-		int available = BufferIO::ReadInt32(pbuf);
+		int available = BufferIO::Read<int32_t>(pbuf);
 		for(int i = 0, filter = 0x1; i < RACES_COUNT; ++i, filter <<= 1) {
 			mainGame->chkRace[i]->setChecked(false);
 			if(filter & available)
@@ -3633,7 +3633,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_ANNOUNCE_ATTRIB: {
 		/*int player = */mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		mainGame->dField.announce_count = BufferIO::Read<uint8_t>(pbuf);
-		int available = BufferIO::ReadInt32(pbuf);
+		int available = BufferIO::Read<int32_t>(pbuf);
 		for(int i = 0, filter = 0x1; i < 7; ++i, filter <<= 1) {
 			mainGame->chkAttribute[i]->setChecked(false);
 			if(filter & available)
@@ -3682,7 +3682,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			}
 		}
 		for (int i = 0; i < count; ++i) {
-			int value = BufferIO::ReadInt32(pbuf);
+			int value = BufferIO::Read<int32_t>(pbuf);
 			myswprintf(textBuffer, L" % d", value);
 			mainGame->cbANNumber->addItem(textBuffer, value);
 			if(quickmode) {
@@ -3726,7 +3726,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int s = BufferIO::Read<uint8_t>(pbuf);
 		BufferIO::Read<uint8_t>(pbuf);
 		int chtype = BufferIO::Read<uint8_t>(pbuf);
-		int value = BufferIO::ReadInt32(pbuf);
+		int value = BufferIO::Read<int32_t>(pbuf);
 		ClientCard* pcard = mainGame->dField.GetCard(c, l, s);
 		if(!pcard)
 			return true;
@@ -3760,7 +3760,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	case MSG_PLAYER_HINT: {
 		int player = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 		int chtype = BufferIO::Read<uint8_t>(pbuf);
-		int value = BufferIO::ReadInt32(pbuf);
+		int value = BufferIO::Read<int32_t>(pbuf);
 		auto& player_desc_hints = mainGame->dField.player_desc_hints[player];
 		if(value == CARD_QUESTION && player == 0) {
 			if(chtype == PHINT_DESC_ADD) {
@@ -3779,7 +3779,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		return true;
 	}
 	case MSG_MATCH_KILL: {
-		match_kill = BufferIO::ReadInt32(pbuf);
+		match_kill = BufferIO::Read<int32_t>(pbuf);
 		return true;
 	}
 	case MSG_TAG_SWAP: {
@@ -3788,7 +3788,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		size_t ecount = (size_t)BufferIO::Read<uint8_t>(pbuf);
 		size_t pcount = (size_t)BufferIO::Read<uint8_t>(pbuf);
 		size_t hcount = (size_t)BufferIO::Read<uint8_t>(pbuf);
-		int topcode = BufferIO::ReadInt32(pbuf);
+		int topcode = BufferIO::Read<int32_t>(pbuf);
 		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 			for (auto cit = mainGame->dField.deck[player].begin(); cit != mainGame->dField.deck[player].end(); ++cit) {
 				if(player == 0) (*cit)->dPos.Y = 0.4f;
@@ -3877,7 +3877,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 				(*mainGame->dField.deck[player].rbegin())->code = topcode;
 			for (auto cit = mainGame->dField.hand[player].begin(); cit != mainGame->dField.hand[player].end(); ++cit) {
 				ClientCard* pcard = *cit;
-				pcard->code = BufferIO::ReadInt32(pbuf);
+				pcard->code = BufferIO::Read<int32_t>(pbuf);
 				mainGame->dField.GetCardLocation(pcard, &pcard->curPos, &pcard->curRot);
 				if(player == 0) pcard->curPos.Y += 2.0f;
 				else pcard->curPos.Y -= 3.0f;
@@ -3885,7 +3885,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			}
 			for (auto cit = mainGame->dField.extra[player].begin(); cit != mainGame->dField.extra[player].end(); ++cit) {
 				ClientCard* pcard = *cit;
-				pcard->code = BufferIO::ReadInt32(pbuf) & 0x7fffffff;
+				pcard->code = BufferIO::Read<int32_t>(pbuf) & 0x7fffffff;
 				mainGame->dField.GetCardLocation(pcard, &pcard->curPos, &pcard->curRot);
 				if(player == 0) pcard->curPos.Y += 2.0f;
 				else pcard->curPos.Y -= 3.0f;
@@ -3904,7 +3904,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		int val = 0;
 		for(int i = 0; i < 2; ++i) {
 			int p = mainGame->LocalPlayer(i);
-			mainGame->dInfo.lp[p] = BufferIO::ReadInt32(pbuf);
+			mainGame->dInfo.lp[p] = BufferIO::Read<int32_t>(pbuf);
 			myswprintf(mainGame->dInfo.strLP[p], L"%d", mainGame->dInfo.lp[p]);
 			for(int seq = 0; seq < 7; ++seq) {
 				val = BufferIO::Read<uint8_t>(pbuf);
@@ -3966,7 +3966,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.RefreshAllCards();
 		val = BufferIO::Read<uint8_t>(pbuf); //chains
 		for(int i = 0; i < val; ++i) {
-			unsigned int code = BufferIO::ReadInt32(pbuf);
+			unsigned int code = BufferIO::Read<int32_t>(pbuf);
 			int pcc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			unsigned int pcl = BufferIO::Read<uint8_t>(pbuf);
 			int pcs = BufferIO::Read<uint8_t>(pbuf);
@@ -3974,7 +3974,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			int cc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
 			unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
 			int cs = BufferIO::Read<uint8_t>(pbuf);
-			int desc = BufferIO::ReadInt32(pbuf);
+			int desc = BufferIO::Read<int32_t>(pbuf);
 			ClientCard* pcard = mainGame->dField.GetCard(pcc, pcl, pcs, subs);
 			mainGame->dField.current_chain.chain_card = pcard;
 			mainGame->dField.current_chain.code = code;

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -49,16 +49,16 @@ public:
 	static void SendResponse();
 	static void SendPacketToServer(unsigned char proto) {
 		auto p = duel_client_write;
-		buffer_write<uint16_t>(p, 1);
-		buffer_write<uint8_t>(p, proto);
+		BufferIO::Write<uint16_t>(p, 1);
+		BufferIO::Write<uint8_t>(p, proto);
 		bufferevent_write(client_bev, duel_client_write, 3);
 	}
 	template<typename ST>
 	static void SendPacketToServer(unsigned char proto, const ST& st) {
 		auto p = duel_client_write;
 		static_assert(sizeof(ST) <= MAX_DATA_SIZE, "Packet size is too large.");
-		buffer_write<uint16_t>(p, (uint16_t)(1 + sizeof(ST)));
-		buffer_write<uint8_t>(p, proto);
+		BufferIO::Write<uint16_t>(p, (uint16_t)(1 + sizeof(ST)));
+		BufferIO::Write<uint8_t>(p, proto);
 		std::memcpy(p, &st, sizeof(ST));
 		bufferevent_write(client_bev, duel_client_write, sizeof(ST) + 3);
 	}
@@ -66,8 +66,8 @@ public:
 		auto p = duel_client_write;
 		if (len > MAX_DATA_SIZE)
 			len = MAX_DATA_SIZE;
-		buffer_write<uint16_t>(p, (uint16_t)(1 + len));
-		buffer_write<uint8_t>(p, proto);
+		BufferIO::Write<uint16_t>(p, (uint16_t)(1 + len));
+		BufferIO::Write<uint8_t>(p, proto);
 		std::memcpy(p, buffer, len);
 		bufferevent_write(client_bev, duel_client_write, len + 3);
 	}

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -17,14 +17,14 @@ void UpdateDeck() {
 	BufferIO::CopyWideString(mainGame->cbDeckSelect->getText(), mainGame->gameConf.lastdeck);
 	unsigned char deckbuf[1024]{};
 	auto pdeck = deckbuf;
-	BufferIO::WriteInt32(pdeck, deckManager.current_deck.main.size() + deckManager.current_deck.extra.size());
-	BufferIO::WriteInt32(pdeck, deckManager.current_deck.side.size());
+	BufferIO::Write<int32_t>(pdeck, deckManager.current_deck.main.size() + deckManager.current_deck.extra.size());
+	BufferIO::Write<int32_t>(pdeck, deckManager.current_deck.side.size());
 	for(size_t i = 0; i < deckManager.current_deck.main.size(); ++i)
-		BufferIO::WriteInt32(pdeck, deckManager.current_deck.main[i]->first);
+		BufferIO::Write<int32_t>(pdeck, deckManager.current_deck.main[i]->first);
 	for(size_t i = 0; i < deckManager.current_deck.extra.size(); ++i)
-		BufferIO::WriteInt32(pdeck, deckManager.current_deck.extra[i]->first);
+		BufferIO::Write<int32_t>(pdeck, deckManager.current_deck.extra[i]->first);
 	for(size_t i = 0; i < deckManager.current_deck.side.size(); ++i)
-		BufferIO::WriteInt32(pdeck, deckManager.current_deck.side[i]->first);
+		BufferIO::Write<int32_t>(pdeck, deckManager.current_deck.side[i]->first);
 	DuelClient::SendBufferToServer(CTOS_UPDATE_DECK, deckbuf, pdeck - deckbuf);
 }
 bool MenuHandler::OnEvent(const irr::SEvent& event) {

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -185,7 +185,7 @@ void NetServer::DisconnectPlayer(DuelPlayer* dp) {
 }
 void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	auto pdata = data;
-	unsigned char pktType = buffer_read<uint8_t>(pdata);
+	unsigned char pktType = BufferIO::Read<uint8_t>(pdata);
 	if((pktType != CTOS_SURRENDER) && (pktType != CTOS_CHAT) && (dp->state == 0xff || (dp->state && dp->state != pktType)))
 		return;
 	switch(pktType) {

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -380,7 +380,7 @@ size_t NetServer::CreateChatPacket(unsigned char* src, int src_size, unsigned ch
 		return 0;
 	// STOC_Chat packet
 	auto pdst = dst;
-	buffer_write<uint16_t>(pdst, dst_player_type);
+	BufferIO::Write<uint16_t>(pdst, dst_player_type);
 	buffer_write_block(pdst, src_msg, src_size);
 	return sizeof(dst_player_type) + src_size;
 }

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -381,7 +381,8 @@ size_t NetServer::CreateChatPacket(unsigned char* src, int src_size, unsigned ch
 	// STOC_Chat packet
 	auto pdst = dst;
 	BufferIO::Write<uint16_t>(pdst, dst_player_type);
-	buffer_write_block(pdst, src_msg, src_size);
+	std::memcpy(pdst, src_msg, src_size);
+	pdst += src_size;
 	return sizeof(dst_player_type) + src_size;
 }
 

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -185,7 +185,7 @@ void NetServer::DisconnectPlayer(DuelPlayer* dp) {
 }
 void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	auto pdata = data;
-	unsigned char pktType = BufferIO::ReadUInt8(pdata);
+	unsigned char pktType = buffer_read<uint8_t>(pdata);
 	if((pktType != CTOS_SURRENDER) && (pktType != CTOS_CHAT) && (dp->state == 0xff || (dp->state && dp->state != pktType)))
 		return;
 	switch(pktType) {

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -261,7 +261,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 		// for other server & reverse proxy use only
 		/*
 		wchar_t hostname[LEN_HOSTNAME];
-		uint32_t real_ip = ntohl(BufferIO::ReadInt32(pdata));
+		uint32_t real_ip = ntohl(BufferIO::Read<int32_t>(pdata));
 		BufferIO::CopyCharArray((uint16_t*)pdata, hostname);
 		*/
 		break;

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -34,8 +34,8 @@ public:
 	static size_t CreateChatPacket(unsigned char* src, int src_size, unsigned char* dst, uint16_t dst_player_type);
 	static void SendPacketToPlayer(DuelPlayer* dp, unsigned char proto) {
 		auto p = net_server_write;
-		buffer_write<uint16_t>(p, 1);
-		buffer_write<uint8_t>(p, proto);
+		BufferIO::Write<uint16_t>(p, 1);
+		BufferIO::Write<uint8_t>(p, proto);
 		last_sent = 3;
 		if (dp)
 			bufferevent_write(dp->bev, net_server_write, 3);
@@ -44,8 +44,8 @@ public:
 	static void SendPacketToPlayer(DuelPlayer* dp, unsigned char proto, const ST& st) {
 		auto p = net_server_write;
 		static_assert(sizeof(ST) <= MAX_DATA_SIZE, "Packet size is too large.");
-		buffer_write<uint16_t>(p, (uint16_t)(1 + sizeof(ST)));
-		buffer_write<uint8_t>(p, proto);
+		BufferIO::Write<uint16_t>(p, (uint16_t)(1 + sizeof(ST)));
+		BufferIO::Write<uint8_t>(p, proto);
 		std::memcpy(p, &st, sizeof(ST));
 		last_sent = sizeof(ST) + 3;
 		if (dp)
@@ -55,8 +55,8 @@ public:
 		auto p = net_server_write;
 		if (len > MAX_DATA_SIZE)
 			len = MAX_DATA_SIZE;
-		buffer_write<uint16_t>(p, (uint16_t)(1 + len));
-		buffer_write<uint8_t>(p, proto);
+		BufferIO::Write<uint16_t>(p, (uint16_t)(1 + len));
+		BufferIO::Write<uint8_t>(p, proto);
 		std::memcpy(p, buffer, len);
 		last_sent = len + 3;
 		if (dp)

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -300,7 +300,7 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		auto offset = pbuf;
 		bool pauseable = true;
-		mainGame->dInfo.curMsg = BufferIO::ReadUInt8(pbuf);
+		mainGame->dInfo.curMsg = buffer_read<uint8_t>(pbuf);
 		switch (mainGame->dInfo.curMsg) {
 		case MSG_RETRY: {
 			if(mainGame->dInfo.isReplaySkiping) {
@@ -332,61 +332,61 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			return false;
 		}
 		case MSG_SELECT_BATTLECMD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8 + 2;
 			ReplayRefresh();
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_IDLECMD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11 + 3;
 			ReplayRefresh();
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_EFFECTYN: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 12;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_YESNO: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_OPTION: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_CARD:
 		case MSG_SELECT_TRIBUTE: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 3;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_UNSELECT_CARD: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			return ReadReplayResponse();
 		}
@@ -398,48 +398,48 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SELECT_PLACE:
 		case MSG_SELECT_DISFIELD: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_POSITION: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_COUNTER: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 9;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_SUM: {
 			pbuf++;
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 6;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
 			return ReadReplayResponse();
 		}
 		case MSG_SORT_CARD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			return ReadReplayResponse();
 		}
 		case MSG_CONFIRM_DECKTOP: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_CONFIRM_EXTRATOP: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -453,21 +453,21 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_DECK: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			ReplayRefreshDeck(player);
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
-			/*int oplayer = */BufferIO::ReadUInt8(pbuf);
-			int count = BufferIO::ReadUInt8(pbuf);
+			/*int oplayer = */buffer_read<uint8_t>(pbuf);
+			int count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_SHUFFLE_EXTRA: {
-			/*int oplayer = */BufferIO::ReadUInt8(pbuf);
-			int count = BufferIO::ReadUInt8(pbuf);
+			/*int oplayer = */buffer_read<uint8_t>(pbuf);
+			int count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -478,7 +478,7 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SWAP_GRAVE_DECK: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			ReplayRefreshGrave(player);
 			break;
@@ -496,7 +496,7 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SHUFFLE_SET_CARD: {
 			pbuf++;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -510,7 +510,7 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 					mainGame->gMutex.unlock();
 				}
 			}
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
@@ -634,22 +634,22 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_CARD_SELECTED:
 		case MSG_RANDOM_SELECTED: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			pauseable = false;
 			break;
 		}
 		case MSG_BECOME_TARGET: {
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_DRAW: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -742,21 +742,21 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_COIN: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_TOSS_DICE: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_ROCK_PAPER_SCISSORS: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			return ReadReplayResponse();
 		}
 		case MSG_HAND_RES: {
@@ -765,19 +765,19 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_ANNOUNCE_RACE: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			return ReadReplayResponse();
 		}
 		case MSG_ANNOUNCE_ATTRIB: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			return ReadReplayResponse();
 		}
 		case MSG_ANNOUNCE_CARD:
 		case MSG_ANNOUNCE_NUMBER: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += 4 * count;
 			return ReadReplayResponse();
 		}
@@ -808,12 +808,12 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			for(int p = 0; p < 2; ++p) {
 				pbuf += 4;
 				for(int seq = 0; seq < 7; ++seq) {
-					int val = BufferIO::ReadUInt8(pbuf);
+					int val = buffer_read<uint8_t>(pbuf);
 					if(val)
 						pbuf += 2;
 				}
 				for(int seq = 0; seq < 8; ++seq) {
-					int val = BufferIO::ReadUInt8(pbuf);
+					int val = buffer_read<uint8_t>(pbuf);
 					if(val)
 						pbuf++;
 				}

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -391,8 +391,8 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_CHAIN: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 9 + count * 14;
 			return ReadReplayResponse();
 		}
@@ -445,9 +445,9 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_CONFIRM_CARDS: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 1;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -300,7 +300,7 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		auto offset = pbuf;
 		bool pauseable = true;
-		mainGame->dInfo.curMsg = buffer_read<uint8_t>(pbuf);
+		mainGame->dInfo.curMsg = BufferIO::Read<uint8_t>(pbuf);
 		switch (mainGame->dInfo.curMsg) {
 		case MSG_RETRY: {
 			if(mainGame->dInfo.isReplaySkiping) {
@@ -332,61 +332,61 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			return false;
 		}
 		case MSG_SELECT_BATTLECMD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8 + 2;
 			ReplayRefresh();
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_IDLECMD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11 + 3;
 			ReplayRefresh();
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_EFFECTYN: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 12;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_YESNO: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_OPTION: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_CARD:
 		case MSG_SELECT_TRIBUTE: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 3;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_UNSELECT_CARD: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			return ReadReplayResponse();
 		}
@@ -398,48 +398,48 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SELECT_PLACE:
 		case MSG_SELECT_DISFIELD: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_POSITION: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_COUNTER: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 9;
 			return ReadReplayResponse();
 		}
 		case MSG_SELECT_SUM: {
 			pbuf++;
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 6;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
 			return ReadReplayResponse();
 		}
 		case MSG_SORT_CARD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			return ReadReplayResponse();
 		}
 		case MSG_CONFIRM_DECKTOP: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_CONFIRM_EXTRATOP: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -453,21 +453,21 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_DECK: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			ReplayRefreshDeck(player);
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
-			/*int oplayer = */buffer_read<uint8_t>(pbuf);
-			int count = buffer_read<uint8_t>(pbuf);
+			/*int oplayer = */BufferIO::Read<uint8_t>(pbuf);
+			int count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_SHUFFLE_EXTRA: {
-			/*int oplayer = */buffer_read<uint8_t>(pbuf);
-			int count = buffer_read<uint8_t>(pbuf);
+			/*int oplayer = */BufferIO::Read<uint8_t>(pbuf);
+			int count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -478,7 +478,7 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SWAP_GRAVE_DECK: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			ReplayRefreshGrave(player);
 			break;
@@ -496,7 +496,7 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SHUFFLE_SET_CARD: {
 			pbuf++;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -510,7 +510,7 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 					mainGame->gMutex.unlock();
 				}
 			}
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
@@ -634,22 +634,22 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_CARD_SELECTED:
 		case MSG_RANDOM_SELECTED: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			pauseable = false;
 			break;
 		}
 		case MSG_BECOME_TARGET: {
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_DRAW: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -742,21 +742,21 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_COIN: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_TOSS_DICE: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_ROCK_PAPER_SCISSORS: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			return ReadReplayResponse();
 		}
 		case MSG_HAND_RES: {
@@ -765,19 +765,19 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_ANNOUNCE_RACE: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			return ReadReplayResponse();
 		}
 		case MSG_ANNOUNCE_ATTRIB: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			return ReadReplayResponse();
 		}
 		case MSG_ANNOUNCE_CARD:
 		case MSG_ANNOUNCE_NUMBER: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4 * count;
 			return ReadReplayResponse();
 		}
@@ -808,12 +808,12 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			for(int p = 0; p < 2; ++p) {
 				pbuf += 4;
 				for(int seq = 0; seq < 7; ++seq) {
-					int val = buffer_read<uint8_t>(pbuf);
+					int val = BufferIO::Read<uint8_t>(pbuf);
 					if(val)
 						pbuf += 2;
 				}
 				for(int seq = 0; seq < 8; ++seq) {
-					int val = buffer_read<uint8_t>(pbuf);
+					int val = BufferIO::Read<uint8_t>(pbuf);
 					if(val)
 						pbuf++;
 				}
@@ -826,12 +826,12 @@ bool ReplayMode::ReplayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_AI_NAME: {
-			int len = buffer_read<uint16_t>(pbuf);
+			int len = BufferIO::Read<uint16_t>(pbuf);
 			pbuf += len + 1;
 			break;
 		}
 		case MSG_SHOW_HINT: {
-			int len = buffer_read<uint16_t>(pbuf);
+			int len = BufferIO::Read<uint16_t>(pbuf);
 			pbuf += len + 1;
 			break;
 		}

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -331,12 +331,12 @@ void SingleDuel::StartDuel(DuelPlayer* dp) {
 	}
 	unsigned char deckbuff[12];
 	auto pbuf = deckbuff;
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].main.size());
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].extra.size());
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].side.size());
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[1].main.size());
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[1].extra.size());
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[1].side.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[0].main.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[0].extra.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[0].side.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[1].main.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[1].extra.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[1].side.size());
 	NetServer::SendBufferToPlayer(players[0], STOC_DECK_COUNT, deckbuff, 12);
 	char tempbuff[6];
 	std::memcpy(tempbuff, deckbuff, 6);
@@ -457,15 +457,15 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	last_replay.Flush();
 	unsigned char startbuf[32]{};
 	auto pbuf = startbuf;
-	buffer_write<uint8_t>(pbuf, MSG_START);
-	buffer_write<uint8_t>(pbuf, 0);
-	buffer_write<uint8_t>(pbuf, host_info.duel_rule);
+	BufferIO::Write<uint8_t>(pbuf, MSG_START);
+	BufferIO::Write<uint8_t>(pbuf, 0);
+	BufferIO::Write<uint8_t>(pbuf, host_info.duel_rule);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
-	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
-	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
-	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
-	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
+	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
+	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
+	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
+	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, startbuf, 19);
 	startbuf[1] = 1;
 	NetServer::SendBufferToPlayer(players[1], STOC_GAME_MSG, startbuf, 19);
@@ -1462,9 +1462,9 @@ void SingleDuel::TimeConfirm(DuelPlayer* dp) {
 }
 inline int SingleDuel::WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
-	buffer_write<uint8_t>(qbuf, MSG_UPDATE_DATA);
-	buffer_write<uint8_t>(qbuf, player);
-	buffer_write<uint8_t>(qbuf, location);
+	BufferIO::Write<uint8_t>(qbuf, MSG_UPDATE_DATA);
+	BufferIO::Write<uint8_t>(qbuf, player);
+	BufferIO::Write<uint8_t>(qbuf, location);
 	int len = query_field_card(pduel, player, location, flag, qbuf, use_cache);
 	return len;
 }
@@ -1552,10 +1552,10 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	flag |= (QUERY_CODE | QUERY_POSITION);
 	unsigned char query_buffer[0x1000];
 	auto qbuf = query_buffer;
-	buffer_write<uint8_t>(qbuf, MSG_UPDATE_CARD);
-	buffer_write<uint8_t>(qbuf, player);
-	buffer_write<uint8_t>(qbuf, location);
-	buffer_write<uint8_t>(qbuf, sequence);
+	BufferIO::Write<uint8_t>(qbuf, MSG_UPDATE_CARD);
+	BufferIO::Write<uint8_t>(qbuf, player);
+	BufferIO::Write<uint8_t>(qbuf, location);
+	BufferIO::Write<uint8_t>(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer, len + 4);
 	if (len <= LEN_HEADER)

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -331,12 +331,12 @@ void SingleDuel::StartDuel(DuelPlayer* dp) {
 	}
 	unsigned char deckbuff[12];
 	auto pbuf = deckbuff;
-	BufferIO::WriteInt16(pbuf, (short)pdeck[0].main.size());
-	BufferIO::WriteInt16(pbuf, (short)pdeck[0].extra.size());
-	BufferIO::WriteInt16(pbuf, (short)pdeck[0].side.size());
-	BufferIO::WriteInt16(pbuf, (short)pdeck[1].main.size());
-	BufferIO::WriteInt16(pbuf, (short)pdeck[1].extra.size());
-	BufferIO::WriteInt16(pbuf, (short)pdeck[1].side.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].main.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].extra.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].side.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[1].main.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[1].extra.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[1].side.size());
 	NetServer::SendBufferToPlayer(players[0], STOC_DECK_COUNT, deckbuff, 12);
 	char tempbuff[6];
 	std::memcpy(tempbuff, deckbuff, 6);
@@ -457,15 +457,15 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	last_replay.Flush();
 	unsigned char startbuf[32]{};
 	auto pbuf = startbuf;
-	BufferIO::WriteInt8(pbuf, MSG_START);
-	BufferIO::WriteInt8(pbuf, 0);
-	BufferIO::WriteInt8(pbuf, host_info.duel_rule);
+	BufferIO::WriteUInt8(pbuf, MSG_START);
+	BufferIO::WriteUInt8(pbuf, 0);
+	BufferIO::WriteUInt8(pbuf, host_info.duel_rule);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
-	BufferIO::WriteInt16(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
-	BufferIO::WriteInt16(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
-	BufferIO::WriteInt16(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
-	BufferIO::WriteInt16(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
+	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
+	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
+	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
+	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, startbuf, 19);
 	startbuf[1] = 1;
 	NetServer::SendBufferToPlayer(players[1], STOC_GAME_MSG, startbuf, 19);
@@ -1462,9 +1462,9 @@ void SingleDuel::TimeConfirm(DuelPlayer* dp) {
 }
 inline int SingleDuel::WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
-	BufferIO::WriteInt8(qbuf, MSG_UPDATE_DATA);
-	BufferIO::WriteInt8(qbuf, player);
-	BufferIO::WriteInt8(qbuf, location);
+	BufferIO::WriteUInt8(qbuf, MSG_UPDATE_DATA);
+	BufferIO::WriteUInt8(qbuf, player);
+	BufferIO::WriteUInt8(qbuf, location);
 	int len = query_field_card(pduel, player, location, flag, qbuf, use_cache);
 	return len;
 }
@@ -1552,10 +1552,10 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	flag |= (QUERY_CODE | QUERY_POSITION);
 	unsigned char query_buffer[0x1000];
 	auto qbuf = query_buffer;
-	BufferIO::WriteInt8(qbuf, MSG_UPDATE_CARD);
-	BufferIO::WriteInt8(qbuf, player);
-	BufferIO::WriteInt8(qbuf, location);
-	BufferIO::WriteInt8(qbuf, sequence);
+	BufferIO::WriteUInt8(qbuf, MSG_UPDATE_CARD);
+	BufferIO::WriteUInt8(qbuf, player);
+	BufferIO::WriteUInt8(qbuf, location);
+	BufferIO::WriteUInt8(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer, len + 4);
 	if (len <= LEN_HEADER)

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -578,7 +578,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 	int player, count, type;
 	while (pbuf - msgbuffer < (int)len) {
 		offset = pbuf;
-		unsigned char engType = BufferIO::ReadUInt8(pbuf);
+		unsigned char engType = buffer_read<uint8_t>(pbuf);
 		switch (engType) {
 		case MSG_RETRY: {
 			WaitforResponse(last_response);
@@ -586,8 +586,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_HINT: {
-			type = BufferIO::ReadUInt8(pbuf);
-			player = BufferIO::ReadUInt8(pbuf);
+			type = buffer_read<uint8_t>(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			BufferIO::ReadInt32(pbuf);
 			switch (type) {
 			case 1:
@@ -619,8 +619,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_WIN: {
-			player = BufferIO::ReadUInt8(pbuf);
-			type = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			type = buffer_read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
@@ -639,10 +639,10 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 2;
 		}
 		case MSG_SELECT_BATTLECMD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8 + 2;
 			RefreshMzone(0);
 			RefreshMzone(1);
@@ -655,18 +655,18 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_IDLECMD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11 + 3;
 			RefreshMzone(0);
 			RefreshMzone(1);
@@ -679,22 +679,22 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_EFFECTYN: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 12;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_YESNO: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_OPTION: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -702,17 +702,17 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_CARD:
 		case MSG_SELECT_TRIBUTE: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 3;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = BufferIO::ReadUInt8(pbuf);
-				/*l = */BufferIO::ReadUInt8(pbuf);
-				/*s = */BufferIO::ReadUInt8(pbuf);
-				/*ss = */BufferIO::ReadUInt8(pbuf);
+				c = buffer_read<uint8_t>(pbuf);
+				/*l = */buffer_read<uint8_t>(pbuf);
+				/*s = */buffer_read<uint8_t>(pbuf);
+				/*ss = */buffer_read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
 			WaitforResponse(player);
@@ -720,27 +720,27 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_UNSELECT_CARD: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = BufferIO::ReadUInt8(pbuf);
-				/*l = */BufferIO::ReadUInt8(pbuf);
-				/*s = */BufferIO::ReadUInt8(pbuf);
-				/*ss = */BufferIO::ReadUInt8(pbuf);
+				c = buffer_read<uint8_t>(pbuf);
+				/*l = */buffer_read<uint8_t>(pbuf);
+				/*s = */buffer_read<uint8_t>(pbuf);
+				/*ss = */buffer_read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = BufferIO::ReadUInt8(pbuf);
-				/*l = */BufferIO::ReadUInt8(pbuf);
-				/*s = */BufferIO::ReadUInt8(pbuf);
-				/*ss = */BufferIO::ReadUInt8(pbuf);
+				c = buffer_read<uint8_t>(pbuf);
+				/*l = */buffer_read<uint8_t>(pbuf);
+				/*s = */buffer_read<uint8_t>(pbuf);
+				/*ss = */buffer_read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
 			WaitforResponse(player);
@@ -757,23 +757,23 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_PLACE:
 		case MSG_SELECT_DISFIELD: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_POSITION: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_COUNTER: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 9;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -781,27 +781,27 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_SUM: {
 			pbuf++;
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 6;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SORT_CARD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_CONFIRM_DECKTOP: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -810,8 +810,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_CONFIRM_EXTRATOP: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -836,7 +836,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_DECK: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
@@ -844,8 +844,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for(int i = 0; i < count; ++i)
 				BufferIO::WriteInt32(pbuf, 0);
@@ -856,8 +856,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_EXTRA: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for (int i = 0; i < count; ++i)
 				BufferIO::WriteInt32(pbuf, 0);
@@ -876,7 +876,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SWAP_GRAVE_DECK: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
@@ -900,8 +900,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_SET_CARD: {
-			unsigned int loc = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			unsigned int loc = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1148,14 +1148,14 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_CARD_SELECTED: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			break;
 		}
 		case MSG_RANDOM_SELECTED: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1164,7 +1164,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_BECOME_TARGET: {
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1173,8 +1173,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_DRAW: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbufw = pbuf;
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1317,8 +1317,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_COIN: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1327,8 +1327,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_DICE: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1337,7 +1337,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_ROCK_PAPER_SCISSORS: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
@@ -1351,14 +1351,14 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_ANNOUNCE_RACE: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_ANNOUNCE_ATTRIB: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1366,8 +1366,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_ANNOUNCE_CARD:
 		case MSG_ANNOUNCE_NUMBER: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += 4 * count;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -748,8 +748,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_CHAIN: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 9 + count * 14;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -820,9 +820,9 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_CONFIRM_CARDS: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 1;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			if(pbuf[5] != LOCATION_DECK) {
 				pbuf += count * 7;
 				NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -588,7 +588,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		case MSG_HINT: {
 			type = BufferIO::Read<uint8_t>(pbuf);
 			player = BufferIO::Read<uint8_t>(pbuf);
-			BufferIO::ReadInt32(pbuf);
+			BufferIO::Read<int32_t>(pbuf);
 			switch (type) {
 			case 1:
 			case 2:
@@ -708,7 +708,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
-				/*code = */BufferIO::ReadInt32(pbuf);
+				/*code = */BufferIO::Read<int32_t>(pbuf);
 				c = BufferIO::Read<uint8_t>(pbuf);
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
@@ -726,7 +726,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
-				/*code = */BufferIO::ReadInt32(pbuf);
+				/*code = */BufferIO::Read<int32_t>(pbuf);
 				c = BufferIO::Read<uint8_t>(pbuf);
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
@@ -736,7 +736,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			count = BufferIO::Read<uint8_t>(pbuf);
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
-				/*code = */BufferIO::ReadInt32(pbuf);
+				/*code = */BufferIO::Read<int32_t>(pbuf);
 				c = BufferIO::Read<uint8_t>(pbuf);
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
@@ -1390,7 +1390,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_MATCH_KILL: {
-			int code = BufferIO::ReadInt32(pbuf);
+			int code = BufferIO::Read<int32_t>(pbuf);
 			if(match_mode) {
 				match_kill = code;
 				NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1476,7 +1476,7 @@ void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	int qlen = 0;
 	while(qlen < len) {
-		const int clen = BufferIO::ReadInt32(qbuf);
+		const int clen = BufferIO::Read<int32_t>(qbuf);
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
@@ -1497,7 +1497,7 @@ void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	int qlen = 0;
 	while(qlen < len) {
-		const int clen = BufferIO::ReadInt32(qbuf);
+		const int clen = BufferIO::Read<int32_t>(qbuf);
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
@@ -1518,7 +1518,7 @@ void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	int qlen = 0;
 	while(qlen < len) {
-		const int slen = BufferIO::ReadInt32(qbuf);
+		const int slen = BufferIO::Read<int32_t>(qbuf);
 		qlen += slen;
 		if (slen <= LEN_HEADER)
 			continue;
@@ -1560,7 +1560,7 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer, len + 4);
 	if (len <= LEN_HEADER)
 		return;
-	const int clen = BufferIO::ReadInt32(qbuf);
+	const int clen = BufferIO::Read<int32_t>(qbuf);
 	auto position = GetPosition(qbuf, 8);
 	if (position & POS_FACEDOWN) {
 		BufferIO::WriteInt32(qbuf, QUERY_CODE);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -331,12 +331,12 @@ void SingleDuel::StartDuel(DuelPlayer* dp) {
 	}
 	unsigned char deckbuff[12];
 	auto pbuf = deckbuff;
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].main.size());
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].extra.size());
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].side.size());
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[1].main.size());
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[1].extra.size());
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[1].side.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].main.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].extra.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].side.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[1].main.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[1].extra.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[1].side.size());
 	NetServer::SendBufferToPlayer(players[0], STOC_DECK_COUNT, deckbuff, 12);
 	char tempbuff[6];
 	std::memcpy(tempbuff, deckbuff, 6);
@@ -462,10 +462,10 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	BufferIO::WriteUInt8(pbuf, host_info.duel_rule);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
-	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
-	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
-	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
-	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
+	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
+	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
+	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
+	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, startbuf, 19);
 	startbuf[1] = 1;
 	NetServer::SendBufferToPlayer(players[1], STOC_GAME_MSG, startbuf, 19);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -460,8 +460,8 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	BufferIO::Write<uint8_t>(pbuf, MSG_START);
 	BufferIO::Write<uint8_t>(pbuf, 0);
 	BufferIO::Write<uint8_t>(pbuf, host_info.duel_rule);
-	BufferIO::WriteInt32(pbuf, host_info.start_lp);
-	BufferIO::WriteInt32(pbuf, host_info.start_lp);
+	BufferIO::Write<int32_t>(pbuf, host_info.start_lp);
+	BufferIO::Write<int32_t>(pbuf, host_info.start_lp);
 	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
 	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
 	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
@@ -713,7 +713,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
 				/*ss = */BufferIO::Read<uint8_t>(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) BufferIO::Write<int32_t>(pbufw, 0);
 			}
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -731,7 +731,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
 				/*ss = */BufferIO::Read<uint8_t>(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) BufferIO::Write<int32_t>(pbufw, 0);
 			}
 			count = BufferIO::Read<uint8_t>(pbuf);
 			for (int i = 0; i < count; ++i) {
@@ -741,7 +741,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
 				/*ss = */BufferIO::Read<uint8_t>(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) BufferIO::Write<int32_t>(pbufw, 0);
 			}
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -848,7 +848,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			count = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for(int i = 0; i < count; ++i)
-				BufferIO::WriteInt32(pbuf, 0);
+				BufferIO::Write<int32_t>(pbuf, 0);
 			NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, offset, pbuf - offset);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 				NetServer::ReSendToPlayer(*oit);
@@ -860,7 +860,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			count = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for (int i = 0; i < count; ++i)
-				BufferIO::WriteInt32(pbuf, 0);
+				BufferIO::Write<int32_t>(pbuf, 0);
 			NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, offset, pbuf - offset);
 			for (auto oit = observers.begin(); oit != observers.end(); ++oit)
 				NetServer::ReSendToPlayer(*oit);
@@ -960,7 +960,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 16;
 			NetServer::SendBufferToPlayer(players[cc], STOC_GAME_MSG, offset, pbuf - offset);
 			if (!(cl & (LOCATION_GRAVE + LOCATION_OVERLAY)) && ((cl & (LOCATION_DECK + LOCATION_HAND)) || (cp & POS_FACEDOWN)))
-				BufferIO::WriteInt32(pbufw, 0);
+				BufferIO::Write<int32_t>(pbufw, 0);
 			NetServer::SendBufferToPlayer(players[1 - cc], STOC_GAME_MSG, offset, pbuf - offset);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 				NetServer::ReSendToPlayer(*oit);
@@ -984,7 +984,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SET: {
-			BufferIO::WriteInt32(pbuf, 0);
+			BufferIO::Write<int32_t>(pbuf, 0);
 			pbuf += 4;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1180,7 +1180,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			for (int i = 0; i < count; ++i) {
 				if(!(pbufw[3] & 0x80))
-					BufferIO::WriteInt32(pbufw, 0);
+					BufferIO::Write<int32_t>(pbufw, 0);
 				else
 					pbufw += 4;
 			}
@@ -1563,8 +1563,8 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	const int clen = BufferIO::Read<int32_t>(qbuf);
 	auto position = GetPosition(qbuf, 8);
 	if (position & POS_FACEDOWN) {
-		BufferIO::WriteInt32(qbuf, QUERY_CODE);
-		BufferIO::WriteInt32(qbuf, 0);
+		BufferIO::Write<int32_t>(qbuf, QUERY_CODE);
+		BufferIO::Write<int32_t>(qbuf, 0);
 		std::memset(qbuf, 0, clen - 12);
 	}
 	NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, query_buffer, len + 4);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -457,9 +457,9 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	last_replay.Flush();
 	unsigned char startbuf[32]{};
 	auto pbuf = startbuf;
-	BufferIO::WriteUInt8(pbuf, MSG_START);
-	BufferIO::WriteUInt8(pbuf, 0);
-	BufferIO::WriteUInt8(pbuf, host_info.duel_rule);
+	buffer_write<uint8_t>(pbuf, MSG_START);
+	buffer_write<uint8_t>(pbuf, 0);
+	buffer_write<uint8_t>(pbuf, host_info.duel_rule);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
 	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
@@ -1462,9 +1462,9 @@ void SingleDuel::TimeConfirm(DuelPlayer* dp) {
 }
 inline int SingleDuel::WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
-	BufferIO::WriteUInt8(qbuf, MSG_UPDATE_DATA);
-	BufferIO::WriteUInt8(qbuf, player);
-	BufferIO::WriteUInt8(qbuf, location);
+	buffer_write<uint8_t>(qbuf, MSG_UPDATE_DATA);
+	buffer_write<uint8_t>(qbuf, player);
+	buffer_write<uint8_t>(qbuf, location);
 	int len = query_field_card(pduel, player, location, flag, qbuf, use_cache);
 	return len;
 }
@@ -1552,10 +1552,10 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	flag |= (QUERY_CODE | QUERY_POSITION);
 	unsigned char query_buffer[0x1000];
 	auto qbuf = query_buffer;
-	BufferIO::WriteUInt8(qbuf, MSG_UPDATE_CARD);
-	BufferIO::WriteUInt8(qbuf, player);
-	BufferIO::WriteUInt8(qbuf, location);
-	BufferIO::WriteUInt8(qbuf, sequence);
+	buffer_write<uint8_t>(qbuf, MSG_UPDATE_CARD);
+	buffer_write<uint8_t>(qbuf, player);
+	buffer_write<uint8_t>(qbuf, location);
+	buffer_write<uint8_t>(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer, len + 4);
 	if (len <= LEN_HEADER)

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -578,7 +578,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 	int player, count, type;
 	while (pbuf - msgbuffer < (int)len) {
 		offset = pbuf;
-		unsigned char engType = buffer_read<uint8_t>(pbuf);
+		unsigned char engType = BufferIO::Read<uint8_t>(pbuf);
 		switch (engType) {
 		case MSG_RETRY: {
 			WaitforResponse(last_response);
@@ -586,8 +586,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_HINT: {
-			type = buffer_read<uint8_t>(pbuf);
-			player = buffer_read<uint8_t>(pbuf);
+			type = BufferIO::Read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			BufferIO::ReadInt32(pbuf);
 			switch (type) {
 			case 1:
@@ -619,8 +619,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_WIN: {
-			player = buffer_read<uint8_t>(pbuf);
-			type = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			type = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
@@ -639,10 +639,10 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 2;
 		}
 		case MSG_SELECT_BATTLECMD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8 + 2;
 			RefreshMzone(0);
 			RefreshMzone(1);
@@ -655,18 +655,18 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_IDLECMD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11 + 3;
 			RefreshMzone(0);
 			RefreshMzone(1);
@@ -679,22 +679,22 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_EFFECTYN: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 12;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_YESNO: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_OPTION: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -702,17 +702,17 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_CARD:
 		case MSG_SELECT_TRIBUTE: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 3;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = buffer_read<uint8_t>(pbuf);
-				/*l = */buffer_read<uint8_t>(pbuf);
-				/*s = */buffer_read<uint8_t>(pbuf);
-				/*ss = */buffer_read<uint8_t>(pbuf);
+				c = BufferIO::Read<uint8_t>(pbuf);
+				/*l = */BufferIO::Read<uint8_t>(pbuf);
+				/*s = */BufferIO::Read<uint8_t>(pbuf);
+				/*ss = */BufferIO::Read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
 			WaitforResponse(player);
@@ -720,27 +720,27 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_UNSELECT_CARD: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = buffer_read<uint8_t>(pbuf);
-				/*l = */buffer_read<uint8_t>(pbuf);
-				/*s = */buffer_read<uint8_t>(pbuf);
-				/*ss = */buffer_read<uint8_t>(pbuf);
+				c = BufferIO::Read<uint8_t>(pbuf);
+				/*l = */BufferIO::Read<uint8_t>(pbuf);
+				/*s = */BufferIO::Read<uint8_t>(pbuf);
+				/*ss = */BufferIO::Read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = buffer_read<uint8_t>(pbuf);
-				/*l = */buffer_read<uint8_t>(pbuf);
-				/*s = */buffer_read<uint8_t>(pbuf);
-				/*ss = */buffer_read<uint8_t>(pbuf);
+				c = BufferIO::Read<uint8_t>(pbuf);
+				/*l = */BufferIO::Read<uint8_t>(pbuf);
+				/*s = */BufferIO::Read<uint8_t>(pbuf);
+				/*ss = */BufferIO::Read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
 			WaitforResponse(player);
@@ -757,23 +757,23 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_PLACE:
 		case MSG_SELECT_DISFIELD: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_POSITION: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_COUNTER: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 9;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -781,27 +781,27 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_SUM: {
 			pbuf++;
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 6;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SORT_CARD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_CONFIRM_DECKTOP: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -810,8 +810,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_CONFIRM_EXTRATOP: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -836,7 +836,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_DECK: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
@@ -844,8 +844,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for(int i = 0; i < count; ++i)
 				BufferIO::WriteInt32(pbuf, 0);
@@ -856,8 +856,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_EXTRA: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for (int i = 0; i < count; ++i)
 				BufferIO::WriteInt32(pbuf, 0);
@@ -876,7 +876,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SWAP_GRAVE_DECK: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
@@ -900,8 +900,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_SET_CARD: {
-			unsigned int loc = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			unsigned int loc = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1148,14 +1148,14 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_CARD_SELECTED: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			break;
 		}
 		case MSG_RANDOM_SELECTED: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1164,7 +1164,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_BECOME_TARGET: {
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1173,8 +1173,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_DRAW: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbufw = pbuf;
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1317,8 +1317,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_COIN: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1327,8 +1327,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_DICE: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1337,7 +1337,7 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_ROCK_PAPER_SCISSORS: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
@@ -1351,14 +1351,14 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_ANNOUNCE_RACE: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_ANNOUNCE_ATTRIB: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1366,8 +1366,8 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_ANNOUNCE_CARD:
 		case MSG_ANNOUNCE_NUMBER: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4 * count;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -188,7 +188,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		if(is_closing || !is_continuing)
 			return false;
 		offset = pbuf;
-		mainGame->dInfo.curMsg = buffer_read<uint8_t>(pbuf);
+		mainGame->dInfo.curMsg = BufferIO::Read<uint8_t>(pbuf);
 		switch (mainGame->dInfo.curMsg) {
 		case MSG_RETRY: {
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
@@ -198,8 +198,8 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_HINT: {
-			/*int type = */buffer_read<uint8_t>(pbuf);
-			int player = buffer_read<uint8_t>(pbuf);
+			/*int type = */BufferIO::Read<uint8_t>(pbuf);
+			int player = BufferIO::Read<uint8_t>(pbuf);
 			/*int data = */BufferIO::ReadInt32(pbuf);
 			if(player == 0)
 				DuelClient::ClientAnalyze(offset, pbuf - offset);
@@ -211,10 +211,10 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			return false;
 		}
 		case MSG_SELECT_BATTLECMD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8 + 2;
 			SinglePlayRefresh();
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
@@ -224,18 +224,18 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_IDLECMD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11 + 3;
 			SinglePlayRefresh();
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
@@ -245,7 +245,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_EFFECTYN: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 12;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
@@ -255,7 +255,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_YESNO: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -264,8 +264,8 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_OPTION: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -275,9 +275,9 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SELECT_CARD:
 		case MSG_SELECT_TRIBUTE: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 3;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -286,11 +286,11 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_UNSELECT_CARD: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -310,7 +310,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SELECT_PLACE:
 		case MSG_SELECT_DISFIELD: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -319,7 +319,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_POSITION: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -328,9 +328,9 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_COUNTER: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 9;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -340,11 +340,11 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SELECT_SUM: {
 			pbuf++;
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 6;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -353,8 +353,8 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SORT_CARD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -363,15 +363,15 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_CONFIRM_DECKTOP: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_CONFIRM_EXTRATOP: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -385,21 +385,21 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_DECK: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			SinglePlayRefreshDeck(player);
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
-			/*int oplayer = */buffer_read<uint8_t>(pbuf);
-			int count = buffer_read<uint8_t>(pbuf);
+			/*int oplayer = */BufferIO::Read<uint8_t>(pbuf);
+			int count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_SHUFFLE_EXTRA: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -410,7 +410,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SWAP_GRAVE_DECK: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			SinglePlayRefreshGrave(player);
 			break;
@@ -428,13 +428,13 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SHUFFLE_SET_CARD: {
 			pbuf++;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_NEW_TURN: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
@@ -550,21 +550,21 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_CARD_SELECTED:
 		case MSG_RANDOM_SELECTED: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_BECOME_TARGET: {
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_DRAW: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -649,21 +649,21 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_COIN: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_TOSS_DICE: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_ROCK_PAPER_SCISSORS: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
 				mainGame->singleSignal.Wait();
@@ -676,7 +676,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_ANNOUNCE_RACE: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -685,7 +685,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_ANNOUNCE_ATTRIB: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -695,8 +695,8 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_ANNOUNCE_CARD:
 		case MSG_ANNOUNCE_NUMBER: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4 * count;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -731,18 +731,18 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			for(int p = 0; p < 2; ++p) {
 				pbuf += 4;
 				for(int seq = 0; seq < 7; ++seq) {
-					int val = buffer_read<uint8_t>(pbuf);
+					int val = BufferIO::Read<uint8_t>(pbuf);
 					if(val)
 						pbuf += 2;
 				}
 				for(int seq = 0; seq < 8; ++seq) {
-					int val = buffer_read<uint8_t>(pbuf);
+					int val = BufferIO::Read<uint8_t>(pbuf);
 					if(val)
 						pbuf++;
 				}
 				pbuf += 6;
 			}
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 15;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			SinglePlayReload();
@@ -754,7 +754,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		case MSG_AI_NAME: {
 			char namebuf[SIZE_AI_NAME]{};
 			wchar_t wname[20]{};
-			int name_len = buffer_read<uint16_t>(pbuf);
+			int name_len = BufferIO::Read<uint16_t>(pbuf);
 			if (name_len + 1 <= (int)sizeof namebuf) {
 				std::memcpy(namebuf, pbuf, name_len);
 				namebuf[name_len] = 0;
@@ -767,7 +767,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		case MSG_SHOW_HINT: {
 			char msgbuf[SIZE_HINT_MSG]{};
 			wchar_t msg[SIZE_HINT_MSG]{};
-			int msg_len = buffer_read<uint16_t>(pbuf);
+			int msg_len = BufferIO::Read<uint16_t>(pbuf);
 			if (msg_len + 1 <= (int)sizeof msgbuf) {
 				std::memcpy(msgbuf, pbuf, msg_len);
 				msgbuf[msg_len] = 0;

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -299,8 +299,8 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_CHAIN: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 9 + count * 14;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -377,9 +377,9 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_CONFIRM_CARDS: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 1;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -188,7 +188,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		if(is_closing || !is_continuing)
 			return false;
 		offset = pbuf;
-		mainGame->dInfo.curMsg = BufferIO::ReadUInt8(pbuf);
+		mainGame->dInfo.curMsg = buffer_read<uint8_t>(pbuf);
 		switch (mainGame->dInfo.curMsg) {
 		case MSG_RETRY: {
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
@@ -198,8 +198,8 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_HINT: {
-			/*int type = */BufferIO::ReadUInt8(pbuf);
-			int player = BufferIO::ReadUInt8(pbuf);
+			/*int type = */buffer_read<uint8_t>(pbuf);
+			int player = buffer_read<uint8_t>(pbuf);
 			/*int data = */BufferIO::ReadInt32(pbuf);
 			if(player == 0)
 				DuelClient::ClientAnalyze(offset, pbuf - offset);
@@ -211,10 +211,10 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			return false;
 		}
 		case MSG_SELECT_BATTLECMD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8 + 2;
 			SinglePlayRefresh();
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
@@ -224,18 +224,18 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_IDLECMD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11 + 3;
 			SinglePlayRefresh();
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
@@ -245,7 +245,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_EFFECTYN: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 12;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
@@ -255,7 +255,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_YESNO: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -264,8 +264,8 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_OPTION: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -275,9 +275,9 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SELECT_CARD:
 		case MSG_SELECT_TRIBUTE: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 3;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -286,11 +286,11 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_UNSELECT_CARD: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -310,7 +310,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SELECT_PLACE:
 		case MSG_SELECT_DISFIELD: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -319,7 +319,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_POSITION: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -328,9 +328,9 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SELECT_COUNTER: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 9;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -340,11 +340,11 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SELECT_SUM: {
 			pbuf++;
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 6;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -353,8 +353,8 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SORT_CARD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -363,15 +363,15 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_CONFIRM_DECKTOP: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_CONFIRM_EXTRATOP: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -385,21 +385,21 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_DECK: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			SinglePlayRefreshDeck(player);
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
-			/*int oplayer = */BufferIO::ReadUInt8(pbuf);
-			int count = BufferIO::ReadUInt8(pbuf);
+			/*int oplayer = */buffer_read<uint8_t>(pbuf);
+			int count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_SHUFFLE_EXTRA: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -410,7 +410,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_SWAP_GRAVE_DECK: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			SinglePlayRefreshGrave(player);
 			break;
@@ -428,13 +428,13 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_SHUFFLE_SET_CARD: {
 			pbuf++;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_NEW_TURN: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
@@ -550,21 +550,21 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_CARD_SELECTED:
 		case MSG_RANDOM_SELECTED: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_BECOME_TARGET: {
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_DRAW: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
@@ -649,21 +649,21 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_COIN: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_TOSS_DICE: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;
 		}
 		case MSG_ROCK_PAPER_SCISSORS: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
 				mainGame->singleSignal.Wait();
@@ -676,7 +676,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_ANNOUNCE_RACE: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -685,7 +685,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_ANNOUNCE_ATTRIB: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -695,8 +695,8 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		}
 		case MSG_ANNOUNCE_CARD:
 		case MSG_ANNOUNCE_NUMBER: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += 4 * count;
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
@@ -731,18 +731,18 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			for(int p = 0; p < 2; ++p) {
 				pbuf += 4;
 				for(int seq = 0; seq < 7; ++seq) {
-					int val = BufferIO::ReadUInt8(pbuf);
+					int val = buffer_read<uint8_t>(pbuf);
 					if(val)
 						pbuf += 2;
 				}
 				for(int seq = 0; seq < 8; ++seq) {
-					int val = BufferIO::ReadUInt8(pbuf);
+					int val = buffer_read<uint8_t>(pbuf);
 					if(val)
 						pbuf++;
 				}
 				pbuf += 6;
 			}
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 15;
 			DuelClient::ClientAnalyze(offset, pbuf - offset);
 			SinglePlayReload();

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -200,7 +200,7 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		case MSG_HINT: {
 			/*int type = */BufferIO::Read<uint8_t>(pbuf);
 			int player = BufferIO::Read<uint8_t>(pbuf);
-			/*int data = */BufferIO::ReadInt32(pbuf);
+			/*int data = */BufferIO::Read<int32_t>(pbuf);
 			if(player == 0)
 				DuelClient::ClientAnalyze(offset, pbuf - offset);
 			break;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -704,8 +704,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_CHAIN: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 9 + count * 14;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -780,9 +780,9 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_CONFIRM_CARDS: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 1;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			if(pbuf[5] != LOCATION_DECK) {
 				pbuf += count * 7;
 				NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -296,12 +296,12 @@ void TagDuel::StartDuel(DuelPlayer* dp) {
 	}
 	unsigned char deckbuff[12];
 	auto pbuf = deckbuff;
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].main.size());
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].extra.size());
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].side.size());
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[2].main.size());
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[2].extra.size());
-	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[2].side.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].main.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].extra.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].side.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[2].main.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[2].extra.size());
+	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[2].side.size());
 	NetServer::SendBufferToPlayer(players[0], STOC_DECK_COUNT, deckbuff, 12);
 	NetServer::ReSendToPlayer(players[1]);
 	char tempbuff[6];
@@ -451,10 +451,10 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	BufferIO::WriteUInt8(pbuf, host_info.duel_rule);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
-	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
-	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
-	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
-	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
+	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
+	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
+	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
+	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, startbuf, 19);
 	NetServer::ReSendToPlayer(players[1]);
 	startbuf[1] = 1;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -446,9 +446,9 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	last_replay.Flush();
 	unsigned char startbuf[32]{};
 	auto pbuf = startbuf;
-	BufferIO::WriteUInt8(pbuf, MSG_START);
-	BufferIO::WriteUInt8(pbuf, 0);
-	BufferIO::WriteUInt8(pbuf, host_info.duel_rule);
+	buffer_write<uint8_t>(pbuf, MSG_START);
+	buffer_write<uint8_t>(pbuf, 0);
+	buffer_write<uint8_t>(pbuf, host_info.duel_rule);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
 	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
@@ -1571,9 +1571,9 @@ void TagDuel::TimeConfirm(DuelPlayer* dp) {
 }
 inline int TagDuel::WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
-	BufferIO::WriteUInt8(qbuf, MSG_UPDATE_DATA);
-	BufferIO::WriteUInt8(qbuf, player);
-	BufferIO::WriteUInt8(qbuf, location);
+	buffer_write<uint8_t>(qbuf, MSG_UPDATE_DATA);
+	buffer_write<uint8_t>(qbuf, player);
+	buffer_write<uint8_t>(qbuf, location);
 	int len = query_field_card(pduel, player, location, flag, qbuf, use_cache);
 	return len;
 }
@@ -1673,10 +1673,10 @@ void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
 	unsigned char query_buffer[0x1000];
 	auto qbuf = query_buffer;
-	BufferIO::WriteUInt8(qbuf, MSG_UPDATE_CARD);
-	BufferIO::WriteUInt8(qbuf, player);
-	BufferIO::WriteUInt8(qbuf, location);
-	BufferIO::WriteUInt8(qbuf, sequence);
+	buffer_write<uint8_t>(qbuf, MSG_UPDATE_CARD);
+	buffer_write<uint8_t>(qbuf, player);
+	buffer_write<uint8_t>(qbuf, location);
+	buffer_write<uint8_t>(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
 	auto position = GetPosition(qbuf, 12);
 	if(location & LOCATION_ONFIELD) {

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -540,7 +540,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 	int player, count, type;
 	while (pbuf - msgbuffer < (int)len) {
 		offset = pbuf;
-		unsigned char engType = buffer_read<uint8_t>(pbuf);
+		unsigned char engType = BufferIO::Read<uint8_t>(pbuf);
 		switch (engType) {
 		case MSG_RETRY: {
 			WaitforResponse(last_response);
@@ -548,8 +548,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_HINT: {
-			type = buffer_read<uint8_t>(pbuf);
-			player = buffer_read<uint8_t>(pbuf);
+			type = BufferIO::Read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			BufferIO::ReadInt32(pbuf);
 			switch (type) {
 			case 1:
@@ -583,8 +583,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_WIN: {
-			player = buffer_read<uint8_t>(pbuf);
-			type = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			type = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
@@ -595,10 +595,10 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 2;
 		}
 		case MSG_SELECT_BATTLECMD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8 + 2;
 			RefreshMzone(0);
 			RefreshMzone(1);
@@ -611,18 +611,18 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_IDLECMD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11 + 3;
 			RefreshMzone(0);
 			RefreshMzone(1);
@@ -635,22 +635,22 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_EFFECTYN: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 12;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_YESNO: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_OPTION: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -658,17 +658,17 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_CARD:
 		case MSG_SELECT_TRIBUTE: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 3;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = buffer_read<uint8_t>(pbuf);
-				/*l = */buffer_read<uint8_t>(pbuf);
-				/*s = */buffer_read<uint8_t>(pbuf);
-				/*ss = */buffer_read<uint8_t>(pbuf);
+				c = BufferIO::Read<uint8_t>(pbuf);
+				/*l = */BufferIO::Read<uint8_t>(pbuf);
+				/*s = */BufferIO::Read<uint8_t>(pbuf);
+				/*ss = */BufferIO::Read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
 			WaitforResponse(player);
@@ -676,27 +676,27 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_UNSELECT_CARD: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = buffer_read<uint8_t>(pbuf);
-				/*l = */buffer_read<uint8_t>(pbuf);
-				/*s = */buffer_read<uint8_t>(pbuf);
-				/*ss = */buffer_read<uint8_t>(pbuf);
+				c = BufferIO::Read<uint8_t>(pbuf);
+				/*l = */BufferIO::Read<uint8_t>(pbuf);
+				/*s = */BufferIO::Read<uint8_t>(pbuf);
+				/*ss = */BufferIO::Read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = buffer_read<uint8_t>(pbuf);
-				/*l = */buffer_read<uint8_t>(pbuf);
-				/*s = */buffer_read<uint8_t>(pbuf);
-				/*ss = */buffer_read<uint8_t>(pbuf);
+				c = BufferIO::Read<uint8_t>(pbuf);
+				/*l = */BufferIO::Read<uint8_t>(pbuf);
+				/*s = */BufferIO::Read<uint8_t>(pbuf);
+				/*ss = */BufferIO::Read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
 			WaitforResponse(player);
@@ -713,23 +713,23 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_PLACE:
 		case MSG_SELECT_DISFIELD: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_POSITION: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_COUNTER: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 9;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -737,27 +737,27 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_SUM: {
 			pbuf++;
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 6;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 11;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SORT_CARD: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_CONFIRM_DECKTOP: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -768,8 +768,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_CONFIRM_EXTRATOP: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -798,7 +798,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_DECK: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
@@ -808,8 +808,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for(int i = 0; i < count; ++i)
 				BufferIO::WriteInt32(pbuf, 0);
@@ -822,8 +822,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_EXTRA: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for(int i = 0; i < count; ++i)
 				BufferIO::WriteInt32(pbuf, 0);
@@ -846,7 +846,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SWAP_GRAVE_DECK: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
@@ -876,8 +876,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_SET_CARD: {
-			unsigned int loc = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			unsigned int loc = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1176,14 +1176,14 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_CARD_SELECTED: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			break;
 		}
 		case MSG_RANDOM_SELECTED: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1194,7 +1194,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_BECOME_TARGET: {
-			count = buffer_read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1205,8 +1205,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_DRAW: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbufw = pbuf;
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1381,8 +1381,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_COIN: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1393,8 +1393,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_DICE: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += count;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1405,7 +1405,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_ROCK_PAPER_SCISSORS: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
@@ -1421,14 +1421,14 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_ANNOUNCE_RACE: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_ANNOUNCE_ATTRIB: {
-			player = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1436,8 +1436,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_ANNOUNCE_CARD:
 		case MSG_ANNOUNCE_NUMBER: {
-			player = buffer_read<uint8_t>(pbuf);
-			count = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			count = BufferIO::Read<uint8_t>(pbuf);
 			pbuf += 4 * count;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1464,11 +1464,11 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_TAG_SWAP: {
-			player = buffer_read<uint8_t>(pbuf);
-			/*int mcount = */buffer_read<uint8_t>(pbuf);
-			int ecount = buffer_read<uint8_t>(pbuf);
-			/*int pcount = */buffer_read<uint8_t>(pbuf);
-			int hcount = buffer_read<uint8_t>(pbuf);
+			player = BufferIO::Read<uint8_t>(pbuf);
+			/*int mcount = */BufferIO::Read<uint8_t>(pbuf);
+			int ecount = BufferIO::Read<uint8_t>(pbuf);
+			/*int pcount = */BufferIO::Read<uint8_t>(pbuf);
+			int hcount = BufferIO::Read<uint8_t>(pbuf);
 			pbufw = pbuf + 4;
 			pbuf += hcount * 4 + ecount * 4 + 4;
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -449,8 +449,8 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	BufferIO::Write<uint8_t>(pbuf, MSG_START);
 	BufferIO::Write<uint8_t>(pbuf, 0);
 	BufferIO::Write<uint8_t>(pbuf, host_info.duel_rule);
-	BufferIO::WriteInt32(pbuf, host_info.start_lp);
-	BufferIO::WriteInt32(pbuf, host_info.start_lp);
+	BufferIO::Write<int32_t>(pbuf, host_info.start_lp);
+	BufferIO::Write<int32_t>(pbuf, host_info.start_lp);
 	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
 	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
 	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
@@ -669,7 +669,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
 				/*ss = */BufferIO::Read<uint8_t>(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) BufferIO::Write<int32_t>(pbufw, 0);
 			}
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -687,7 +687,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
 				/*ss = */BufferIO::Read<uint8_t>(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) BufferIO::Write<int32_t>(pbufw, 0);
 			}
 			count = BufferIO::Read<uint8_t>(pbuf);
 			for (int i = 0; i < count; ++i) {
@@ -697,7 +697,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
 				/*ss = */BufferIO::Read<uint8_t>(pbuf);
-				if (c != player) BufferIO::WriteInt32(pbufw, 0);
+				if (c != player) BufferIO::Write<int32_t>(pbufw, 0);
 			}
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -812,7 +812,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			count = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for(int i = 0; i < count; ++i)
-				BufferIO::WriteInt32(pbuf, 0);
+				BufferIO::Write<int32_t>(pbuf, 0);
 			for(int i = 0; i < 4; ++i)
 				if(players[i] != cur_player[player])
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
@@ -826,7 +826,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			count = BufferIO::Read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for(int i = 0; i < count; ++i)
-				BufferIO::WriteInt32(pbuf, 0);
+				BufferIO::Write<int32_t>(pbuf, 0);
 			for(int i = 0; i < 4; ++i)
 				if(players[i] != cur_player[player])
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
@@ -952,7 +952,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			pbuf += 16;
 			NetServer::SendBufferToPlayer(cur_player[cc], STOC_GAME_MSG, offset, pbuf - offset);
 			if (!(cl & (LOCATION_GRAVE + LOCATION_OVERLAY)) && ((cl & (LOCATION_DECK + LOCATION_HAND)) || (cp & POS_FACEDOWN)))
-				BufferIO::WriteInt32(pbufw, 0);
+				BufferIO::Write<int32_t>(pbufw, 0);
 			for(int i = 0; i < 4; ++i)
 				if(players[i] != cur_player[cc])
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
@@ -980,7 +980,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SET: {
-			BufferIO::WriteInt32(pbuf, 0);
+			BufferIO::Write<int32_t>(pbuf, 0);
 			pbuf += 4;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1212,7 +1212,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			for (int i = 0; i < count; ++i) {
 				if(!(pbufw[3] & 0x80))
-					BufferIO::WriteInt32(pbufw, 0);
+					BufferIO::Write<int32_t>(pbufw, 0);
 				else
 					pbufw += 4;
 			}
@@ -1474,13 +1474,13 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			for (int i = 0; i < hcount; ++i) {
 				if(!(pbufw[3] & 0x80))
-					BufferIO::WriteInt32(pbufw, 0);
+					BufferIO::Write<int32_t>(pbufw, 0);
 				else
 					pbufw += 4;
 			}
 			for (int i = 0; i < ecount; ++i) {
 				if(!(pbufw[3] & 0x80))
-					BufferIO::WriteInt32(pbufw, 0);
+					BufferIO::Write<int32_t>(pbufw, 0);
 				else
 					pbufw += 4;
 			}

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -540,7 +540,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 	int player, count, type;
 	while (pbuf - msgbuffer < (int)len) {
 		offset = pbuf;
-		unsigned char engType = BufferIO::ReadUInt8(pbuf);
+		unsigned char engType = buffer_read<uint8_t>(pbuf);
 		switch (engType) {
 		case MSG_RETRY: {
 			WaitforResponse(last_response);
@@ -548,8 +548,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_HINT: {
-			type = BufferIO::ReadUInt8(pbuf);
-			player = BufferIO::ReadUInt8(pbuf);
+			type = buffer_read<uint8_t>(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			BufferIO::ReadInt32(pbuf);
 			switch (type) {
 			case 1:
@@ -583,8 +583,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_WIN: {
-			player = BufferIO::ReadUInt8(pbuf);
-			type = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			type = buffer_read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
@@ -595,10 +595,10 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 2;
 		}
 		case MSG_SELECT_BATTLECMD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8 + 2;
 			RefreshMzone(0);
 			RefreshMzone(1);
@@ -611,18 +611,18 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_IDLECMD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11 + 3;
 			RefreshMzone(0);
 			RefreshMzone(1);
@@ -635,22 +635,22 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_EFFECTYN: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 12;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_YESNO: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_OPTION: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -658,17 +658,17 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_CARD:
 		case MSG_SELECT_TRIBUTE: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 3;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = BufferIO::ReadUInt8(pbuf);
-				/*l = */BufferIO::ReadUInt8(pbuf);
-				/*s = */BufferIO::ReadUInt8(pbuf);
-				/*ss = */BufferIO::ReadUInt8(pbuf);
+				c = buffer_read<uint8_t>(pbuf);
+				/*l = */buffer_read<uint8_t>(pbuf);
+				/*s = */buffer_read<uint8_t>(pbuf);
+				/*ss = */buffer_read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
 			WaitforResponse(player);
@@ -676,27 +676,27 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			return 1;
 		}
 		case MSG_SELECT_UNSELECT_CARD: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = BufferIO::ReadUInt8(pbuf);
-				/*l = */BufferIO::ReadUInt8(pbuf);
-				/*s = */BufferIO::ReadUInt8(pbuf);
-				/*ss = */BufferIO::ReadUInt8(pbuf);
+				c = buffer_read<uint8_t>(pbuf);
+				/*l = */buffer_read<uint8_t>(pbuf);
+				/*s = */buffer_read<uint8_t>(pbuf);
+				/*ss = */buffer_read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
 				/*code = */BufferIO::ReadInt32(pbuf);
-				c = BufferIO::ReadUInt8(pbuf);
-				/*l = */BufferIO::ReadUInt8(pbuf);
-				/*s = */BufferIO::ReadUInt8(pbuf);
-				/*ss = */BufferIO::ReadUInt8(pbuf);
+				c = buffer_read<uint8_t>(pbuf);
+				/*l = */buffer_read<uint8_t>(pbuf);
+				/*s = */buffer_read<uint8_t>(pbuf);
+				/*ss = */buffer_read<uint8_t>(pbuf);
 				if (c != player) BufferIO::WriteInt32(pbufw, 0);
 			}
 			WaitforResponse(player);
@@ -713,23 +713,23 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_PLACE:
 		case MSG_SELECT_DISFIELD: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_POSITION: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SELECT_COUNTER: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 4;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 9;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -737,27 +737,27 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_SELECT_SUM: {
 			pbuf++;
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 6;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 11;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_SORT_CARD: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_CONFIRM_DECKTOP: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -768,8 +768,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_CONFIRM_EXTRATOP: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 7;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -798,7 +798,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_DECK: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
@@ -808,8 +808,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_HAND: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for(int i = 0; i < count; ++i)
 				BufferIO::WriteInt32(pbuf, 0);
@@ -822,8 +822,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_EXTRA: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, (pbuf - offset) + count * 4);
 			for(int i = 0; i < count; ++i)
 				BufferIO::WriteInt32(pbuf, 0);
@@ -846,7 +846,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SWAP_GRAVE_DECK: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
 			NetServer::ReSendToPlayer(players[2]);
@@ -876,8 +876,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SHUFFLE_SET_CARD: {
-			unsigned int loc = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			unsigned int loc = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 8;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1176,14 +1176,14 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_CARD_SELECTED: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			break;
 		}
 		case MSG_RANDOM_SELECTED: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1194,7 +1194,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_BECOME_TARGET: {
-			count = BufferIO::ReadUInt8(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1205,8 +1205,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_DRAW: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbufw = pbuf;
 			pbuf += count * 4;
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1381,8 +1381,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_COIN: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1393,8 +1393,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_TOSS_DICE: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += count;
 			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[1]);
@@ -1405,7 +1405,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_ROCK_PAPER_SCISSORS: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
@@ -1421,14 +1421,14 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_ANNOUNCE_RACE: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
 		}
 		case MSG_ANNOUNCE_ATTRIB: {
-			player = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
 			pbuf += 5;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1436,8 +1436,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		}
 		case MSG_ANNOUNCE_CARD:
 		case MSG_ANNOUNCE_NUMBER: {
-			player = BufferIO::ReadUInt8(pbuf);
-			count = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			count = buffer_read<uint8_t>(pbuf);
 			pbuf += 4 * count;
 			WaitforResponse(player);
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1464,11 +1464,11 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_TAG_SWAP: {
-			player = BufferIO::ReadUInt8(pbuf);
-			/*int mcount = */BufferIO::ReadUInt8(pbuf);
-			int ecount = BufferIO::ReadUInt8(pbuf);
-			/*int pcount = */BufferIO::ReadUInt8(pbuf);
-			int hcount = BufferIO::ReadUInt8(pbuf);
+			player = buffer_read<uint8_t>(pbuf);
+			/*int mcount = */buffer_read<uint8_t>(pbuf);
+			int ecount = buffer_read<uint8_t>(pbuf);
+			/*int pcount = */buffer_read<uint8_t>(pbuf);
+			int hcount = buffer_read<uint8_t>(pbuf);
 			pbufw = pbuf + 4;
 			pbuf += hcount * 4 + ecount * 4 + 4;
 			NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -550,7 +550,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		case MSG_HINT: {
 			type = BufferIO::Read<uint8_t>(pbuf);
 			player = BufferIO::Read<uint8_t>(pbuf);
-			BufferIO::ReadInt32(pbuf);
+			BufferIO::Read<int32_t>(pbuf);
 			switch (type) {
 			case 1:
 			case 2:
@@ -664,7 +664,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
-				/*code = */BufferIO::ReadInt32(pbuf);
+				/*code = */BufferIO::Read<int32_t>(pbuf);
 				c = BufferIO::Read<uint8_t>(pbuf);
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
@@ -682,7 +682,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			int c/*, l, s, ss, code*/;
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
-				/*code = */BufferIO::ReadInt32(pbuf);
+				/*code = */BufferIO::Read<int32_t>(pbuf);
 				c = BufferIO::Read<uint8_t>(pbuf);
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
@@ -692,7 +692,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			count = BufferIO::Read<uint8_t>(pbuf);
 			for (int i = 0; i < count; ++i) {
 				pbufw = pbuf;
-				/*code = */BufferIO::ReadInt32(pbuf);
+				/*code = */BufferIO::Read<int32_t>(pbuf);
 				c = BufferIO::Read<uint8_t>(pbuf);
 				/*l = */BufferIO::Read<uint8_t>(pbuf);
 				/*s = */BufferIO::Read<uint8_t>(pbuf);
@@ -1587,7 +1587,7 @@ void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 	NetServer::ReSendToPlayer(players[pid + 1]);
 	int qlen = 0;
 	while(qlen < len) {
-		int clen = BufferIO::ReadInt32(qbuf);
+		int clen = BufferIO::Read<int32_t>(qbuf);
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
@@ -1612,7 +1612,7 @@ void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 	NetServer::ReSendToPlayer(players[pid + 1]);
 	int qlen = 0;
 	while(qlen < len) {
-		int clen = BufferIO::ReadInt32(qbuf);
+		int clen = BufferIO::Read<int32_t>(qbuf);
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
@@ -1635,7 +1635,7 @@ void TagDuel::RefreshHand(int player, int flag, int use_cache) {
 	NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	int qlen = 0;
 	while(qlen < len) {
-		int slen = BufferIO::ReadInt32(qbuf);
+		int slen = BufferIO::Read<int32_t>(qbuf);
 		qlen += slen;
 		if (slen <= LEN_HEADER)
 			continue;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -296,12 +296,12 @@ void TagDuel::StartDuel(DuelPlayer* dp) {
 	}
 	unsigned char deckbuff[12];
 	auto pbuf = deckbuff;
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].main.size());
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].extra.size());
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[0].side.size());
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[2].main.size());
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[2].extra.size());
-	buffer_write<uint16_t>(pbuf, (uint16_t)pdeck[2].side.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[0].main.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[0].extra.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[0].side.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[2].main.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[2].extra.size());
+	BufferIO::Write<uint16_t>(pbuf, (uint16_t)pdeck[2].side.size());
 	NetServer::SendBufferToPlayer(players[0], STOC_DECK_COUNT, deckbuff, 12);
 	NetServer::ReSendToPlayer(players[1]);
 	char tempbuff[6];
@@ -446,15 +446,15 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	last_replay.Flush();
 	unsigned char startbuf[32]{};
 	auto pbuf = startbuf;
-	buffer_write<uint8_t>(pbuf, MSG_START);
-	buffer_write<uint8_t>(pbuf, 0);
-	buffer_write<uint8_t>(pbuf, host_info.duel_rule);
+	BufferIO::Write<uint8_t>(pbuf, MSG_START);
+	BufferIO::Write<uint8_t>(pbuf, 0);
+	BufferIO::Write<uint8_t>(pbuf, host_info.duel_rule);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
-	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
-	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
-	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
-	buffer_write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
+	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
+	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
+	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
+	BufferIO::Write<uint16_t>(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, startbuf, 19);
 	NetServer::ReSendToPlayer(players[1]);
 	startbuf[1] = 1;
@@ -1571,9 +1571,9 @@ void TagDuel::TimeConfirm(DuelPlayer* dp) {
 }
 inline int TagDuel::WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
-	buffer_write<uint8_t>(qbuf, MSG_UPDATE_DATA);
-	buffer_write<uint8_t>(qbuf, player);
-	buffer_write<uint8_t>(qbuf, location);
+	BufferIO::Write<uint8_t>(qbuf, MSG_UPDATE_DATA);
+	BufferIO::Write<uint8_t>(qbuf, player);
+	BufferIO::Write<uint8_t>(qbuf, location);
 	int len = query_field_card(pduel, player, location, flag, qbuf, use_cache);
 	return len;
 }
@@ -1673,10 +1673,10 @@ void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
 	unsigned char query_buffer[0x1000];
 	auto qbuf = query_buffer;
-	buffer_write<uint8_t>(qbuf, MSG_UPDATE_CARD);
-	buffer_write<uint8_t>(qbuf, player);
-	buffer_write<uint8_t>(qbuf, location);
-	buffer_write<uint8_t>(qbuf, sequence);
+	BufferIO::Write<uint8_t>(qbuf, MSG_UPDATE_CARD);
+	BufferIO::Write<uint8_t>(qbuf, player);
+	BufferIO::Write<uint8_t>(qbuf, location);
+	BufferIO::Write<uint8_t>(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
 	auto position = GetPosition(qbuf, 12);
 	if(location & LOCATION_ONFIELD) {

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -296,12 +296,12 @@ void TagDuel::StartDuel(DuelPlayer* dp) {
 	}
 	unsigned char deckbuff[12];
 	auto pbuf = deckbuff;
-	BufferIO::WriteInt16(pbuf, (short)pdeck[0].main.size());
-	BufferIO::WriteInt16(pbuf, (short)pdeck[0].extra.size());
-	BufferIO::WriteInt16(pbuf, (short)pdeck[0].side.size());
-	BufferIO::WriteInt16(pbuf, (short)pdeck[2].main.size());
-	BufferIO::WriteInt16(pbuf, (short)pdeck[2].extra.size());
-	BufferIO::WriteInt16(pbuf, (short)pdeck[2].side.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].main.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].extra.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[0].side.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[2].main.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[2].extra.size());
+	BufferIO::WriteUInt16(pbuf, (uint16_t)pdeck[2].side.size());
 	NetServer::SendBufferToPlayer(players[0], STOC_DECK_COUNT, deckbuff, 12);
 	NetServer::ReSendToPlayer(players[1]);
 	char tempbuff[6];
@@ -446,15 +446,15 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	last_replay.Flush();
 	unsigned char startbuf[32]{};
 	auto pbuf = startbuf;
-	BufferIO::WriteInt8(pbuf, MSG_START);
-	BufferIO::WriteInt8(pbuf, 0);
-	BufferIO::WriteInt8(pbuf, host_info.duel_rule);
+	BufferIO::WriteUInt8(pbuf, MSG_START);
+	BufferIO::WriteUInt8(pbuf, 0);
+	BufferIO::WriteUInt8(pbuf, host_info.duel_rule);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
 	BufferIO::WriteInt32(pbuf, host_info.start_lp);
-	BufferIO::WriteInt16(pbuf, query_field_count(pduel, 0, 0x1));
-	BufferIO::WriteInt16(pbuf, query_field_count(pduel, 0, 0x40));
-	BufferIO::WriteInt16(pbuf, query_field_count(pduel, 1, 0x1));
-	BufferIO::WriteInt16(pbuf, query_field_count(pduel, 1, 0x40));
+	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 0, LOCATION_DECK));
+	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 0, LOCATION_EXTRA));
+	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 1, LOCATION_DECK));
+	BufferIO::WriteUInt16(pbuf, query_field_count(pduel, 1, LOCATION_EXTRA));
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, startbuf, 19);
 	NetServer::ReSendToPlayer(players[1]);
 	startbuf[1] = 1;
@@ -1571,9 +1571,9 @@ void TagDuel::TimeConfirm(DuelPlayer* dp) {
 }
 inline int TagDuel::WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
-	BufferIO::WriteInt8(qbuf, MSG_UPDATE_DATA);
-	BufferIO::WriteInt8(qbuf, player);
-	BufferIO::WriteInt8(qbuf, location);
+	BufferIO::WriteUInt8(qbuf, MSG_UPDATE_DATA);
+	BufferIO::WriteUInt8(qbuf, player);
+	BufferIO::WriteUInt8(qbuf, location);
 	int len = query_field_card(pduel, player, location, flag, qbuf, use_cache);
 	return len;
 }
@@ -1673,10 +1673,10 @@ void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
 	unsigned char query_buffer[0x1000];
 	auto qbuf = query_buffer;
-	BufferIO::WriteInt8(qbuf, MSG_UPDATE_CARD);
-	BufferIO::WriteInt8(qbuf, player);
-	BufferIO::WriteInt8(qbuf, location);
-	BufferIO::WriteInt8(qbuf, sequence);
+	BufferIO::WriteUInt8(qbuf, MSG_UPDATE_CARD);
+	BufferIO::WriteUInt8(qbuf, player);
+	BufferIO::WriteUInt8(qbuf, location);
+	BufferIO::WriteUInt8(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
 	auto position = GetPosition(qbuf, 12);
 	if(location & LOCATION_ONFIELD) {


### PR DESCRIPTION
# Problem
Single script:
```lua
Debug.SetAIName("AI")
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,800,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(39910367,0,0,LOCATION_SZONE,5,POS_FACEUP_ATTACK)
Debug.AddCard(65342096,0,0,LOCATION_HAND,0,POS_FACEDOWN_DEFENSE)
Debug.ReloadFieldEnd()

```
39910367
魔法都市エンディミオン
①：このカードがフィールドゾーンに存在する限り、自分または相手が魔法カードを発動する度に、このカードに魔力カウンターを１つ置く。

Change line 47 of c39910367.lua
```lua
e:GetHandler():AddCounter(0x1,65530)
```
(put 65530 counters)

![圖片](https://github.com/user-attachments/assets/0aa7beb3-2969-42ef-8ded-091170420780)

The maximum number of counters is 65535, so the players can put 65530 counters.

# Solution
Now we do not use int8_t and int16_t.
For types smaller than int, we only use uint8_t and uint16_t.

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust

