### PR TITLE
upgrade Windows x64 Build from SSE2 to AVX2

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -260,9 +260,11 @@ workspace "YGOPro"
 
     filter { "system:windows", "platforms:Win32" }
         architecture "x86"
+        vectorextensions "SSE2"
 
     filter { "system:windows", "platforms:x64" }
         architecture "x86_64"
+        vectorextensions "AVX2"
 
     filter "system:macosx"
         libdirs { "/usr/local/lib" }
@@ -314,7 +316,6 @@ workspace "YGOPro"
     filter "action:vs*"
         cdialect "C11"
         conformancemode "On" 
-        vectorextensions "SSE2"
         buildoptions { "/utf-8" }
         defines { "_CRT_SECURE_NO_WARNINGS" }
 


### PR DESCRIPTION
### Summary

This PR upgrades the **Windows x64** build target from **SSE2** to **AVX2**.

As of **2026**, AVX2 has been available in consumer CPUs for over a decade (introduced in 2013). According to the latest [Steam Hardware Survey](https://store.steampowered.com/hwsurvey/?platform=pc), **96.84% of CPUs support AVX2**, making it a practical and safe baseline for modern Windows x64 systems.
<img width="960" height="662" alt="image" src="https://github.com/user-attachments/assets/a5fa8a4a-787f-4fa7-a65b-024810cd904b" />

### Why AVX2

AVX2 (Advanced Vector Extensions 2) is a 256-bit SIMD instruction set extension for x86 CPUs. It enables wider vector operations, improved integer throughput, and more efficient parallel data processing, leading to measurable performance gains in math-heavy, media, and compute workloads.

### Platform Scope

* **Windows x64**: Upgraded to AVX2 (this PR)
* **Windows x86 (32-bit)**: Remains on SSE2 for compatibility
* **Linux**: Appears to have moved to AVX already; further optimization is not part of this PR
* **macOS**: x86_64 support is being phased out; ARM NEON support requires separate validation and is not part of this PR

### Rationale

Given near-universal AVX2 availability on Windows x64 hardware and its clear performance advantages, continuing to target SSE2 unnecessarily limits modern systems. This change modernizes our baseline while preserving compatibility where still required.
