### PR TITLE
use cp -pr to copy out premake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -437,8 +437,8 @@ jobs:
 
     - name: Copy premake files
       run: |
-        cp -r premake/* .
-        cp -r resource/* .
+        cp -pr premake/* .
+        cp -pr resource/* .
 
     - name: Use premake to generate make files (apt packages)
       if: matrix.static-link != true
@@ -664,8 +664,8 @@ jobs:
 
     - name: Copy premake files
       run: |
-        cp -r premake/* .
-        cp -r resource/* .
+        cp -pr premake/* .
+        cp -pr resource/* .
 
     - name: Use premake to generate make files (Homebrew packages)
       if: matrix.static-link != true


### PR DESCRIPTION
yet another alt to https://github.com/Fluorohydride/ygopro/pull/2898

but stupid enough because most CIs, as well as dev envs for everyone, should be replaced