### PR TITLE
fix FileSystem::RemoveFile(const char* file) on Windows

### DIFF
--- a/gframe/myfilesystem.h
+++ b/gframe/myfilesystem.h
@@ -99,7 +99,9 @@ public:
 	}
 
 	static bool RemoveFile(const char* file) {
-		return DeleteFileA(file);
+		wchar_t wfile[1024];
+		BufferIO::DecodeUTF8(file, wfile);
+		return RemoveFile(wfile);
 	}
 
 	static void TraversalDir(const wchar_t* wpath, const std::function<void(const wchar_t*, bool)>& cb) {


### PR DESCRIPTION
`DeleteFileA` is Windows API and don't follow `setlocale` to support UTF-8.

_`FileSystem::RemoveFile(const char* file)` is not currently used in the code base on Windows._