### PR TITLE
Remove unnecessary std::forward

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -54,12 +54,12 @@
 #include "../ocgcore/ocgapi.h"
 
 template<size_t N, typename... TR>
-inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR&&... args) {
-	return std::swprintf(buf, N, fmt, std::forward<TR>(args)...);
+inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
+	return std::swprintf(buf, N, fmt, args...);
 }
 template<size_t N, typename... TR>
-inline int mysnprintf(char(&buf)[N], const char* fmt, TR&&... args) {
-	return std::snprintf(buf, N, fmt, std::forward<TR>(args)...);
+inline int mysnprintf(char(&buf)[N], const char* fmt, TR... args) {
+	return std::snprintf(buf, N, fmt, args...);
 }
 
 inline FILE* mywfopen(const wchar_t* filename, const char* mode) {


### PR DESCRIPTION
This PR removes the usage of `std::forward` and universal references (`TR&&...`) from the `myswprintf` wrapper function, changing the template parameter pack to use direct pass-by-value (`TR...`).

## Reasoning for Changes:

1. **Incompatibility with C-Style APIs:**
The underlying function, `std::swprintf`, is a C-style variadic function. It does not support C++ move semantics or reference handling. It operates strictly by copying values (scalars and pointers) onto the stack. Consequently, `std::forward` (designed for perfect forwarding and move semantics) serves no functional purpose in this context.
2. **Redundant for Scalar Types:**
The arguments passed to `swprintf` are typically fundamental types (integers, floats) or raw pointers (via `.c_str()`). For these types, a "move" operation is mechanically identical to a "copy" operation. Using `std::forward` adds syntactic complexity without providing any performance benefit.
3. **Code Clarity:**
Using `std::forward` and universal references implies that the function is managing complex object lifecycles or ownership transfer. Removing them makes the code intention explicit: this is a wrapper passing simple values to a C API.
4. **Optimization (Pass-by-Value):**
Switching to pass-by-value (`TR... args`) is preferred over pass-by-reference (`const TR&...`) for this specific use case. Since the arguments are small scalars (pointers or integers), passing them in registers (by value) is generally more efficient than passing them via memory addresses (by reference), and it strictly aligns with the signature of the underlying variadic function.

----
本 PR 移除了 `myswprintf` 包裝函式中使用的 `std::forward` 與通用參考 (Universal References, `TR&&`)，並將參數傳遞方式改為直接傳值 (`TR...`)。

## 修改理由

1. **不適用於 C 語言 API：**
底層呼叫的 `std::swprintf` 屬於 C 語言風格的變參函數 (Variadic Function)。這類函數的運作機制是基於堆疊 (Stack) 的數值拷貝，完全無法識別、也無法利用 C++ 的移動語義 (Move Semantics) 或完美轉發 (Perfect Forwarding)。因此，在此處使用 `std::forward` 沒有實際作用。
2. **純量型別無優化效益：**
傳遞給 `swprintf` 的參數通常是基本資料型別 (Scalar Types，如 `int`、`double`) 或原始指標 (如 `.c_str()` 返回的 `wchar_t*`)。對於這些型別而言，「移動」與「複製」在機器碼層級是完全等價的操作，使用 `std::forward` 徒增語法雜訊，並無效能提升。
3. **提升程式碼可讀性：**
保留 `std::forward` 容易誤導維護者，讓人誤以為此處涉及複雜的物件擁有權轉移或生命週期管理。移除後能使程式碼意圖更清晰：這僅是一個將數值傳遞給 C API 的簡單包裝。
4. **符合底層傳遞機制 (Pass-by-Value)：**
針對此類小型的純量參數，改為「傳值 (`TR...`)」通常比「傳參考」更有效率 (可直接利用 CPU 暫存器傳遞)，且這更符合 C 語言變參函數原本的設計預期。