### PR TITLE
remove: pics/thumbnail, RemoveTexture(int code)

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1375,8 +1375,6 @@ void DeckBuilder::GetHoveredCard() {
 	if(!is_draging && pre_code != hovered_code) {
 		if(hovered_code)
 			mainGame->ShowCardInfo(hovered_code);
-		if(pre_code)
-			imageManager.RemoveTexture(pre_code);
 	}
 }
 void DeckBuilder::StartFilter() {

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1328,8 +1328,6 @@ void Game::LoadConfig() {
 			gameConf.antialias = std::strtol(valbuf, nullptr, 10);
 		} else if(!std::strcmp(strbuf, "use_d3d")) {
 			gameConf.use_d3d = std::strtol(valbuf, nullptr, 10) > 0;
-		} else if(!std::strcmp(strbuf, "use_image_scale")) {
-			gameConf.use_image_scale = std::strtol(valbuf, nullptr, 10) > 0;
 		} else if (!std::strcmp(strbuf, "use_image_scale_multi_thread")) {
 			gameConf.use_image_scale_multi_thread = std::strtol(valbuf, nullptr, 10) > 0;
 		} else if (!std::strcmp(strbuf, "use_image_load_background_thread")) {
@@ -1464,7 +1462,6 @@ void Game::SaveConfig() {
 	std::fprintf(fp, "#config file\n#nickname & gamename should be less than 20 characters\n");
 	char linebuf[CONFIG_LINE_SIZE];
 	std::fprintf(fp, "use_d3d = %d\n", gameConf.use_d3d ? 1 : 0);
-	std::fprintf(fp, "use_image_scale = %d\n", gameConf.use_image_scale ? 1 : 0);
 	std::fprintf(fp, "use_image_scale_multi_thread = %d\n", gameConf.use_image_scale_multi_thread ? 1 : 0);
 	std::fprintf(fp, "use_image_load_background_thread = %d\n", gameConf.use_image_load_background_thread ? 1 : 0);
 	std::fprintf(fp, "antialias = %d\n", gameConf.antialias);

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -48,7 +48,6 @@ bool IsExtension(const char* filename, const char(&extension)[N]) {
 
 struct Config {
 	bool use_d3d{ false };
-	bool use_image_scale{ true };
 	bool use_image_scale_multi_thread{ true };
 #ifdef _OPENMP
 	bool use_image_load_background_thread{ false };

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -80,20 +80,6 @@ void ImageManager::ClearTexture() {
 	tThumbLoadingMutex.unlock();
 	tFields.clear();
 }
-void ImageManager::RemoveTexture(int code) {
-	auto tit = tMap[0].find(code);
-	if(tit != tMap[0].end()) {
-		if(tit->second)
-			driver->removeTexture(tit->second);
-		tMap[0].erase(tit);
-	}
-	tit = tMap[1].find(code);
-	if(tit != tMap[1].end()) {
-		if(tit->second)
-			driver->removeTexture(tit->second);
-		tMap[1].erase(tit);
-	}
-}
 void ImageManager::ResizeTexture() {
 	irr::s32 imgWidth = CARD_IMG_WIDTH * mainGame->xScale;
 	irr::s32 imgHeight = CARD_IMG_HEIGHT * mainGame->yScale;

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -203,24 +203,20 @@ void imageScaleNNAA(irr::video::IImage *src, irr::video::IImage *dest) {
 } // end of parallel region
 }
 irr::video::ITexture* ImageManager::GetTextureFromFile(const char* file, irr::s32 width, irr::s32 height) {
-	if(mainGame->gameConf.use_image_scale) {
-		irr::video::ITexture* texture;
-		irr::video::IImage* srcimg = driver->createImageFromFile(file);
-		if(srcimg == nullptr)
-			return nullptr;
-		if(srcimg->getDimension() == irr::core::dimension2d<irr::u32>(width, height)) {
-			texture = driver->addTexture(file, srcimg);
-		} else {
-			irr::video::IImage *destimg = driver->createImage(srcimg->getColorFormat(), irr::core::dimension2d<irr::u32>(width, height));
-			imageScaleNNAA(srcimg, destimg);
-			texture = driver->addTexture(file, destimg);
-			destimg->drop();
-		}
-		srcimg->drop();
-		return texture;
+	irr::video::ITexture* texture;
+	irr::video::IImage* srcimg = driver->createImageFromFile(file);
+	if(srcimg == nullptr)
+		return nullptr;
+	if(srcimg->getDimension() == irr::core::dimension2d<irr::u32>(width, height)) {
+		texture = driver->addTexture(file, srcimg);
 	} else {
-		return driver->getTexture(file);
+		irr::video::IImage *destimg = driver->createImage(srcimg->getColorFormat(), irr::core::dimension2d<irr::u32>(width, height));
+		imageScaleNNAA(srcimg, destimg);
+		texture = driver->addTexture(file, destimg);
+		destimg->drop();
 	}
+	srcimg->drop();
+	return texture;	
 }
 irr::video::ITexture* ImageManager::GetTexture(int code, bool fit) {
 	if(code == 0)
@@ -243,17 +239,13 @@ irr::video::ITexture* ImageManager::GetTexture(int code, bool fit) {
 			std::snprintf(file, sizeof file, "pics/%d.jpg", code);
 			img = GetTextureFromFile(file, width, height);
 		}
-		if(img == nullptr && !mainGame->gameConf.use_image_scale) {
-			tMap[fit ? 1 : 0][code] = nullptr;
-			return GetTextureThumb(code);
-		}
 		tMap[fit ? 1 : 0][code] = img;
 		return (img == nullptr) ? (fit ? tUnknownFit : tUnknown) : img;
 	}
-	if(tit->second)
+	if (tit->second)
 		return tit->second;
 	else
-		return mainGame->gameConf.use_image_scale ? (fit ? tUnknownFit : tUnknown) : GetTextureThumb(code);
+		return fit ? tUnknownFit : tUnknown;
 }
 irr::video::ITexture* ImageManager::GetBigPicture(int code, float zoom) {
 	if(code == 0)
@@ -293,17 +285,9 @@ int ImageManager::LoadThumbThread() {
 		imageManager.tThumbLoadingCodes.pop();
 		imageManager.tThumbLoadingMutex.unlock();
 		char file[256];
-		std::snprintf(file, sizeof file, "expansions/pics/thumbnail/%d.jpg", code);
+		std::snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
 		irr::video::IImage* img = imageManager.driver->createImageFromFile(file);
 		if(img == nullptr) {
-			std::snprintf(file, sizeof file, "pics/thumbnail/%d.jpg", code);
-			img = imageManager.driver->createImageFromFile(file);
-		}
-		if(img == nullptr && mainGame->gameConf.use_image_scale) {
-			std::snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
-			img = imageManager.driver->createImageFromFile(file);
-		}
-		if(img == nullptr && mainGame->gameConf.use_image_scale) {
 			std::snprintf(file, sizeof file, "pics/%d.jpg", code);
 			img = imageManager.driver->createImageFromFile(file);
 		}
@@ -347,21 +331,13 @@ irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 	auto tit = tThumb.find(code);
 	if(tit == tThumb.end() && !mainGame->gameConf.use_image_load_background_thread) {
 		char file[256];
-		std::snprintf(file, sizeof file, "expansions/pics/thumbnail/%d.jpg", code);
+		std::snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
 		int width = CARD_THUMB_WIDTH * mainGame->xScale;
 		int height = CARD_THUMB_HEIGHT * mainGame->yScale;
 		irr::video::ITexture* img = GetTextureFromFile(file, width, height);
 		if(img == NULL) {
-			std::snprintf(file, sizeof file, "pics/thumbnail/%d.jpg", code);
+			std::snprintf(file, sizeof file, "pics/%d.jpg", code);
 			img = GetTextureFromFile(file, width, height);
-		}
-		if(img == NULL && mainGame->gameConf.use_image_scale) {
-			std::snprintf(file, sizeof file, "expansions/pics/%d.jpg", code);
-			img = GetTextureFromFile(file, width, height);
-			if(img == NULL) {
-				std::snprintf(file, sizeof file, "pics/%d.jpg", code);
-				img = GetTextureFromFile(file, width, height);
-			}
 		}
 		tThumb[code] = img;
 		return (img == NULL) ? tUnknownThumb : img;
@@ -372,7 +348,7 @@ irr::video::ITexture* ImageManager::GetTextureThumb(int code) {
 		if(lit != tThumbLoading.end()) {
 			if(lit->second != nullptr) {
 				char file[256];
-				std::snprintf(file, sizeof file, "pics/thumbnail/%d.jpg", code);
+				std::snprintf(file, sizeof file, "pics/%d.jpg", code);
 				irr::video::ITexture* texture = driver->addTexture(file, lit->second); // textures must be added in the main thread due to OpenGL
 				lit->second->drop();
 				tThumb[code] = texture;

--- a/gframe/image_manager.h
+++ b/gframe/image_manager.h
@@ -14,7 +14,6 @@ public:
 	bool Initial();
 	void SetDevice(irr::IrrlichtDevice* dev);
 	void ClearTexture();
-	void RemoveTexture(int code);
 	void ResizeTexture();
 	irr::video::ITexture* GetTextureFromFile(const char* file, irr::s32 width, irr::s32 height);
 	irr::video::ITexture* GetTexture(int code, bool fit = false);


### PR DESCRIPTION
# remove pics/thumbnail
As far as I know, almost nobody uses this directory now.
If this is true, ygopro should not spend time searching in this directory first.

# remove RemoveTexture(int code)
It is only called in `DeckBuilder::GetHoveredCard()`.
For some reason. GetHoveredCard will delete the textures of hovered cards.

If one hover between 2 cards, the textures of these cards will be added and removed and added and removed.
It seems to be unnecessary.

If the textures are not constantly added and removed, trying a wrong directory first might not be a problem

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust

