### PR TITLE
 Add deck category constants & refactor LoadCurrentDeck

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -429,7 +429,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 						mainGame->lstCategories->addItem(catename);
 						catesel = mainGame->lstCategories->getItemCount() - 1;
 					} else {
-						for(int i = 3; i < (int)mainGame->lstCategories->getItemCount(); i++) {
+						for(irr::u32 i = DECK_CATEGORY_CUSTOM; i < mainGame->lstCategories->getItemCount(); i++) {
 							if(!mywcsncasecmp(mainGame->lstCategories->getListItem(i), catename, 256)) {
 								catesel = i;
 								mainGame->stACMessage->setText(dataManager.GetSysString(1474));
@@ -449,6 +449,8 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				}
 				case BUTTON_RENAME_CATEGORY: {
 					int catesel = mainGame->lstCategories->getSelected();
+					if (catesel < DECK_CATEGORY_CUSTOM)
+						break;
 					const wchar_t* oldcatename = mainGame->lstCategories->getListItem(catesel);
 					const wchar_t* newcatename = mainGame->ebDMName->getText();
 					if(DeckManager::RenameCategory(oldcatename, newcatename)) {
@@ -459,7 +461,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 						catesel = mainGame->lstCategories->getItemCount() - 1;
 					} else {
 						catesel = 0;
-						for(int i = 3; i < (int)mainGame->lstCategories->getItemCount(); i++) {
+						for(irr::u32 i = DECK_CATEGORY_CUSTOM; i < mainGame->lstCategories->getItemCount(); i++) {
 							if(!mywcsncasecmp(mainGame->lstCategories->getListItem(i), newcatename, 256)) {
 								catesel = i;
 								mainGame->stACMessage->setText(dataManager.GetSysString(1474));
@@ -479,11 +481,13 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 				}
 				case BUTTON_DELETE_CATEGORY: {
 					int catesel = mainGame->lstCategories->getSelected();
+					if (catesel < DECK_CATEGORY_CUSTOM)
+						break;
 					const wchar_t* catename = mainGame->lstCategories->getListItem(catesel);
 					if(DeckManager::DeleteCategory(catename)) {
 						mainGame->cbDBCategory->removeItem(catesel);
 						mainGame->lstCategories->removeItem(catesel);
-						catesel = 2;
+						catesel = DECK_CATEGORY_NONE;
 						mainGame->lstCategories->setSelected(catesel);
 						RefreshDeckList();
 						mainGame->lstDecks->setSelected(0);

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -429,7 +429,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 						mainGame->lstCategories->addItem(catename);
 						catesel = mainGame->lstCategories->getItemCount() - 1;
 					} else {
-						for(irr::u32 i = DECK_CATEGORY_CUSTOM; i < mainGame->lstCategories->getItemCount(); i++) {
+						for(int i = DECK_CATEGORY_CUSTOM; i < (int)mainGame->lstCategories->getItemCount(); i++) {
 							if(!mywcsncasecmp(mainGame->lstCategories->getListItem(i), catename, 256)) {
 								catesel = i;
 								mainGame->stACMessage->setText(dataManager.GetSysString(1474));
@@ -461,7 +461,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 						catesel = mainGame->lstCategories->getItemCount() - 1;
 					} else {
 						catesel = 0;
-						for(irr::u32 i = DECK_CATEGORY_CUSTOM; i < mainGame->lstCategories->getItemCount(); i++) {
+						for(int i = DECK_CATEGORY_CUSTOM; i < (int)mainGame->lstCategories->getItemCount(); i++) {
 							if(!mywcsncasecmp(mainGame->lstCategories->getListItem(i), newcatename, 256)) {
 								catesel = i;
 								mainGame->stACMessage->setText(dataManager.GetSysString(1474));

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -324,7 +324,7 @@ bool DeckManager::LoadCurrentDeck(int category_index, const wchar_t* category_na
 		current_deck.clear();
 		return false;
 	}
-	bool is_packlist = (category_index == 0);
+	bool is_packlist = (category_index == DECK_CATEGORY_PACK);
 	if(!LoadCurrentDeck(filepath, is_packlist))
 		return false;
 	if (mainGame->is_building)

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -320,11 +320,16 @@ bool DeckManager::LoadCurrentDeck(const wchar_t* file, bool is_packlist) {
 bool DeckManager::LoadCurrentDeck(int category_index, const wchar_t* category_name, const wchar_t* deckname) {
 	wchar_t filepath[256];
 	GetDeckFile(filepath, category_index, category_name, deckname);
+	if (!filepath[0]) {
+		current_deck.clear();
+		return false;
+	}
 	bool is_packlist = (category_index == 0);
-	bool res = LoadCurrentDeck(filepath, is_packlist);
-	if (res && mainGame->is_building)
+	if(!LoadCurrentDeck(filepath, is_packlist))
+		return false;
+	if (mainGame->is_building)
 		mainGame->deckBuilder.RefreshPackListScroll();
-	return res;
+	return true;
 }
 void DeckManager::SaveDeck(const Deck& deck, std::stringstream& deckStream) {
 	deckStream << "#created by ..." << std::endl;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -246,15 +246,15 @@ bool DeckManager::LoadSide(Deck& deck, uint32_t dbuf[], int mainc, int sidec) {
 void DeckManager::GetCategoryPath(wchar_t* ret, int index, const wchar_t* text) {
 	wchar_t catepath[256];
 	switch(index) {
-	case 0:
+	case DECK_CATEGORY_PACK:
 		myswprintf(catepath, L"./pack");
 		break;
-	case 1:
+	case DECK_CATEGORY_BOT:
 		BufferIO::CopyWideString(mainGame->gameConf.bot_deck_path, catepath);
 		break;
 	case -1:
-	case 2:
-	case 3:
+	case DECK_CATEGORY_NONE:
+	case DECK_CATEGORY_SEPARATOR:
 		myswprintf(catepath, L"./deck");
 		break;
 	default:

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -16,6 +16,12 @@ namespace ygo {
 	constexpr int MAINC_MAX = 250;	// the limit of card_state
 	constexpr int SIDEC_MAX = MAINC_MAX;
 
+	constexpr int DECK_CATEGORY_PACK = 0;
+	constexpr int DECK_CATEGORY_BOT = 1;
+	constexpr int DECK_CATEGORY_NONE = 2;
+	constexpr int DECK_CATEGORY_SEPARATOR = 3;
+	constexpr int DECK_CATEGORY_CUSTOM = 4;
+
 struct LFList {
 	unsigned int hash{};
 	std::wstring listName;


### PR DESCRIPTION
<img width="1580" height="1039" alt="bug_cat" src="https://github.com/user-attachments/assets/23db9910-3ae5-4926-a846-cc5202d4855d" />

How to reproduce:
- Create category `--------` (8 dash)
- Create category `--------` again
- The separator will be selected

LoadCurrentDeck
Clear current deck when the path is invalid.
