### PR TITLE
fix `prev_deck` on `BUTTON_SAVE_DECK_AS`

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -214,6 +214,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					mainGame->cbDBDecks->addItem(dname);
 					mainGame->cbDBDecks->setSelected(mainGame->cbDBDecks->getItemCount() - 1);
 				}
+				prev_deck = mainGame->cbDBDecks->getSelected();
 				int catesel = mainGame->cbDBCategory->getSelected();
 				wchar_t catepath[256];
 				DeckManager::GetCategoryPath(catepath, catesel, mainGame->cbDBCategory->getText());


### PR DESCRIPTION
To reproduce:
- enter deck edit
- disable `ignore_deck_changes`
- save the current deck D1 as a new name D2
- do some changes to D2, don't save
- switch to another deck with `cbDBDecks`
- answer no to the confirm dialog
- the selected deck should changed back to D2, but it was changed to D1 before this fix
