### PR TITLE
fix ClientCard::SetCode

### DIFF
--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -32,14 +32,15 @@ ClientCard::~ClientCard() {
 	overlayed.clear();
 }
 void ClientCard::SetCode(unsigned int x) {
-	if((location == LOCATION_HAND) && (code != x)) {
-		code = x;
+	if (code == x) {
+		return;
+	}
+	if (x == 0) {
+		chain_code = code;
+	}
+	code = x;
+	if (location == LOCATION_HAND) {
 		mainGame->dField.MoveCard(this, 5);
-	} else {
-		if (x == 0 && code != 0) {
-			chain_code = code;
-		}
-		code = x;
 	}
 }
 void ClientCard::UpdateInfo(unsigned char* buf) {


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro/pull/2856 didn't set `chain_code` when the card is in hand, causing the card become white during animation of card moving to hand.