### PR TITLE
fix animation of card moving to extra

### DIFF
--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -35,8 +35,12 @@ void ClientCard::SetCode(unsigned int x) {
 	if((location == LOCATION_HAND) && (code != x)) {
 		code = x;
 		mainGame->dField.MoveCard(this, 5);
-	} else
+	} else {
+		if (x == 0 && code != 0) {
+			chain_code = code;
+		}
 		code = x;
+	}
 }
 void ClientCard::UpdateInfo(unsigned char* buf) {
 	int flag = BufferIO::ReadInt32(buf);
@@ -48,11 +52,7 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 		int pdata = BufferIO::ReadInt32(buf);
 		if (!pdata)
 			ClearData();
-		if((location == LOCATION_HAND) && ((unsigned int)pdata != code)) {
-			code = pdata;
-			mainGame->dField.MoveCard(this, 5);
-		} else
-			code = pdata;
+		SetCode(pdata);
 	}
 	if(flag & QUERY_POSITION) {
 		int pdata = (BufferIO::ReadInt32(buf) >> 24) & 0xff;

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -348,6 +348,7 @@ void Game::DrawCard(ClientCard* pcard) {
 		if(pcard->aniFrame == 0) {
 			pcard->is_moving = false;
 			pcard->is_fading = false;
+			pcard->chain_code = 0;
 		}
 	}
 	matManager.mCard.AmbientColor = 0xffffffff;
@@ -355,7 +356,10 @@ void Game::DrawCard(ClientCard* pcard) {
 	driver->setTransform(irr::video::ETS_WORLD, pcard->mTransform);
 	auto m22 = pcard->mTransform(2, 2);
 	if(m22 > -0.99 || pcard->is_moving) {
-		matManager.mCard.setTexture(0, imageManager.GetTexture(pcard->code));
+		auto code = pcard->code;
+		if (code == 0 && pcard->is_moving)
+			code = pcard->chain_code;
+		matManager.mCard.setTexture(0, imageManager.GetTexture(code));
 		driver->setMaterial(matManager.mCard);
 		driver->drawVertexPrimitiveList(matManager.vCardFront, 4, matManager.iRectangle, 2);
 	}


### PR DESCRIPTION
**Before (10x slower):**
![before](https://github.com/user-attachments/assets/5105ccb3-4fc6-4a2b-bbb5-ccf39c824d17)

**Fixed:**
![after](https://github.com/user-attachments/assets/b86a500d-beb2-4c3e-a45c-69f9f5509717)

**Problem:** 
The `code` of the card, which is moving to extra, is reset to 0 before the animation complete, in 
https://github.com/Fluorohydride/ygopro/blame/ed09b7a36f03a27163429cb324098544d481ecb1/gframe/duelclient.cpp#L2620
(I doubt whether it is necessary to specify `0x40(LOCATION_EXTRA)`)
or in 
https://github.com/Fluorohydride/ygopro/blame/ed09b7a36f03a27163429cb324098544d481ecb1/gframe/single_duel.cpp#L967

**Solution:**
Use a temp code in animation. Assume that if a card had code before but is set to 0 now, it must had been moved.
`chain_code` is used before in `ShowSelectCard`(`conti_selecting`), and we can use this. Maybe we should change the variable name.