### PR TITLE
Version 0x1363

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -80,7 +80,7 @@ inline FILE* mywfopen(const wchar_t* filename, const char* mode) {
 
 #include <irrlicht.h>
 
-constexpr uint16_t PRO_VERSION = 0x1362;
+constexpr uint16_t PRO_VERSION = 0x1363;
 extern unsigned int enable_log;
 extern bool exit_on_return;
 extern bool open_file;


### PR DESCRIPTION
Since the previous version number on **2025-06-29**, although there have been no major changes to the YGOPro communication protocol, the functional changes are still significant enough to warrant a new version number.

https://github.com/Fluorohydride/ygopro/milestone/2
https://github.com/Fluorohydride/ygopro-core/milestone/2
https://github.com/Fluorohydride/ygopro-scripts/milestone/1

*I hope to complete those before **2026-01-24**, i.e., before **BLZD (1304)**.*