### PR TITLE
drop fopen support for old Windows SDK

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -72,20 +72,7 @@ inline FILE* mywfopen(const wchar_t* filename, const char* mode) {
 	return fp;
 }
 
-#if !defined(_WIN32)
 #define myfopen std::fopen
-#elif defined(WDK_NTDDI_VERSION) && (WDK_NTDDI_VERSION >= 0x0A000005) // Redstone 4, Version 1803, Build 17134.
-#define FOPEN_WINDOWS_SUPPORT_UTF8
-#define myfopen std::fopen
-#else
-inline FILE* myfopen(const char* filename, const char* mode) {
-	wchar_t wfilename[256]{};
-	BufferIO::DecodeUTF8(filename, wfilename);
-	wchar_t wmode[20]{};
-	BufferIO::CopyCharArray(mode, wmode);
-	return _wfopen(wfilename, wmode);
-}
-#endif
 
 #include <irrlicht.h>
 

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -8,6 +8,10 @@
 #import <CoreFoundation/CoreFoundation.h>
 #endif
 
+#if defined(_WIN32) && (!defined(WDK_NTDDI_VERSION) || (WDK_NTDDI_VERSION < 0x0A000005)) // Redstone 4, Version 1803, Build 17134.
+#error "This program requires the Windows 10 SDK version 1803 or above to compile on Windows. Otherwise, non-ASCII characters will not be displayed or processed correctly."
+#endif
+
 unsigned int enable_log = 0x3;
 bool exit_on_return = false;
 bool open_file = false;
@@ -23,7 +27,7 @@ void ClickButton(irr::gui::IGUIElement* btn) {
 }
 
 int main(int argc, char* argv[]) {
-#if defined(FOPEN_WINDOWS_SUPPORT_UTF8)
+#if defined(_WIN32)
 	std::setlocale(LC_CTYPE, ".UTF-8");
 #elif defined(__APPLE__)
 	std::setlocale(LC_CTYPE, "UTF-8");

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
 	std::setlocale(LC_CTYPE, ".UTF-8");
 #elif defined(__APPLE__)
 	std::setlocale(LC_CTYPE, "UTF-8");
-#elif !defined(_WIN32)
+#else
 	std::setlocale(LC_CTYPE, "");
 #endif
 #ifdef __APPLE__


### PR DESCRIPTION
- drop fopen support for old Windows SDK, no longer support SDK 7.1, which is required for the Windows XP build toolset