### PR TITLE
Return tUnknownFit in GetBigPicture

### DIFF
--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -282,14 +282,14 @@ irr::video::ITexture* ImageManager::GetTexture(int code, bool fit) {
  * @return Texture pointer. Should NOT be removed nor dropped. */
 irr::video::ITexture* ImageManager::GetBigPicture(int code, float zoom) {
 	if(code == 0)
-		return tUnknown;
+		return tUnknownFit;
 	if(tBigPicture != nullptr) {
 		driver->removeTexture(tBigPicture);
 		tBigPicture = nullptr;
 	}
 	irr::video::IImage* img = GetImage(code);
 	if(img == nullptr) {
-		return tUnknown;
+		return tUnknownFit;
 	}
 	char name[256];
 	mysnprintf(name, "pics/%d/big", code);


### PR DESCRIPTION
Fix: The unknown texture returned by GetBigPicture does not scale with window size.

Size:
特大

## Before
<img width="1538" height="992" alt="test1" src="https://github.com/user-attachments/assets/59195da9-4ba6-4fa5-843a-65d7a59435fe" />
<img width="1538" height="992" alt="test2" src="https://github.com/user-attachments/assets/d6ba0485-0dca-4fc5-8231-7821ba728974" />

## After
<img width="1538" height="992" alt="after" src="https://github.com/user-attachments/assets/fe645fa0-8452-40f0-a5e9-766982fd467c" />


