### PR TITLE
 add GetDataTable, GetStringTable 

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -1547,7 +1547,8 @@ void ClientField::UpdateDeclarableList() {
 	int trycode = BufferIO::GetVal(pname);
 	CardData cd;
 	if (dataManager.GetData(trycode, &cd) && is_declarable(cd, declare_opcodes)) {
-		auto it = dataManager.GetStringPointer(trycode);
+		auto& _strings = dataManager.GetStringTable();
+		auto it = _strings.find(trycode);
 		mainGame->lstANCard->clear();
 		ancard.clear();
 		mainGame->lstANCard->addItem(it->second.name.c_str());
@@ -1560,19 +1561,23 @@ void ClientField::UpdateDeclarableList() {
 	}
 	mainGame->lstANCard->clear();
 	ancard.clear();
-	for(auto cit = dataManager.strings_begin(); cit != dataManager.strings_end(); ++cit) {
-		if(cit->second.name.find(pname) != std::wstring::npos) {
-			auto cp = dataManager.GetCodePointer(cit->first);
-			if (cp == dataManager.datas_end())
+	auto& _datas = dataManager.GetDataTable();
+	auto& _strings = dataManager.GetStringTable();
+	for(auto& entry : _strings) {
+		auto& code = entry.first;
+		auto& str = entry.second;
+		if(str.name.find(pname) != std::wstring::npos) {
+			auto cp = _datas.find(code);
+			if (cp == _datas.end())
 				continue;
 			//datas.alias can be double card names or alias
 			if(is_declarable(cp->second, declare_opcodes)) {
-				if(pname == cit->second.name || trycode == cit->first) { //exact match or last used
-					mainGame->lstANCard->insertItem(0, cit->second.name.c_str(), -1);
-					ancard.insert(ancard.begin(), cit->first);
+				if(pname == str.name || trycode == code) { //exact match or last used
+					mainGame->lstANCard->insertItem(0, str.name.c_str(), -1);
+					ancard.insert(ancard.begin(), code);
 				} else {
-					mainGame->lstANCard->addItem(cit->second.name.c_str());
-					ancard.push_back(cit->first);
+					mainGame->lstANCard->addItem(str.name.c_str());
+					ancard.push_back(code);
 				}
 			}
 		}

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -68,17 +68,11 @@ public:
 
 	code_pointer GetCodePointer(uint32_t code) const;
 	string_pointer GetStringPointer(uint32_t code) const;
-	code_pointer datas_begin() const noexcept {
-		return _datas.cbegin();
+	const std::unordered_map<uint32_t, CardDataC>& GetDataTable() const {
+		return _datas;
 	}
-	code_pointer datas_end() const noexcept {
-		return _datas.cend();
-	}
-	string_pointer strings_begin() const noexcept {
-		return _strings.cbegin();
-	}
-	string_pointer strings_end() const noexcept {
-		return _strings.cend();
+	const std::unordered_map<uint32_t, CardString>& GetStringTable() const {
+		return _strings;
 	}
 	bool GetData(uint32_t code, CardData* pData) const;
 	bool GetString(uint32_t code, CardString* pStr) const;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1881,16 +1881,16 @@ bool DeckBuilder::check_limit(code_pointer pointer) {
 	auto flit = filterList->content.find(limitcode);
 	if(flit != filterList->content.end())
 		limit = flit->second;
-	for(auto it = deckManager.current_deck.main.begin(); it != deckManager.current_deck.main.end(); ++it) {
-		if((*it)->first == limitcode || (*it)->second.alias == limitcode)
+	for (auto& card : deckManager.current_deck.main) {
+		if (card->first == limitcode || card->second.alias == limitcode)
 			limit--;
 	}
-	for(auto it = deckManager.current_deck.extra.begin(); it != deckManager.current_deck.extra.end(); ++it) {
-		if((*it)->first == limitcode || (*it)->second.alias == limitcode)
+	for (auto& card : deckManager.current_deck.extra) {
+		if (card->first == limitcode || card->second.alias == limitcode)
 			limit--;
 	}
-	for(auto it = deckManager.current_deck.side.begin(); it != deckManager.current_deck.side.end(); ++it) {
-		if((*it)->first == limitcode || (*it)->second.alias == limitcode)
+	for (auto& card : deckManager.current_deck.side) {
+		if (card->first == limitcode || card->second.alias == limitcode)
 			limit--;
 	}
 	return limit > 0;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -141,6 +141,7 @@ void DeckBuilder::Terminate() {
 bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 	if(mainGame->dField.OnCommonEvent(event))
 		return false;
+	auto& _datas = dataManager.GetDataTable();
 	switch(event.EventType) {
 	case irr::EET_GUI_EVENT: {
 		irr::s32 id = event.GUIEvent.Caller->getID();
@@ -1074,8 +1075,8 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				break;
 			dragx = event.MouseInput.X;
 			dragy = event.MouseInput.Y;
-			draging_pointer = dataManager.GetCodePointer(hovered_code);
-			if(draging_pointer == dataManager.datas_end())
+			draging_pointer = _datas.find(hovered_code);
+			if (draging_pointer == _datas.end())
 				break;
 			if(hovered_pos == 4) {
 				if(!check_limit(draging_pointer))
@@ -1128,8 +1129,8 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 					break;
 				if(hovered_pos == 0 || hovered_seq == -1)
 					break;
-				auto pointer = dataManager.GetCodePointer(hovered_code);
-				if(pointer == dataManager.datas_end())
+				auto pointer = _datas.find(hovered_code);
+				if (pointer == _datas.end())
 					break;
 				soundManager.PlaySoundEffect(SOUND_CARD_DROP);
 				if(hovered_pos == 1) {
@@ -1163,8 +1164,8 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				} else if(hovered_pos == 3) {
 					pop_side(hovered_seq);
 				} else {
-					auto pointer = dataManager.GetCodePointer(hovered_code);
-					if(pointer == dataManager.datas_end())
+					auto pointer = _datas.find(hovered_code);
+					if (pointer == _datas.end())
 						break;
 					if(!check_limit(pointer))
 						break;
@@ -1198,8 +1199,8 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				break;
 			if (is_draging)
 				break;
-			auto pointer = dataManager.GetCodePointer(hovered_code);
-			if (pointer == dataManager.datas_end())
+			auto pointer = _datas.find(hovered_code);
+			if (pointer == _datas.end())
 				break;
 			if(!check_limit(pointer))
 				break;
@@ -1468,10 +1469,13 @@ void DeckBuilder::FilterCards() {
 			query_elements.push_back(element);
 		}
 	}
-	for(code_pointer ptr = dataManager.datas_begin(); ptr != dataManager.datas_end(); ++ptr) {
-		const CardDataC& data = ptr->second;
-		auto strpointer = dataManager.GetStringPointer(ptr->first);
-		if (strpointer == dataManager.strings_end())
+	auto& _datas = dataManager.GetDataTable();
+	auto& _strings = dataManager.GetStringTable();
+	for (code_pointer ptr = _datas.begin(); ptr != _datas.end(); ++ptr) {
+		auto& code = ptr->first;
+		auto& data = ptr->second;
+		auto strpointer = _strings.find(code);
+		if (strpointer == _strings.end())
 			continue;
 		const CardString& strings = strpointer->second;
 		if(data.type & TYPE_TOKEN)

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -150,42 +150,46 @@ unsigned int DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, int r
 uint32_t DeckManager::LoadDeck(Deck& deck, uint32_t dbuf[], int mainc, int sidec, bool is_packlist) {
 	deck.clear();
 	uint32_t errorcode = 0;
-	CardData cd;
+	auto& _datas = dataManager.GetDataTable();
 	for(int i = 0; i < mainc; ++i) {
 		auto code = dbuf[i];
-		if(!dataManager.GetData(code, &cd)) {
+		auto it = _datas.find(code);
+		if(it == _datas.end()) {
 			errorcode = code;
 			continue;
 		}
+		auto& cd = it->second;
 		if (cd.type & TYPE_TOKEN) {
 			errorcode = code;
 			continue;
 		}
 		if(is_packlist) {
-			deck.main.push_back(dataManager.GetCodePointer(code));
+			deck.main.push_back(it);
 			continue;
 		}
 		if (cd.type & TYPES_EXTRA_DECK) {
 			if (deck.extra.size() < EXTRA_MAX_SIZE)
-				deck.extra.push_back(dataManager.GetCodePointer(code));
+				deck.extra.push_back(it);
 		}
 		else {
 			if (deck.main.size() < DECK_MAX_SIZE)
-				deck.main.push_back(dataManager.GetCodePointer(code));
+				deck.main.push_back(it);
 		}
 	}
 	for(int i = 0; i < sidec; ++i) {
 		auto code = dbuf[mainc + i];
-		if(!dataManager.GetData(code, &cd)) {
+		auto it = _datas.find(code);
+		if(it == _datas.end()) {
 			errorcode = code;
 			continue;
 		}
+		auto& cd = it->second;
 		if (cd.type & TYPE_TOKEN) {
 			errorcode = code;
 			continue;
 		}
 		if(deck.side.size() < SIDE_MAX_SIZE)
-			deck.side.push_back(dataManager.GetCodePointer(code));
+			deck.side.push_back(it);
 	}
 	return errorcode;
 }

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1536,8 +1536,9 @@ void Game::ShowCardInfo(int code, bool resize) {
 	if(showingcode == code && !resize)
 		return;
 	wchar_t formatBuffer[256];
-	auto cit = dataManager.GetCodePointer(code);
-	bool is_valid = (cit != dataManager.datas_end());
+	auto& _datas = dataManager.GetDataTable();
+	auto cit = _datas.find(code);
+	bool is_valid = (cit != _datas.end());
 	imgCard->setImage(imageManager.GetTexture(code, true));
 	if (is_valid) {
 		auto& cd = cit->second;
@@ -1558,8 +1559,8 @@ void Game::ShowCardInfo(int code, bool resize) {
 	if (is_valid && !gameConf.hide_setname) {
 		auto& cd = cit->second;
 		auto target = cit;
-		if (cd.alias && dataManager.GetCodePointer(cd.alias) != dataManager.datas_end()) {
-			target = dataManager.GetCodePointer(cd.alias);
+		if (cd.alias && _datas.find(cd.alias) != _datas.end()) {
+			target = _datas.find(cd.alias);
 		}
 		if (target->second.setcode[0]) {
 			offset = 23;// *yScale;


### PR DESCRIPTION
```cpp
const std::unordered_map<uint32_t, CardDataC>& GetDataTable() const {
	return _datas;
}
const std::unordered_map<uint32_t, CardString>& GetStringTable() const {
	return _strings;
}
```
Get the read-only tables.


GetCodePointer
GetStringPointer
replaced by:
```cpp
auto& _datas = dataManager.GetDataTable();
auto& _strings = dataManager.GetStringTable();
_datas.find(code);
_strings.find(code)
```

DeckManager::LoadDeck
`GetData()` will copy data, which is unnecessary.
Now it uses table lookup.

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust