### PR TITLE
add ReplayMode::LoadReplay

### DIFF
--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "game.h"
 #include "data_manager.h"
+#include "replay_mode.h"
 #include <event2/thread.h>
 #include <clocale>
 #include <memory>
@@ -11,10 +12,10 @@
 unsigned int enable_log = 0x3;
 bool exit_on_return = false;
 bool open_file = false;
-wchar_t open_file_name[256] = L"";
+wchar_t open_file_name[256]{};
 bool bot_mode = false;
 
-void ClickButton(irr::gui::IGUIElement* btn) {
+static void ClickButton(irr::gui::IGUIElement* btn) {
 	irr::SEvent event;
 	event.EventType = irr::EET_GUI_EVENT;
 	event.GUIEvent.EventType = irr::gui::EGET_BUTTON_CLICKED;
@@ -100,7 +101,7 @@ int main(int argc, char* argv[]) {
 				BufferIO::CopyWideString(wargv[1], open_file_name);
 				exit_on_return = true;
 				ClickButton(ygo::mainGame->btnReplayMode);
-				ClickButton(ygo::mainGame->btnLoadReplay);
+				ygo::ReplayMode::LoadReplay(open_file_name);
 				break;
 			}
 		}
@@ -185,8 +186,8 @@ int main(int argc, char* argv[]) {
 				BufferIO::CopyWideString(wargv[i], open_file_name);
 			}
 			ClickButton(ygo::mainGame->btnReplayMode);
-			if(open_file)
-				ClickButton(ygo::mainGame->btnLoadReplay);
+			if (open_file)
+				ygo::ReplayMode::LoadReplay(open_file_name);
 			break;
 		} else if(!std::wcscmp(wargv[i], L"-s")) { // Single
 			exit_on_return = !keep_on_return;

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -232,36 +232,13 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				break;
 			}
 			case BUTTON_LOAD_REPLAY: {
-				int start_turn = 1;
-				if(open_file) {
-					ReplayMode::cur_replay.OpenReplay(open_file_name);
-					open_file = false;
-				} else {
-					auto selected = mainGame->lstReplayList->getSelected();
-					if(selected == -1)
-						break;
-					wchar_t replay_path[256]{};
-					myswprintf(replay_path, L"./replay/%ls", mainGame->lstReplayList->getListItem(selected));
-					if (!ReplayMode::cur_replay.OpenReplay(replay_path))
-						break;
-					start_turn = std::wcstol(mainGame->ebRepStartTurn->getText(), nullptr, 10);
-				}
-				mainGame->ClearCardInfo();
-				mainGame->wCardImg->setVisible(true);
-				mainGame->wInfos->setVisible(true);
-				mainGame->wReplay->setVisible(true);
-				mainGame->wReplayControl->setVisible(true);
-				mainGame->btnReplayStart->setVisible(false);
-				mainGame->btnReplayPause->setVisible(true);
-				mainGame->btnReplayStep->setVisible(false);
-				mainGame->btnReplayUndo->setVisible(false);
-				mainGame->wPhase->setVisible(true);
-				mainGame->dField.Clear();
-				mainGame->HideElement(mainGame->wReplay);
-				mainGame->device->setEventReceiver(&mainGame->dField);
-				if(start_turn == 1)
-					start_turn = 0;
-				ReplayMode::StartReplay(start_turn);
+				auto selected = mainGame->lstReplayList->getSelected();
+				if (selected < 0)
+					break;
+				wchar_t replay_path[256]{};
+				myswprintf(replay_path, L"./replay/%ls", mainGame->lstReplayList->getListItem(selected));
+				int start_turn = std::wcstol(mainGame->ebRepStartTurn->getText(), nullptr, 10);
+				ReplayMode::LoadReplay(replay_path, start_turn);
 				break;
 			}
 			case BUTTON_DELETE_REPLAY: {

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -20,10 +20,34 @@ int ReplayMode::skip_turn = 0;
 int ReplayMode::current_step = 0;
 int ReplayMode::skip_step = 0;
 
+void ReplayMode::LoadReplay(const wchar_t* replay_path, int start_turn) {
+	if (!ReplayMode::cur_replay.OpenReplay(replay_path)) {
+		if (exit_on_return)
+			mainGame->device->closeDevice();
+		return;
+	}
+	open_file = false;
+	mainGame->ClearCardInfo();
+	mainGame->wCardImg->setVisible(true);
+	mainGame->wInfos->setVisible(true);
+	mainGame->wReplay->setVisible(true);
+	mainGame->wReplayControl->setVisible(true);
+	mainGame->btnReplayStart->setVisible(false);
+	mainGame->btnReplayPause->setVisible(true);
+	mainGame->btnReplayStep->setVisible(false);
+	mainGame->btnReplayUndo->setVisible(false);
+	mainGame->wPhase->setVisible(true);
+	mainGame->dField.Clear();
+	mainGame->HideElement(mainGame->wReplay);
+	mainGame->device->setEventReceiver(&mainGame->dField);
+	if (start_turn == 1)
+		start_turn = 0;
+	ReplayMode::StartReplay(start_turn);
+}
 bool ReplayMode::StartReplay(int skipturn) {
+	if (skipturn < 0)
+		skipturn = 0;
 	skip_turn = skipturn;
-	if(skip_turn < 0)
-		skip_turn = 0;
 	std::thread(ReplayThread).detach();
 	return true;
 }

--- a/gframe/replay_mode.h
+++ b/gframe/replay_mode.h
@@ -25,6 +25,7 @@ private:
 public:
 	static Replay cur_replay;
 	
+	static void LoadReplay(const wchar_t* replay_path, int start_turn = 0);
 	static bool StartReplay(int skipturn);
 	static void StopReplay(bool is_exiting = false);
 	static void SwapField();


### PR DESCRIPTION
# Problem
![圖片](https://github.com/user-attachments/assets/91566b0d-a122-44c1-9cf7-d6935b0a92f1)
```
ygopro -r asdfzxcvbnm.yrp
```
If ygopro is executed in command line with a wrong filename, the error will occur.

# Reason
https://github.com/Fluorohydride/ygopro/blob/f0e9bc883176cc66969d0321c8aa30bb6d783456/gframe/menu_handler.cpp#L237

It does not check the return value of OpenReplay.
Moreover, sending the click event manually is not a good way.

# Solution
BUTTON_LOAD_REPLAY and command line argument will call this function.

@mercury233 
@purerosefallen 