### PR TITLE
fix face-down MSG_SPSUMMONING

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2912,12 +2912,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			else
 				soundManager.PlaySoundEffect(SOUND_SPECIAL_SUMMON);
 			myswprintf(event_string, dataManager.GetSysString(1605), dataManager.GetName(code));
-			mainGame->showcardcode = code;
-			mainGame->showcarddif = 1;
-			mainGame->showcard = 5;
-			mainGame->WaitFrameSignal(30);
-			mainGame->showcard = 0;
-			mainGame->WaitFrameSignal(11);
+			if(code) {
+				mainGame->showcardcode = code;
+				mainGame->showcarddif = 1;
+				mainGame->showcard = 5;
+				mainGame->WaitFrameSignal(30);
+				mainGame->showcard = 0;
+				mainGame->WaitFrameSignal(11);
+			}
 		}
 		return true;
 	}

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1036,9 +1036,16 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SPSUMMONING: {
+			pbufw = pbuf;
+			int cc = pbuf[4];
+			/*int cl = pbuf[5];*/
+			/*int cs = pbuf[6];*/
+			int cp = pbuf[7];
 			pbuf += 8;
-			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
-			NetServer::ReSendToPlayer(players[1]);
+			NetServer::SendBufferToPlayer(players[cc], STOC_GAME_MSG, offset, pbuf - offset);
+			if (cp & POS_FACEDOWN)
+				BufferIO::Write<int32_t>(pbufw, 0);
+			NetServer::SendBufferToPlayer(players[1 - cc], STOC_GAME_MSG, offset, pbuf - offset);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 				NetServer::ReSendToPlayer(*oit);
 			break;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1048,12 +1048,14 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			/*int cs = pbuf[6];*/
 			int cp = pbuf[7];
 			pbuf += 8;
-			NetServer::SendBufferToPlayer(cur_player[cc], STOC_GAME_MSG, offset, pbuf - offset);
+			auto pid = (cc == 0) ? 0 : 2;
+			NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, offset, pbuf - offset);
+			NetServer::ReSendToPlayer(players[pid + 1]);
 			if (cp & POS_FACEDOWN)
 				BufferIO::Write<int32_t>(pbufw, 0);
-			for (int i = 0; i < 4; ++i)
-				if (players[i] != cur_player[cc])
-					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
+			pid = 2 - pid;
+			NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, offset, pbuf - offset);
+			NetServer::ReSendToPlayer(players[pid + 1]);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 				NetServer::ReSendToPlayer(*oit);
 			break;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1042,11 +1042,18 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			break;
 		}
 		case MSG_SPSUMMONING: {
+			pbufw = pbuf;
+			int cc = pbuf[4];
+			/*int cl = pbuf[5];*/
+			/*int cs = pbuf[6];*/
+			int cp = pbuf[7];
 			pbuf += 8;
-			NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
-			NetServer::ReSendToPlayer(players[1]);
-			NetServer::ReSendToPlayer(players[2]);
-			NetServer::ReSendToPlayer(players[3]);
+			NetServer::SendBufferToPlayer(cur_player[cc], STOC_GAME_MSG, offset, pbuf - offset);
+			if (cp & POS_FACEDOWN)
+				BufferIO::Write<int32_t>(pbufw, 0);
+			for (int i = 0; i < 4; ++i)
+				if (players[i] != cur_player[cc])
+					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 				NetServer::ReSendToPlayer(*oit);
 			break;


### PR DESCRIPTION
**Problem:**

> サブテラーマリスの妖魔

> ②：自分メインフェイズに発動できる。デッキからリバースモンスター１体を墓地へ送り、手札からモンスター１体をこのカードのリンク先に裏側守備表示で特殊召喚する。

> ■処理時に『デッキからリバースモンスター１体を墓地へ送り』の処理を行い、墓地へ送ることに成功した場合、『手札からモンスター１体をこのカードのリンク先に裏側守備表示で特殊召喚する』処理を行います。**（特殊召喚するモンスターは相手に見せません。）**
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13370&request_locale=ja

The opponent should not be able to see which monster is Special Summoned by this effect.

However, in the current YGOPro implementation, `PROCESSOR_SPSUMMON` (`PROCESSOR_SPSUMMON_STEP`) always sends `MSG_SPSUMMONING`, which contains the code of the summoned card.

https://github.com/Fluorohydride/ygopro-core/blob/fd48b60783b389a601d76de9f880a1fc6fbd395f/operations.cpp#L3284-L3286

**Solution:**

If the summoned card is face-down, erase the code before sending the message to other players, just as YGOPro already does for `MSG_MOVE`.

Some effects require confirmation of the summoned card (e.g., *Apprentice Magician*). In such cases, the confirmation should be handled in the script:
https://github.com/Fluorohydride/ygopro-scripts/blob/336b4afbca4d12b220e527aa0ea43bb86dc5c4c5/c9156135.lua#L58-L59
