### PR TITLE
add default statement SELECT_STMT

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -6,6 +6,9 @@ namespace ygo {
 
 unsigned char DataManager::scriptBuffer[0x100000] = {};
 DataManager dataManager;
+static const char SELECT_STMT[] = "SELECT datas.id, datas.ot, datas.alias, datas.setcode, datas.type, datas.atk, datas.def, datas.level, datas.race, datas.attribute, datas.category,"
+" texts.name, texts.desc, texts.str1, texts.str2, texts.str3, texts.str4, texts.str5, texts.str6, texts.str7, texts.str8,"
+" texts.str9, texts.str10, texts.str11, texts.str12, texts.str13, texts.str14, texts.str15, texts.str16 FROM datas INNER JOIN texts ON datas.id = texts.id";
 
 DataManager::DataManager() : _datas(32768), _strings(32768) {
 	extra_setcode = { 

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -20,10 +20,6 @@ constexpr int MAX_STRING_ID = 0x7ff;
 constexpr uint32_t MIN_CARD_ID = (uint32_t)(MAX_STRING_ID + 1) >> 4;
 constexpr uint32_t MAX_CARD_ID = 0x0fffffffU;
 
-const char SELECT_STMT[] = "SELECT datas.id, datas.ot, datas.alias, datas.setcode, datas.type, datas.atk, datas.def, datas.level, datas.race, datas.attribute, datas.category,"
-" texts.name, texts.desc, texts.str1, texts.str2, texts.str3, texts.str4, texts.str5, texts.str6, texts.str7, texts.str8,"
-" texts.str9, texts.str10, texts.str11, texts.str12, texts.str13, texts.str14, texts.str15, texts.str16 FROM datas INNER JOIN texts ON datas.id = texts.id";
-
 using CardData = card_data;
 struct CardDataC {
 	uint32_t code{};


### PR DESCRIPTION
default statement:
SELECT datas.id, datas.ot, datas.alias, datas.setcode, datas.type, datas.atk, datas.def, datas.level, datas.race, datas.attribute, datas.category,
 texts.name, texts.desc, texts.str1, texts.str2, texts.str3, texts.str4, texts.str5, texts.str6, texts.str7, texts.str8,
 texts.str9, texts.str10, texts.str11, texts.str12, texts.str13, texts.str14, texts.str15, texts.str16 FROM datas INNER JOIN texts ON datas.id=texts.id

https://sqlite.org/lang_select.html#determination_of_input_data_from_clause_processing_
If there is a USING clause then each of the column names specified must exist in the datasets to both the left and right of the join-operator. For each pair of named columns, the expression "lhs.X = rhs.X" is evaluated for each row of the cartesian product as a [boolean expression](https://sqlite.org/lang_expr.html#booleanexpr).

For each pair of columns identified by a USING clause, the column from the right-hand dataset is omitted from the joined dataset. This is the only difference between a USING clause and its equivalent ON constraint. 

----
The header file should explicitly list the column ygopro needs.
頭文件應該明確列出 ygopro 所需的column。

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust
