### PR TITLE
add SQLITE_TRUSTED_SCHEMA=0

### DIFF
--- a/premake/sqlite3/premake5.lua
+++ b/premake/sqlite3/premake5.lua
@@ -10,4 +10,5 @@ project "sqlite3"
         "SQLITE_OMIT_DEPRECATED",
         "SQLITE_OMIT_PROGRESS_CALLBACK",
         "SQLITE_OMIT_SHARED_CACHE",
+        "SQLITE_TRUSTED_SCHEMA=0",
     }


### PR DESCRIPTION
https://www.sqlite.org/security.html
If the application includes any [custom SQL functions](https://www.sqlite.org/appfunc.html) or [custom virtual tables](https://www.sqlite.org/vtab.html#customvtab) that have side effects or that might leak privileged information, then the application should use one or more of the techniques below to prevent a maliciously crafted database schema from surreptitiously running those SQL functions and/or virtual tables for nefarious purposes:
...
C. Compile SQLite using the [-DSQLITE_TRUSTED_SCHEMA=0](https://www.sqlite.org/compile.html#trusted_schema) compile-time option.

https://www.sqlite.org/compile.html#trusted_schema
SQLITE_TRUSTED_SCHEMA=<0 or 1>
This macro determines the default value for the [SQLITE_DBCONFIG_TRUSTED_SCHEMA](https://www.sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigtrustedschema) and [PRAGMA trusted_schema](https://www.sqlite.org/pragma.html#pragma_trusted_schema) setting. If no alternative is specified, the trusted-schema setting defaults to ON (a value of 1) for legacy compatibility. However, for best security, systems that implement [application-defined SQL functions](https://www.sqlite.org/appfunc.html) and/or [virtual tables](https://www.sqlite.org/vtab.html) should consider changing the default to OFF.

https://www.sqlite.org/pragma.html#pragma_trusted_schema
PRAGMA trusted_schema;
PRAGMA trusted_schema = boolean;
The trusted_schema setting is a per-connection boolean that determines whether or not SQL functions and virtual tables that have not been security audited are allowed to be run by views, triggers, or in expressions of the schema such as [CHECK constraints](https://www.sqlite.org/lang_createtable.html#ckconst), [DEFAULT clauses](https://www.sqlite.org/lang_createtable.html#dfltval), [generated columns](https://www.sqlite.org/gencol.html), [expression indexes](https://www.sqlite.org/expridx.html), and/or [partial indexes](https://www.sqlite.org/partialindex.html). This setting can also be controlled using the [sqlite3_db_config](https://www.sqlite.org/c3ref/db_config.html)(db,[SQLITE_DBCONFIG_TRUSTED_SCHEMA](https://www.sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigtrustedschema),...) C-language interface.

In order to maintain backwards compatibility, this setting is ON by default. There are advantages to turning it off, and most applications will be unaffected if it is turned off. For that reason, all applications are encouraged to switch this setting off on every database connection as soon as that connection is opened.

The [-DSQLITE_TRUSTED_SCHEMA=0](https://www.sqlite.org/compile.html#trusted_schema) compile-time option will cause this setting to default to OFF.

----
-DSQLITE_TRUSTED_SCHEMA=0
使`PRAGMA trusted_schema`的預設值變成0

PRAGMA trusted_schema
由於向下相容的理由，預設值為1
開啟：允許在schema, trigger, view執行自訂函數
也就是只要適當修改資料庫schema
有可能在程式非預期的狀態執行自訂函數

官方文件的範例：
https://www.sqlite.org/appfunc.html#security_implications
```c
// some powerful function
void systemFunc(
  sqlite3_context *context,
  int argc,
  sqlite3_value **argv
){
const char *zCmd = (const char*)sqlite3_value_text(argv[0]);
  if( zCmd!=0 ){
    int rc = system(zCmd);
    sqlite3_result_int(context, rc);
  }
}
```
一般來說即使是功能如此強大的函數
只要不呼叫也不會產生問題

但是在`PRAGMA trusted_schema=ON`的狀態
只要用以下指令修改table名稱並加入view
就能讓程式在無自覺的狀態呼叫自訂函數
```sql
ALTER TABLE datas RENAME TO datas_real;
CREATE VIEW datas AS SELECT * FROM datas_real WHERE system('rm -rf *') IS NOT NULL;
```

程式啟動時查詢datas表格
```sql
SELECT * FROM datas;
```
由於現在的datas是自訂的view
程式就會在無自覺的狀態呼叫`system('rm -rf *')`

官方文件明確提到
> In order to maintain backwards compatibility, this setting is ON by default. There are advantages to turning it off, and most applications will be unaffected if it is turned off. For that reason, all applications are encouraged to switch this setting off on every database connection as soon as that connection is opened. 
如果沒有特殊理由
關閉這個選項可以避免以後可能發生的問題

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust
