### PR TITLE
read freetype patch headers from premake directly

### DIFF
--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -30,7 +30,7 @@ project "YGOPro"
     end
 
     if BUILD_FREETYPE then
-        includedirs { "../freetype/custom", "../freetype/include" }
+        includedirs { FirstPossibleDir("../premake/freetype/custom", "../freetype/custom"), "../freetype/include" }
     else
         includedirs { FREETYPE_INCLUDE_DIR }
         libdirs { FREETYPE_LIB_DIR }

--- a/premake/freetype/premake5.lua
+++ b/premake/freetype/premake5.lua
@@ -1,7 +1,7 @@
 project "freetype"
     kind "StaticLib"
 
-    includedirs { "custom", "include" }
+    includedirs { FirstPossibleDir("../premake/freetype/custom", "custom"), "include" }
     defines { "FT2_BUILD_LIBRARY" }
 
     files {

--- a/premake5.lua
+++ b/premake5.lua
@@ -98,6 +98,15 @@ function FindHeaderWithSubDir(header, subdir)
     return result
 end
 
+function FirstPossibleDir(...)
+    for _, dir in ipairs({...}) do
+        if os.isdir(dir) then
+            return dir
+        end
+    end
+    return nil
+end
+
 if GetParam("build-lua") then
     BUILD_LUA = true
 elseif GetParam("no-build-lua") then


### PR DESCRIPTION
<img width="602" height="530" alt="image" src="https://github.com/user-attachments/assets/1603703d-59c4-49bd-be0a-f82c0f11702f" />

with current code, all `gframe` and `freetype` code builds every time due to freetype custom headers copied in from `premake` dir. This shouldn't be happening because the compiler (at least gcc/g++) thinks the header changed, rebuilding everything.

Now it reads from `premake` dir directly to prevent this.