### PR TITLE
move MAINC_MAX, SIDEC_MAX to deck_manager.h

### DIFF
--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -13,6 +13,9 @@ namespace ygo {
 	constexpr int SIDE_MAX_SIZE = 15;
 	constexpr int PACK_MAX_SIZE = 1000;
 
+	constexpr int MAINC_MAX = 250;	// the limit of card_state
+	constexpr int SIDEC_MAX = MAINC_MAX;
+
 struct LFList {
 	unsigned int hash{};
 	std::wstring listName;

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -9,14 +9,13 @@
 #include <event2/buffer.h>
 #include <event2/thread.h>
 #include <type_traits>
+#include "deck_manager.h"
 
 #define check_trivially_copyable(T) static_assert(std::is_trivially_copyable<T>::value == true && std::is_standard_layout<T>::value == true, "not trivially copyable")
 
 namespace ygo {
 	constexpr int SIZE_NETWORK_BUFFER = 0x20000;
 	constexpr int MAX_DATA_SIZE = UINT16_MAX - 1;
-	constexpr int MAINC_MAX = 250;	// the limit of card_state
-	constexpr int SIDEC_MAX = MAINC_MAX;
 
 struct HostInfo {
 	uint32_t lflist{};

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -1,6 +1,5 @@
 #include "replay.h"
 #include "myfilesystem.h"
-#include "network.h"
 #include "lzma/LzmaLib.h"
 
 namespace ygo {


### PR DESCRIPTION
The order of winsock2.h and Windows.h can be a problem.
Now class Replay does not include `network.h`.

Reference
https://stackoverflow.com/questions/1372480/c-redefinition-header-files-winsock2-h