### PR TITLE
Fix pixel range in imageScaleNNAA, add use_threading param 

### DIFF
--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -124,6 +124,8 @@ void ImageManager::ResizeTexture() {
 void imageScaleNNAA(irr::video::IImage* src, irr::video::IImage* dest, bool use_threading) {
 	const auto& srcDim = src->getDimension();
 	const auto& destDim = dest->getDimension();
+	if (destDim.Width == 0 || destDim.Height == 0)
+		return;
 
 	// Cache scale ratios.
 	const double rx = (double)srcDim.Width / destDim.Width;


### PR DESCRIPTION
## Problem
- **Floating-point loop counters:** 
Using `double` variables (`sx`, `sy`) for loop control is unsafe due to floating-point precision errors. Accumulated rounding errors can cause the loop condition (`sx < maxsx`) to evaluate incorrectly, potentially leading to **out-of-bounds memory access** or incorrect iteration counts.

- **Dependency on global state:** 
The function directly accesses the global pointer `mainGame` within the OpenMP directive. This creates **tight coupling**, and it will make the function difficult to unit test in isolation.

## Example
srcWidth: 2
destWidth: 93

dx = destWidth - 1 = 92
rx = 0.02150537634408602322144687946092744823545217514038
minsx = 1.97849462365591421963983975729206576943397521972656
maxsx = 2.00000000000000044408920985006261616945266723632812

```
sx = 2
sx < maxsx is true
Call src->getPixel(2, ...
```