### PR TITLE
add LUA_USE_LONGJMP

### DIFF
--- a/premake/lua/premake5.lua
+++ b/premake/lua/premake5.lua
@@ -5,6 +5,8 @@ project "lua"
     files { "src/*.c", "src/*.h" }
     removefiles { "src/lua.c", "src/luac.c", "src/linit.c", "src/onelua.c" }
 
+    defines { "LUA_USE_LONGJMP" }
+
     filter "configurations:Debug"
         defines { "LUA_USE_APICHECK" }
 


### PR DESCRIPTION
ygopro builds Lua in C++ but without a proper catch for C++ exceptions. This sometimes crashes YGOPro, especially in dynamic linking situations.