### PR TITLE
Fix size calculation for STOC_HS_PlayerEnter

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -829,11 +829,11 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 		break;
 	}
 	case STOC_HS_PLAYER_ENTER: {
-		if (len < 1 + STOC_HS_PlayerEnter_size)
+		if (len < 1 + sizeof(STOC_HS_PlayerEnter))
 			return;
 		soundManager.PlaySoundEffect(SOUND_PLAYER_ENTER);
 		STOC_HS_PlayerEnter packet;
-		std::memcpy(&packet, pdata, STOC_HS_PlayerEnter_size);
+		std::memcpy(&packet, pdata, sizeof(STOC_HS_PlayerEnter));
 		auto pkt = &packet;
 		if(pkt->pos > 3)
 			break;

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -172,14 +172,14 @@ constexpr int LEN_CHAT_PLAYER = 1;
 constexpr int LEN_CHAT_MSG = 256;
 constexpr int SIZE_STOC_CHAT = (LEN_CHAT_PLAYER + LEN_CHAT_MSG) * sizeof(uint16_t);
 
+#pragma pack(push, 1)
 struct STOC_HS_PlayerEnter {
 	uint16_t name[20]{};
 	uint8_t pos{};
-	// byte padding[1]
 };
+#pragma pack(pop)
 check_trivially_copyable(STOC_HS_PlayerEnter);
-//static_assert(sizeof(STOC_HS_PlayerEnter) == 42, "size mismatch: STOC_HS_PlayerEnter");
-constexpr int STOC_HS_PlayerEnter_size = 41;	//workwround
+static_assert(sizeof(STOC_HS_PlayerEnter) == 41, "size mismatch: STOC_HS_PlayerEnter");
 
 struct STOC_HS_PlayerChange {
 	//pos<<4 | state


### PR DESCRIPTION
Fix the problem in #2551 
Now there is no padding at the end of `STOC_HS_PlayerEnter`.
The size is 41 bytes.