### PR TITLE
use _IRR_WCHAR_FILESYSTEM instead of _WIN32 in related #ifdef

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -80,7 +80,7 @@ bool DataManager::ReadDB(sqlite3* pDB) {
 bool DataManager::LoadDB(const wchar_t* wfile) {
 	char file[256];
 	BufferIO::EncodeUTF8(wfile, file);
-#ifdef _WIN32
+#ifdef _IRR_WCHAR_FILESYSTEM
 	auto reader = FileSystem->createAndOpenFile(wfile);
 #else
 	auto reader = FileSystem->createAndOpenFile(file);
@@ -394,7 +394,7 @@ unsigned char* DataManager::ScriptReaderEx(const char* script_path, int* slen) {
 	return nullptr;
 }
 unsigned char* DataManager::ReadScriptFromIrrFS(const char* script_name, int* slen) {
-#ifdef _WIN32
+#ifdef _IRR_WCHAR_FILESYSTEM
 	wchar_t fname[256]{};
 	BufferIO::DecodeUTF8(script_name, fname);
 	auto reader = dataManager.FileSystem->createAndOpenFile(fname);

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -278,7 +278,7 @@ FILE* DeckManager::OpenDeckFile(const wchar_t* file, const char* mode) {
 	return fp;
 }
 irr::io::IReadFile* DeckManager::OpenDeckReader(const wchar_t* file) {
-#ifdef _WIN32
+#ifdef _IRR_WCHAR_FILESYSTEM
 	auto reader = dataManager.FileSystem->createAndOpenFile(file);
 #else
 	char file2[256];

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1143,7 +1143,7 @@ void Game::LoadExpansions() {
 			return;
 		}
 		if (IsExtension(name, L".zip") || IsExtension(name, L".ypk")) {
-#ifdef _WIN32
+#ifdef _IRR_WCHAR_FILESYSTEM
 			dataManager.FileSystem->addFileArchive(fpath, true, false, irr::io::EFAT_ZIP);
 #else
 			char upath[1024];
@@ -1156,7 +1156,7 @@ void Game::LoadExpansions() {
 	for(irr::u32 i = 0; i < dataManager.FileSystem->getFileArchiveCount(); ++i) {
 		auto archive = dataManager.FileSystem->getFileArchive(i)->getFileList();
 		for(irr::u32 j = 0; j < archive->getFileCount(); ++j) {
-#ifdef _WIN32
+#ifdef _IRR_WCHAR_FILESYSTEM
 			const wchar_t* fname = archive->getFullFileName(j).c_str();
 #else
 			wchar_t fname[1024];
@@ -1168,7 +1168,7 @@ void Game::LoadExpansions() {
 				continue;
 			}
 			if (IsExtension(fname, L".conf")) {
-#ifdef _WIN32
+#ifdef _IRR_WCHAR_FILESYSTEM
 				auto reader = dataManager.FileSystem->createAndOpenFile(fname);
 #else
 				auto reader = dataManager.FileSystem->createAndOpenFile(uname);


### PR DESCRIPTION
```
//! Define _IRR_WCHAR_FILESYSTEM to enable unicode filesystem support for the engine.
/** This enables the engine to read/write from unicode filesystem. If you
disable this feature, the engine behave as before (ANSI). This is currently only supported
for Windows based systems. You also have to set #define UNICODE for this to compile.
*/
```