### PR TITLE
fix location after selecting continuous effect

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -417,7 +417,8 @@ void ClientField::ClearChainSelect() {
 	conti_act = false;
 }
 // needs to be synchronized with EGET_SCROLL_BAR_CHANGED
-void ClientField::ShowSelectCard(bool buttonok, bool chain) {
+void ClientField::ShowSelectCard(bool buttonok, bool is_continuous) {
+	select_continuous = is_continuous;
 	if(cant_check_grave) {
 		bool has_card_in_grave = false;
 		for (auto& pcard : selectable_cards) {
@@ -444,7 +445,7 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 		// image
 		if(selectable_cards[i]->code)
 			mainGame->imageLoading.insert(std::make_pair(mainGame->btnCardSelect[i], selectable_cards[i]->code));
-		else if(conti_selecting)
+		else if(select_continuous)
 			mainGame->imageLoading.insert(std::make_pair(mainGame->btnCardSelect[i], selectable_cards[i]->chain_code));
 		else
 			mainGame->btnCardSelect[i]->setImage(imageManager.tCover[selectable_cards[i]->controler + 2]);
@@ -454,7 +455,7 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 		if(mainGame->dInfo.curMsg != MSG_SORT_CARD) {
 			// text
 			wchar_t formatBuffer[2048];
-			if(conti_selecting)
+			if(select_continuous)
 				myswprintf(formatBuffer, L"%ls", dataManager.unknown_string);
 			else if(cant_check_grave && selectable_cards[i]->location == LOCATION_GRAVE)
 				myswprintf(formatBuffer, L"%ls", dataManager.FormatLocation(selectable_cards[i]->location, 0));
@@ -470,7 +471,7 @@ void ClientField::ShowSelectCard(bool buttonok, bool chain) {
 			if (selectable_cards[i]->is_selected)
 				mainGame->stCardPos[i]->setBackgroundColor(0xffffff00);
 			else {
-				if(conti_selecting)
+				if(select_continuous)
 					mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 				else if(selectable_cards[i]->location == LOCATION_OVERLAY) {
 					if(selectable_cards[i]->owner != selectable_cards[i]->overlayTarget->controler)

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -86,7 +86,7 @@ public:
 	ChainInfo current_chain;
 	bool last_chain{ false };
 	bool deck_reversed{ false };
-	bool conti_selecting{ false };
+	bool select_continuous{ false };
 	bool cant_check_grave{ false };
 	bool tag_surrender{ false };
 	bool tag_teammate_surrender{ false };
@@ -105,7 +105,7 @@ public:
 	void ClearCommandFlag();
 	void ClearSelect();
 	void ClearChainSelect();
-	void ShowSelectCard(bool buttonok = false, bool chain = false);
+	void ShowSelectCard(bool buttonok = false, bool is_continuous = false);
 	void ShowChainCard();
 	void ShowLocationCard();
 	void ShowSelectOption(int select_hint = 0);

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1095,7 +1095,6 @@ void Game::HideElement(irr::gui::IGUIElement * win, bool set_action) {
 	if(win == wCardSelect) {
 		for(int i = 0; i < 5; ++i)
 			btnCardSelect[i]->setDrawImage(false);
-		dField.conti_selecting = false;
 		stCardListTip->setVisible(false);
 		for(auto& pcard : dField.selectable_cards)
 			dField.SetShowMark(pcard, false);

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -404,7 +404,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					}
 				} else {
 					selectable_cards.clear();
-					conti_selecting = false;
+					bool is_continuous = false;
 					switch(command_location) {
 					case LOCATION_DECK: {
 						for(size_t i = 0; i < deck[command_controler].size(); ++i)
@@ -431,15 +431,15 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						break;
 					}
 					case POSITION_HINT: {
+						is_continuous = true;
 						selectable_cards = conti_cards;
 						std::sort(selectable_cards.begin(), selectable_cards.end());
 						auto eit = std::unique(selectable_cards.begin(), selectable_cards.end());
 						selectable_cards.erase(eit, selectable_cards.end());
-						conti_selecting = true;
 						break;
 					}
 					}
-					if(!conti_selecting) {
+					if (!is_continuous) {
 						mainGame->wCardSelect->setText(dataManager.GetSysString(566));
 						list_command = COMMAND_ACTIVATE;
 					} else {
@@ -447,7 +447,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						list_command = COMMAND_OPERATION;
 					}
 					std::sort(selectable_cards.begin(), selectable_cards.end(), ClientCard::client_card_sort);
-					ShowSelectCard(true, true);
+					ShowSelectCard(true, is_continuous);
 				}
 				break;
 			}
@@ -892,7 +892,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					// image
 					if(selectable_cards[i + pos]->code)
 						mainGame->btnCardSelect[i]->setImage(imageManager.GetTexture(selectable_cards[i + pos]->code));
-					else if(conti_selecting)
+					else if(select_continuous)
 						mainGame->btnCardSelect[i]->setImage(imageManager.GetTexture(selectable_cards[i + pos]->chain_code));
 					else
 						mainGame->btnCardSelect[i]->setImage(imageManager.tCover[selectable_cards[i + pos]->controler + 2]);
@@ -905,7 +905,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 						else
 							myswprintf(formatBuffer, L"");
 					} else {
-						if(conti_selecting)
+						if(select_continuous)
 							myswprintf(formatBuffer, L"%ls", dataManager.unknown_string);
 						else if(cant_check_grave && selectable_cards[i]->location == LOCATION_GRAVE)
 							myswprintf(formatBuffer, L"%ls", dataManager.FormatLocation(selectable_cards[i]->location, 0));
@@ -919,7 +919,7 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 					}
 					mainGame->stCardPos[i]->setText(formatBuffer);
 					// color
-					if(conti_selecting)
+					if(select_continuous)
 						mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 					else if(selectable_cards[i + pos]->location == LOCATION_OVERLAY) {
 						if(selectable_cards[i + pos]->owner != selectable_cards[i + pos]->overlayTarget->controler)


### PR DESCRIPTION
Bug:
```lua
Debug.SetAIName("AI")
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(74586817, 0, 0, LOCATION_MZONE, 0, POS_FACEUP_ATTACK, true)
Debug.AddCard(27572350, 0, 0, LOCATION_MZONE, 4, POS_FACEUP_DEFENSE)
Debug.AddCard(71818935, 0, 0, LOCATION_EXTRA, 0, POS_FACEDOWN_DEFENSE)

Debug.AddCard(32864, 1, 1, LOCATION_HAND, 0, POS_FACEDOWN_DEFENSE)
Debug.AddCard(32864, 1, 1, LOCATION_HAND, 1, POS_FACEDOWN_DEFENSE)
Debug.ReloadFieldEnd()

```
PSYフレームロード・Ω 
PSY-Framelord Omega
①：１ターンに１度、自分・相手のメインフェイズに発動できる。相手の手札をランダムに１枚選び、そのカードと表側表示のこのカードを次の自分スタンバイフェイズまで表側で除外する。

T1
Activate 1st effect of `PSY-Framelord Omega` twice

T2
Turn End

T3
Standby Phase
Select the effect of `PSY-Framelord Omega`

Main Phase
Activate the 1st effect of `Bystial Dis Pater`
<img width="1589" height="1039" alt="bug_select" src="https://github.com/user-attachments/assets/32872f75-c512-43fd-a576-81734e141e29" />


Reason:
`conti_selecting` is not reset after the selection in Standby Phase

Solution:
renamed to `select_continuous`
always set `select_continuous` to correct value in `ClientField::ShowSelectCard` before opening the window

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust


