### PR TITLE
use get_original_code_rule for recursive alias handle

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1875,21 +1875,21 @@ void DeckBuilder::pop_side(int seq) {
 	GetHoveredCard();
 }
 bool DeckBuilder::check_limit(code_pointer pointer) {
-	auto limitcode = pointer->second.alias ? pointer->second.alias : pointer->first;
+	auto limitcode = get_original_code_rule(pointer->first, pointer->second.alias, DataManager::CardReader);
 	int limit = 3;
 	auto flit = filterList->content.find(limitcode);
 	if(flit != filterList->content.end())
 		limit = flit->second;
 	for (auto& card : deckManager.current_deck.main) {
-		if (card->first == limitcode || card->second.alias == limitcode)
+		if (get_original_code_rule(card->first, card->second.alias, DataManager::CardReader) == limitcode)
 			limit--;
 	}
 	for (auto& card : deckManager.current_deck.extra) {
-		if (card->first == limitcode || card->second.alias == limitcode)
+		if (get_original_code_rule(card->first, card->second.alias, DataManager::CardReader) == limitcode)
 			limit--;
 	}
 	for (auto& card : deckManager.current_deck.side) {
-		if (card->first == limitcode || card->second.alias == limitcode)
+		if (get_original_code_rule(card->first, card->second.alias, DataManager::CardReader) == limitcode)
 			limit--;
 	}
 	return limit > 0;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -105,7 +105,7 @@ unsigned int DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, int r
 			return (gameruleDeckError << 28) | cit->first;
 		if (cit->second.type & (TYPES_EXTRA_DECK | TYPE_TOKEN))
 			return (DECKERROR_MAINCOUNT << 28);
-		int code = cit->second.alias ? cit->second.alias : cit->first;
+		int code = get_original_code_rule(cit->first, cit->second.alias, DataManager::CardReader);
 		ccount[code]++;
 		int dc = ccount[code];
 		if(dc > 3)
@@ -120,7 +120,7 @@ unsigned int DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, int r
 			return (gameruleDeckError << 28) | cit->first;
 		if (!(cit->second.type & TYPES_EXTRA_DECK) || cit->second.type & TYPE_TOKEN)
 			return (DECKERROR_EXTRACOUNT << 28);
-		int code = cit->second.alias ? cit->second.alias : cit->first;
+		int code = get_original_code_rule(cit->first, cit->second.alias, DataManager::CardReader);
 		ccount[code]++;
 		int dc = ccount[code];
 		if(dc > 3)
@@ -135,7 +135,7 @@ unsigned int DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, int r
 			return (gameruleDeckError << 28) | cit->first;
 		if (cit->second.type & TYPE_TOKEN)
 			return (DECKERROR_SIDECOUNT << 28);
-		int code = cit->second.alias ? cit->second.alias : cit->first;
+		int code = get_original_code_rule(cit->first, cit->second.alias, DataManager::CardReader);
 		ccount[code]++;
 		int dc = ccount[code];
 		if(dc > 3)

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1125,9 +1125,7 @@ void Game::WaitFrameSignal(int frame) {
 }
 void Game::DrawThumb(code_pointer cp, irr::core::vector2di pos, const LFList* lflist, bool drag) {
 	auto code = cp->first;
-	auto lcode = cp->second.alias;
-	if(lcode == 0)
-		lcode = code;
+	auto lcode = get_original_code_rule(cp->first, cp->second.alias, DataManager::CardReader);
 	irr::video::ITexture* img = imageManager.GetTextureThumb(code);
 	if(img == nullptr)
 		return; //nullptr->getSize() will cause a crash

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1555,8 +1555,9 @@ void Game::ShowCardInfo(int code, bool resize) {
 	if (is_valid && !gameConf.hide_setname) {
 		auto& cd = cit->second;
 		auto target = cit;
-		if (cd.alias && _datas.find(cd.alias) != _datas.end()) {
-			target = _datas.find(cd.alias);
+		auto orig = get_original_code_rule(cd.code, cd.alias, DataManager::CardReader);
+		if (orig != cd.code && _datas.find(orig) != _datas.end()) {
+			target = _datas.find(orig);
 		}
 		if (target->second.setcode[0]) {
 			offset = 23;// *yScale;


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro/issues/2997

require https://github.com/Fluorohydride/ygopro-core/pull/822

# Support recursive alias resolution via `get_original_code_rule`

## Background

The `alias` field in the card database serves two distinct purposes:

1. **Alternate artwork / reprint** (`is_alternative` returns `true`): the two card IDs are within ±20 of each other. The aliased card is the original printing; the card with the higher ID is a cosmetic variant. For deck-building and ban-list purposes they are treated as the same card.
2. **"Treated as" name** (`is_alternative` returns `false`): the alias points to a card with a very different ID. The card must be counted against the aliased card's copy limit, but they are distinct cards with distinct names.

The existing `card_data::get_original_code()` resolves exactly one hop: if a card is an alternate artwork (`is_alternative` is true) it returns `alias`, otherwise it returns `code`.

## Problem

A new situation has emerged where a **"treated-as" card** — a card whose rules identity is that of another card (`is_alternative` is false, alias points far away) — itself receives alternate artwork printings. The relationship looks like:

```
C (code=20000001, alias=20000000)   ← alternate artwork of B
  → B (code=20000000, alias=37564765, is_alternative=false)   ← "treated as" A
    → A (code=37564765, original)
```

`get_original_code()` for C returns B (`20000000`), because `is_alternative(C, B)` is true and the resolution stops there. C therefore ends up in a different copy-count bucket from A and B, allowing more copies than the rules permit, and the ban-list icon shown for C is incorrect. The correct behavior is for C to inherit B's rules identity — A (`37564765`).


the below line is for PR override

> ocgcore: Fluorohydride/ygopro-core@patch-coderule-backport
