### PR TITLE
Use size_t for index and return uint32_t in CheckDeck

### DIFF
--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -83,7 +83,7 @@ static unsigned int checkAvail(unsigned int ot, unsigned int avail) {
 		return DECKERROR_TCGONLY;
 	return DECKERROR_NOTAVAIL;
 }
-unsigned int DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, int rule) {
+uint32_t DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, size_t rule) {
 	std::unordered_map<uint32_t, int> ccount;
 	// rule
 	if(deck.main.size() < DECK_MIN_SIZE || deck.main.size() > DECK_MAX_SIZE)
@@ -98,7 +98,7 @@ unsigned int DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, int r
 	auto& list = lflist->content;
 	const unsigned int rule_map[6] = { AVAIL_OCG, AVAIL_TCG, AVAIL_SC, AVAIL_CUSTOM, AVAIL_OCGTCG, 0 };
 	unsigned int avail = 0;
-	if (rule >= 0 && rule < (int)(sizeof rule_map / sizeof rule_map[0]))
+	if (rule < sizeof rule_map / sizeof rule_map[0])
 		avail = rule_map[rule];
 	for (auto& cit : deck.main) {
 		auto gameruleDeckError = checkAvail(cit->ot, avail);

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -40,7 +40,7 @@ public:
 	void LoadLFList();
 	const wchar_t* GetLFListName(unsigned int lfhash);
 	const LFList* GetLFList(unsigned int lfhash);
-	unsigned int CheckDeck(const Deck& deck, unsigned int lfhash, int rule);
+	uint32_t CheckDeck(const Deck& deck, unsigned int lfhash, size_t rule);
 	bool LoadCurrentDeck(const wchar_t* file, bool is_packlist = false);
 	bool LoadCurrentDeck(int category_index, const wchar_t* category_name, const wchar_t* deckname);
 	bool LoadCurrentDeck(std::istringstream& deckStream, bool is_packlist = false);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -242,7 +242,7 @@ void SingleDuel::PlayerReady(DuelPlayer* dp, bool is_ready) {
 	if(ready[dp->type] == is_ready)
 		return;
 	if(is_ready) {
-		unsigned int deckerror = 0;
+		uint32_t deckerror = 0;
 		if(!host_info.no_check_deck) {
 			if(deck_error[dp->type]) {
 				deckerror = (DECKERROR_UNKNOWNCARD << 28) | deck_error[dp->type];

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -224,7 +224,7 @@ void TagDuel::PlayerReady(DuelPlayer* dp, bool is_ready) {
 	if(dp->type > 3 || ready[dp->type] == is_ready)
 		return;
 	if(is_ready) {
-		unsigned int deckerror = 0;
+		uint32_t deckerror = 0;
 		if(!host_info.no_check_deck) {
 			if(deck_error[dp->type]) {
 				deckerror = (DECKERROR_UNKNOWNCARD << 28) | deck_error[dp->type];


### PR DESCRIPTION
## return value
network.h
```cpp
struct STOC_ErrorMsg {
	uint8_t msg{};
	// byte padding[3]

	uint32_t code{};
};
```

The return value is stored in the packet, and the function should return `uint32_t` explicitly.

## rule
It is the index of array `rule_map`.
It is better to use size_t.

