### PR TITLE
use patched miniaudio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
     - name: Download miniaudio
       if: matrix.audiolib == 'miniaudio'
       run: |
-        git clone --depth=1 --branch 0.11.22 https://github.com/mackron/miniaudio
+        git clone --depth=1 https://github.com/mercury233/miniaudio
         cd miniaudio
         xcopy /Y extras\miniaudio_split\miniaudio.* .
         cd ..
@@ -367,7 +367,7 @@ jobs:
 
     - name: Download miniaudio
       run: |
-        git clone --depth=1 --branch 0.11.22 https://github.com/mackron/miniaudio
+        git clone --depth=1 https://github.com/mercury233/miniaudio
         cd miniaudio
         cp extras/miniaudio_split/miniaudio.* .
         cd ..
@@ -593,7 +593,7 @@ jobs:
 
     - name: Download miniaudio
       run: |
-        git clone --depth=1 --branch 0.11.22 https://github.com/mackron/miniaudio
+        git clone --depth=1 https://github.com/mercury233/miniaudio
         cd miniaudio
         cp extras/miniaudio_split/miniaudio.* .
         cd ..


### PR DESCRIPTION
alternate to https://github.com/Fluorohydride/ygopro/pull/2833

https://github.com/mercury233/miniaudio : Applied that patch to the codes in `miniaudio_split`, when the `dev` branch of upstream didn't.
