### PR TITLE
change card_data::level to 2 bytes

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -38,7 +38,7 @@ bool DataManager::ReadDB(sqlite3* pDB) {
 		else
 			cd.link_marker = 0;
 		uint32_t level = static_cast<uint32_t>(sqlite3_column_int64(pStmt, 7));
-		cd.level = level & 0xff;
+		cd.level = level & 0xffff;
 		cd.lscale = (level >> 24) & 0xff;
 		cd.rscale = (level >> 16) & 0xff;
 		cd.race = static_cast<decltype(cd.race)>(sqlite3_column_int64(pStmt, 8));


### PR DESCRIPTION
# The disadvantage of packing
Packing multiple unrelated properties into the same column is considered a poor practice in database design.

- Violates database normalization
Normalization is a design principle that separates data into logical tables and columns to reduce redundancy and improve clarity.
Packing multiple attributes into one column breaks this rule, and it makes the schema less readable, harder to understand, and more error-prone.

- Harder to query
Queries are harder to write and maintain.
You must remember which bit means what.
Even simple queries become more complex, requiring constant use of bitwise operations.

- Poor indexing support
SQLite indexes individual columns, but not individual bits inside an integer.
If you pack 4 values  into one INTEGER column, it cannot index each flag efficiently.
Queries on individual bits won’t benefit from indexes, resulting in full table scans.
It can hurt performance, especially when the table grows.

- Difficult to maintain
With individual columns, adding or changing values is straightforward.
But when values are packed into a single field, even basic read or write operations require bitwise manipulation.
For example: 
What is the level of a card with a `level` column of 50528266?
If the level needs to be changed to 11, what is the new value of `level`?

- Minimal space savings in SQLite
SQLite is already very efficient at storing integers.
It uses variable-length integers internally, which take only as many bytes as needed.
The space saving from packing bits is negligible.


# What can ygopro do now?
It is too late to change the behavior of packing the pendulum scale into `level` column.
But ygopro can do something to prevent it from becoming worse.

What this PR tries to do:
- The cdb file remains unchanged.
- If new card properties are introduced in the future, they should be stored in new columns.
- No additional values will be packed into the existing `level` column.
- The lower 16 bits of the level column are now reserved exclusively for storing the level/rank/link value.



----

level column in cdb (from most significant bit)
Before:
first byte: lscale
second byte: rscale
third byte: (not used)
fourth byte: level

After:
first byte: lscale
second byte: rscale
3-4 byte: level


@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust