### PR TITLE
Search when enter deck edit

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -89,6 +89,7 @@ void DeckBuilder::Initialize() {
 		filterList = &deckManager._lfList.back();
 	}
 	ClearSearch();
+	StartFilter();
 	mouse_pos.set(0, 0);
 	hovered_code = 0;
 	hovered_pos = 0;


### PR DESCRIPTION
建议在进入卡组编辑时默认执行一次搜索，以便玩家更好的理解如何组牌。