### PR TITLE
 set bufferevent* to nullptr after freed 

### DIFF
--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -105,8 +105,9 @@ void NetServer::BroadcastEvent(evutil_socket_t fd, short events, void* arg) {
 }
 void NetServer::ServerAccept(evconnlistener* listener, evutil_socket_t fd, sockaddr* address, int socklen, void* ctx) {
 	bufferevent* bev = bufferevent_socket_new(net_evbase, fd, BEV_OPT_CLOSE_ON_FREE);
-	if (!bev)
+	if (!bev) {
 		return;
+	}
 	DuelPlayer dp;
 	dp.name[0] = 0;
 	dp.type = 0xff;
@@ -156,7 +157,7 @@ int NetServer::ServerThread() {
 	for (auto bit = users.begin(); bit != users.end();) {
 		bufferevent_disable(bit->first, EV_READ | EV_WRITE);
 		bufferevent_free(bit->first);
-		bit->second->bev = nullptr;
+		bit->second.bev = nullptr;
 		bit = users.erase(bit);
 	}
 	evconnlistener_free(listener);

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -123,7 +123,7 @@ void NetServer::ServerAcceptError(evconnlistener* listener, void* ctx) {
 * proto: 1 byte
 * [data]: (packet_len - 1) bytes
 */
-void NetServer::ServerEchoRead(bufferevent *bev, void *ctx) {
+void NetServer::ServerEchoRead(bufferevent* bev, void* ctx) {
 	evbuffer* input = bufferevent_get_input(bev);
 	int len = evbuffer_get_length(input);
 	if (len < 2)


### PR DESCRIPTION
https://libevent.org/doc/bufferevent_8h.html#a8baa699f526f237c0d33f618f073c1cc
void bufferevent_free  (struct bufferevent *   bufev)
Deallocate the storage associated with a bufferevent structure. 

free以後
DuelPlayer.bev變成指向無效位置的指標
應該改成nullptr不再使用
並且立即從users刪除

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust