### PR TITLE
Improve error handling in DataManager::Error

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -167,6 +167,8 @@ void DataManager::ReadStringConfLine(const char* linebuf) {
 bool DataManager::Error(sqlite3* pDB, sqlite3_stmt* pStmt) {
 	if (const char* msg = sqlite3_errmsg(pDB))
 		std::snprintf(errmsg, sizeof errmsg, "%s", msg);
+	else
+		errmsg[0] = '\0';
 	sqlite3_finalize(pStmt);
 	return false;
 }


### PR DESCRIPTION
https://www.sqlite.org/c3ref/finalize.html
Invoking sqlite3_finalize() on a NULL pointer is a harmless no-op.

https://www.sqlite.org/c3ref/errcode.html
The sqlite3_errmsg() and sqlite3_errmsg16() return English-language text that describes the error, as either UTF-8 or UTF-16 respectively, or NULL if no error message is available. (See how SQLite handles [invalid UTF](https://www.sqlite.org/invalidutf.html) for exceptions to this rule.) 