### PR TITLE
remove CTOS_HS_READY

### DIFF
--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -184,7 +184,6 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					break;
 				}
 				UpdateDeck();
-				DuelClient::SendPacketToServer(CTOS_HS_READY);
 				mainGame->cbCategorySelect->setEnabled(false);
 				mainGame->cbDeckSelect->setEnabled(false);
 				break;
@@ -636,7 +635,6 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 						break;
 					}
 					UpdateDeck();
-					DuelClient::SendPacketToServer(CTOS_HS_READY);
 					mainGame->cbCategorySelect->setEnabled(false);
 					mainGame->cbDeckSelect->setEnabled(false);
 				} else {

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -337,11 +337,10 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 		duel_mode->ToObserver(dp);
 		break;
 	}
-	case CTOS_HS_READY:
 	case CTOS_HS_NOTREADY: {
 		if (!duel_mode || duel_mode->pduel)
 			return;
-		duel_mode->PlayerReady(dp, (CTOS_HS_NOTREADY - pktType) != 0);
+		duel_mode->PlayerReady(dp, false);
 		break;
 	}
 	case CTOS_HS_KICK: {

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -260,7 +260,7 @@ public:
 #define CTOS_CHAT			0x16	// uint16_t array
 #define CTOS_HS_TODUELIST	0x20	// no data
 #define CTOS_HS_TOOBSERVER	0x21	// no data
-#define CTOS_HS_READY		0x22	// no data
+// #define CTOS_HS_READY		0x22	// no data
 #define CTOS_HS_NOTREADY	0x23	// no data
 #define CTOS_HS_KICK		0x24	// CTOS_Kick
 #define CTOS_HS_START		0x25	// no data

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -290,6 +290,11 @@ void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 	else if (len < (2 + deckbuf.mainc + deckbuf.sidec) * (int)sizeof(int32_t))
 		valid = false;
 	if (!valid) {
+		if(duel_count == 0) {
+			STOC_HS_PlayerChange scpc;
+			scpc.status = (dp->type << 4) | PLAYERCHANGE_NOTREADY;
+			NetServer::SendPacketToPlayer(dp, STOC_HS_PLAYER_CHANGE, scpc);
+		}
 		STOC_ErrorMsg scem;
 		scem.msg = ERRMSG_DECKERROR;
 		scem.code = 0;
@@ -298,6 +303,7 @@ void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 	}
 	if(duel_count == 0) {
 		deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec);
+		PlayerReady(dp, true);
 	} else {
 		if(DeckManager::LoadSide(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec)) {
 			ready[dp->type] = true;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -273,6 +273,9 @@ void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 	else if (len < (2 + deckbuf.mainc + deckbuf.sidec) * (int)sizeof(int32_t))
 		valid = false;
 	if (!valid) {
+		STOC_HS_PlayerChange scpc;
+		scpc.status = (dp->type << 4) | PLAYERCHANGE_NOTREADY;
+		NetServer::SendPacketToPlayer(dp, STOC_HS_PLAYER_CHANGE, scpc);
 		STOC_ErrorMsg scem;
 		scem.msg = ERRMSG_DECKERROR;
 		scem.code = 0;
@@ -280,6 +283,7 @@ void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 		return;
 	}
 	deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec);
+	PlayerReady(dp, true);
 }
 void TagDuel::StartDuel(DuelPlayer* dp) {
 	if(dp != host_player)


### PR DESCRIPTION
This packet does nothing, and `CTOS_UPDATE_DECK` can handle the signal of player ready.

In rare cases those packets may be in random order and cause players facing *0 main decks* error

note: old clients can join without problem, but their `CTOS_HS_READY` would be simply ignored