### PR TITLE
update irrlicht clipboard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
 
     - name: Download irrlicht
       run: |
-        git clone --depth=1 https://github.com/mercury233/irrlicht
+        git clone --depth=1 -b patch-clipboard https://github.com/mercury233/irrlicht
 
     - name: Check DirectX SDK
       if: matrix.nodxsdk != true
@@ -437,7 +437,7 @@ jobs:
 
     - name: Download irrlicht
       run: |
-        git clone --depth=1 https://github.com/mercury233/irrlicht
+        git clone --depth=1 -b patch-clipboard https://github.com/mercury233/irrlicht
 
     - name: Copy premake files
       run: |
@@ -653,7 +653,7 @@ jobs:
 
     - name: Download irrlicht
       run: |
-        git clone --depth=1 https://github.com/mercury233/irrlicht
+        git clone --depth=1 -b patch-clipboard https://github.com/mercury233/irrlicht
 
     - name: Copy premake files
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
 
     - name: Download irrlicht
       run: |
-        git clone --depth=1 -b patch-clipboard https://github.com/mercury233/irrlicht
+        git clone --depth=1 https://github.com/mercury233/irrlicht
 
     - name: Check DirectX SDK
       if: matrix.nodxsdk != true
@@ -437,7 +437,7 @@ jobs:
 
     - name: Download irrlicht
       run: |
-        git clone --depth=1 -b patch-clipboard https://github.com/mercury233/irrlicht
+        git clone --depth=1 https://github.com/mercury233/irrlicht
 
     - name: Copy premake files
       run: |
@@ -653,7 +653,7 @@ jobs:
 
     - name: Download irrlicht
       run: |
-        git clone --depth=1 -b patch-clipboard https://github.com/mercury233/irrlicht
+        git clone --depth=1 https://github.com/mercury233/irrlicht
 
     - name: Copy premake files
       run: |

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -414,9 +414,7 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 			case BUTTON_EXPORT_DECK_CODE: {
 				std::stringstream textStream;
 				deckManager.SaveDeck(deckManager.current_deck, textStream);
-				wchar_t text[0x10000];
-				BufferIO::DecodeUTF8(textStream.str().c_str(), text);
-				mainGame->env->getOSOperator()->copyToClipboard(text);
+				mainGame->env->getOSOperator()->copyToClipboard(textStream.str().c_str());
 				mainGame->stACMessage->setText(dataManager.GetSysString(1480));
 				mainGame->PopupElement(mainGame->wACMessage, 20);
 				break;
@@ -515,11 +513,9 @@ bool DeckBuilder::OnEvent(const irr::SEvent& event) {
 							deckManager.current_deck.extra.clear();
 							deckManager.current_deck.side.clear();
 						} else {
-							const wchar_t* txt = mainGame->env->getOSOperator()->getTextFromClipboard();
+							const char* txt = mainGame->env->getOSOperator()->getTextFromClipboard();
 							if(txt) {
-								char text[0x10000];
-								BufferIO::EncodeUTF8(txt, text);
-								std::istringstream textStream(text);
+								std::istringstream textStream(txt);
 								deckManager.LoadCurrentDeck(textStream);
 							}
 						}


### PR DESCRIPTION
Our current clipboard-related implementation uses a modified version of Irrlicht, where the parameter type is `wchar_t` instead of the original `char`. This no longer seems necessary.

see https://github.com/mercury233/irrlicht/pull/19

> irrlicht: mercury233/irrlicht@patch-clipboard 
