### PR TITLE
add datas2 table to cdb & add setcode1-3

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -15,53 +15,96 @@ DataManager::DataManager() : _datas(32768), _strings(32768) {
 		{55088578u, {0x8f, 0x54, 0x59, 0x82, 0x13a}},
 	};
 }
+static bool table_exists(sqlite3* db, const char* name) {
+	static const char* q =
+		"SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1";
+	sqlite3_stmt* s = NULL;
+	bool ok = false;
+	if (sqlite3_prepare_v2(db, q, -1, &s, NULL) == SQLITE_OK) {
+		sqlite3_bind_text(s, 1, name, -1, SQLITE_STATIC);
+		ok = (sqlite3_step(s) == SQLITE_ROW);
+	}
+	sqlite3_finalize(s);
+	return ok;
+}
 bool DataManager::ReadDB(sqlite3* pDB) {
 	sqlite3_stmt* pStmt = nullptr;
-	const char* sql = "select * from datas,texts where datas.id=texts.id";
+	auto has_datas2 = table_exists(pDB, "datas2");
+	const char* sql = has_datas2
+		? "select * from datas INNER JOIN texts ON datas.id=texts.id LEFT JOIN datas2 ON datas.id=datas2.id"
+		: "select * from datas,texts where datas.id=texts.id";
 	if (sqlite3_prepare_v2(pDB, sql, -1, &pStmt, nullptr) != SQLITE_OK)
 		return Error(pDB, pStmt);
 	wchar_t strBuffer[4096];
 	for (int step = sqlite3_step(pStmt); step != SQLITE_DONE; step = sqlite3_step(pStmt)) {
 		if (step != SQLITE_ROW)
 			return Error(pDB, pStmt);
-		uint32_t code = static_cast<uint32_t>(sqlite3_column_int64(pStmt, 0));
+		auto col_count = sqlite3_column_count(pStmt);
+		uint16_t pos = 0;
+		auto try_read_row = [&](auto getter, auto& value) -> bool {
+			if (pos < col_count) {
+				value = static_cast<std::remove_reference_t<decltype(value)>>(
+					getter(pStmt, pos++)
+				);
+				return true;
+			}
+			return false;
+		};
+		uint32_t code = static_cast<uint32_t>(sqlite3_column_int64(pStmt, pos++));
 		auto& cd = _datas[code];
 		cd.code = code;
-		cd.ot = sqlite3_column_int(pStmt, 1);
-		cd.alias = sqlite3_column_int(pStmt, 2);
-		uint64_t setcode = static_cast<uint64_t>(sqlite3_column_int64(pStmt, 3));
-		write_setcode(cd.setcode, setcode);
-		cd.type = static_cast<decltype(cd.type)>(sqlite3_column_int64(pStmt, 4));
-		cd.attack = sqlite3_column_int(pStmt, 5);
-		cd.defense = sqlite3_column_int(pStmt, 6);
+		cd.ot = sqlite3_column_int(pStmt, pos++);
+		cd.alias = sqlite3_column_int(pStmt, pos++);
+		uint64_t setcode = static_cast<uint64_t>(sqlite3_column_int64(pStmt, pos++));
+		auto setcode_pos = write_setcode(cd.setcode, setcode);
+		cd.type = static_cast<decltype(cd.type)>(sqlite3_column_int64(pStmt, pos++));
+		cd.attack = sqlite3_column_int(pStmt, pos++);
+		cd.defense = sqlite3_column_int(pStmt, pos++);
 		if (cd.type & TYPE_LINK) {
 			cd.link_marker = cd.defense;
 			cd.defense = 0;
 		}
 		else
 			cd.link_marker = 0;
-		uint32_t level = static_cast<uint32_t>(sqlite3_column_int64(pStmt, 7));
+		uint32_t level = static_cast<uint32_t>(sqlite3_column_int64(pStmt, pos++));
 		cd.level = level & 0xff;
 		cd.lscale = (level >> 24) & 0xff;
 		cd.rscale = (level >> 16) & 0xff;
-		cd.race = static_cast<decltype(cd.race)>(sqlite3_column_int64(pStmt, 8));
-		cd.attribute = static_cast<decltype(cd.attribute)>(sqlite3_column_int64(pStmt, 9));
-		cd.category = static_cast<decltype(cd.category)>(sqlite3_column_int64(pStmt, 10));
+		cd.race = static_cast<decltype(cd.race)>(sqlite3_column_int64(pStmt, pos++));
+		cd.attribute = static_cast<decltype(cd.attribute)>(sqlite3_column_int64(pStmt, pos++));
+		cd.category = static_cast<decltype(cd.category)>(sqlite3_column_int64(pStmt, pos++));
 		auto& cs = _strings[code];
-		if (const char* text = (const char*)sqlite3_column_text(pStmt, 12)) {
+		// id appears here again, so skip this field
+		++pos;
+		if (const char* text = (const char*)sqlite3_column_text(pStmt, pos++)) {
 			BufferIO::DecodeUTF8(text, strBuffer);
 			cs.name = strBuffer;
 		}
-		if (const char* text = (const char*)sqlite3_column_text(pStmt, 13)) {
+		if (const char* text = (const char*)sqlite3_column_text(pStmt, pos++)) {
 			BufferIO::DecodeUTF8(text, strBuffer);
 			cs.text = strBuffer;
 		}
 		constexpr int desc_count = sizeof cs.desc / sizeof cs.desc[0];
 		for (int i = 0; i < desc_count; ++i) {
-			if (const char* text = (const char*)sqlite3_column_text(pStmt, i + 14)) {
+			if (const char* text = (const char*)sqlite3_column_text(pStmt, pos++)) {
 				BufferIO::DecodeUTF8(text, strBuffer);
 				cs.desc[i] = strBuffer;
 			}
+		}
+		// the remaining fields are from datas2
+		if(!has_datas2)
+			continue;
+		uint32_t cid = 0;
+		if (!try_read_row(sqlite3_column_int64, cid) || !cid)
+			continue;
+		// setcode1,setcode2,setcode3
+		constexpr int extra_setcode_count = SIZE_SETCODE / (sizeof(uint64_t) / sizeof(uint16_t)) - 1;
+		for (int i = 0; i < extra_setcode_count; ++i) {
+			uint64_t setcode_value = 0;
+			if (!try_read_row(sqlite3_column_int64, setcode_value))
+				break;
+			if (setcode_value)
+				setcode_pos = write_setcode(cd.setcode, setcode_value, setcode_pos);
 		}
 	}
 	sqlite3_finalize(pStmt);


### PR DESCRIPTION
```sql
CREATE TABLE datas2(id integer primary key,setcode1 integer,setcode2 integer,setcode3 integer)
```

it works cross-version though the old client cannot read the extra setcodes.

require https://github.com/Fluorohydride/ygopro-core/pull/785