### PR TITLE
remove pics/thumbnail &  use files in pics/ first 

### DIFF
--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -237,10 +237,10 @@ irr::video::ITexture* ImageManager::GetTexture(int code, bool fit) {
 	auto tit = tMap[fit ? 1 : 0].find(code);
 	if(tit == tMap[fit ? 1 : 0].end()) {
 		char file[256];
-		std::snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
+		std::snprintf(file, sizeof file, "pics/%d.jpg", code);
 		irr::video::ITexture* img = GetTextureFromFile(file, width, height);
 		if(img == nullptr) {
-			std::snprintf(file, sizeof file, "pics/%d.jpg", code);
+			std::snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
 			img = GetTextureFromFile(file, width, height);
 		}
 		if(img == nullptr && !mainGame->gameConf.use_image_scale) {
@@ -264,10 +264,10 @@ irr::video::ITexture* ImageManager::GetBigPicture(int code, float zoom) {
 	}
 	irr::video::ITexture* texture;
 	char file[256];
-	std::snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
+	std::snprintf(file, sizeof file, "pics/%d.jpg", code);
 	irr::video::IImage* srcimg = driver->createImageFromFile(file);
 	if(srcimg == nullptr) {
-		std::snprintf(file, sizeof file, "pics/%d.jpg", code);
+		std::snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
 		srcimg = driver->createImageFromFile(file);
 	}
 	if(srcimg == nullptr) {
@@ -390,18 +390,18 @@ irr::video::ITexture* ImageManager::GetTextureField(int code) {
 	auto tit = tFields.find(code);
 	if(tit == tFields.end()) {
 		char file[256];
-		std::snprintf(file, sizeof file, "expansions/pics/field/%d.png", code);
+		std::snprintf(file, sizeof file, "pics/field/%d.png", code);
 		irr::video::ITexture* img = GetTextureFromFile(file, 512 * mainGame->xScale, 512 * mainGame->yScale);
 		if(img == nullptr) {
-			std::snprintf(file, sizeof file, "expansions/pics/field/%d.jpg", code);
-			img = GetTextureFromFile(file, 512 * mainGame->xScale, 512 * mainGame->yScale);
-		}
-		if(img == nullptr) {
-			std::snprintf(file, sizeof file, "pics/field/%d.png", code);
-			img = GetTextureFromFile(file, 512 * mainGame->xScale, 512 * mainGame->yScale);
-		}
-		if(img == nullptr) {
 			std::snprintf(file, sizeof file, "pics/field/%d.jpg", code);
+			img = GetTextureFromFile(file, 512 * mainGame->xScale, 512 * mainGame->yScale);
+		}
+		if(img == nullptr) {
+			std::snprintf(file, sizeof file, "expansions/pics/field/%d.png", code);
+			img = GetTextureFromFile(file, 512 * mainGame->xScale, 512 * mainGame->yScale);
+		}
+		if(img == nullptr) {
+			std::snprintf(file, sizeof file, "expansions/pics/field/%d.jpg", code);
 			img = GetTextureFromFile(file, 512 * mainGame->xScale, 512 * mainGame->yScale);
 			if(img == nullptr) {
 				tFields[code] = nullptr;


### PR DESCRIPTION
# remove pics/thumbnail
As far as I know, almost nobody uses this directory now.
If this is true, ygopro should not spend time searching in this directory first.


# use files in pics/ first 
In Local Windows Debugger, I can see tons of messages in deck editing page:
```
Could not open file of image: expansions/pics/78872731.jpg
Could not open file of image: expansions/pics/84620194.jpg
Could not open file of image: expansions/pics/47879985.jpg
Could not open file of image: expansions/pics/47879985.jpg
Could not open file of image: expansions/pics/2311603.jpg
Could not open file of image: expansions/pics/95265975.jpg
Could not open file of image: expansions/pics/5405695.jpg
Could not open file of image: expansions/pics/2674965.jpg
Could not open file of image: expansions/pics/94119974.jpg
Could not open file of image: expansions/pics/2674965.jpg
Could not open file of image: expansions/pics/78872731.jpg
Could not open file of image: expansions/pics/94119974.jpg
Could not open file of image: expansions/pics/91939608.jpg
Could not open file of image: expansions/pics/47879985.jpg
Could not open file of image: expansions/pics/2311603.jpg
Could not open file of image: expansions/pics/66073051.jpg
Could not open file of image: expansions/pics/81563416.jpg
Could not open file of image: expansions/pics/13723605.jpg
Could not open file of image: expansions/pics/53713014.jpg
Could not open file of image: expansions/pics/94119974.jpg
Could not open file of image: expansions/pics/13723605.jpg
Could not open file of image: expansions/pics/56369281.jpg
Could not open file of image: expansions/pics/13723605.jpg
Could not open file of image: expansions/pics/53713014.jpg
Could not open file of image: expansions/pics/89631139.jpg
Could not open file of image: expansions/pics/95265975.jpg
Could not open file of image: expansions/pics/91939608.jpg
Could not open file of image: expansions/pics/2311603.jpg
Could not open file of image: expansions/pics/66073051.jpg
Could not open file of image: expansions/pics/56369281.jpg
Could not open file of image: expansions/pics/13723605.jpg
Could not open file of image: expansions/pics/81563416.jpg
Could not open file of image: expansions/pics/95265975.jpg
Could not open file of image: expansions/pics/94119974.jpg
Could not open file of image: expansions/pics/78872731.jpg
Could not open file of image: expansions/pics/2674965.jpg
Could not open file of image: expansions/pics/5405695.jpg
Could not open file of image: expansions/pics/89631139.jpg
Could not open file of image: expansions/pics/53713014.jpg
Could not open file of image: expansions/pics/94119974.jpg
Could not open file of image: expansions/pics/13723605.jpg
Could not open file of image: expansions/pics/56369281.jpg
Could not open file of image: expansions/pics/66073051.jpg
Could not open file of image: expansions/pics/2311603.jpg
Could not open file of image: expansions/pics/91939608.jpg
Could not open file of image: expansions/pics/56369281.jpg
Could not open file of image: expansions/pics/47879985.jpg
Could not open file of image: expansions/pics/84620194.jpg
Could not open file of image: expansions/pics/78872731.jpg
Could not open file of image: expansions/pics/95265975.jpg
Could not open file of image: expansions/pics/5405695.jpg
```

In general, the files in pics is 20 times (or more) than the files in expansions.
So ygopro is searching in the wrong directory first for 90%+ of the time.
I think it should search in `pics/` first.

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust
