### PR TITLE
Verify the hash of files downloaded in the workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,9 +64,10 @@ jobs:
 
     - name: Download lua
       id: lua
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://www.lua.org/ftp/lua-5.4.8.tar.gz
+        sha256: 4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae
 
     - name: Extract lua
       run: |
@@ -304,9 +305,10 @@ jobs:
     - name: Download DirectX SDK
       if: matrix.nodxsdk != true && steps.dxsdk.outputs.cache-hit != 'true'
       id: dxsdk-download
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://download.microsoft.com/download/a/e/7/ae743f1f-632b-4809-87a9-aa1bb3458e31/DXSDK_Jun10.exe
+        sha256: 705271dc83bfee54d9b94e028426e288d5f070784b7446d164f48ecfbb2a02cb
 
     - name: Install DirectX SDK
       if: matrix.nodxsdk != true && steps.dxsdk.outputs.cache-hit != 'true'
@@ -517,10 +519,11 @@ jobs:
 
     - name: Download premake
       id: premake
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://github.com/premake/premake-core/releases/download/v5.0.0-beta7/premake-5.0.0-beta7-macosx.tar.gz
         filename: premake5.tar.gz
+        sha256: f7a6d4978960aefbc0b2c522f211eedf014e6a2783b04a096c3716213c1bff67
 
     - name: Extract premake
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,10 +97,11 @@ jobs:
     steps:
     - name: Download libevent
       id: libevent
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
         filename: libevent.tar.gz
+        sha256: 92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 
     - name: Extract libevent
       run: |
@@ -109,9 +110,10 @@ jobs:
 
     - name: Download freetype
       id: freetype
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://downloads.sourceforge.net/freetype/freetype-2.14.2.tar.gz
+        sha256: 752c2671f85c54a84b7f0dd2b5cd26b6b741117033886ffbc5ac89a68464b848
 
     - name: Extract freetype
       run: |
@@ -120,9 +122,10 @@ jobs:
 
     - name: Download libjpeg-turbo
       id: libjpeg-turbo
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.4.1/libjpeg-turbo-3.1.4.1.tar.gz
+        sha256: ecae8008e2cc9ade2f2c1bb9d5e6d4fb73e7c433866a056bd82980741571a022
 
     - name: Extract libjpeg-turbo
       run: |
@@ -132,9 +135,10 @@ jobs:
 
     - name: Download sqlite
       id: sqlite
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://www.sqlite.org/2026/sqlite-amalgamation-3510300.zip
+        sha256: acb1e6f5d832484bf6d32b681e858c38add8b2acdfd42ac5df24b8afb46552b4
 
     - name: Extract sqlite
       run: |
@@ -147,9 +151,10 @@ jobs:
 
     - name: Download ogg
       id: ogg
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://github.com/xiph/ogg/releases/download/v1.3.6/libogg-1.3.6.tar.gz
+        sha256: 83e6704730683d004d20e21b8f7f55dcb3383cdf84c0daedf30bde175f774638
 
     - name: Extract ogg
       run: |
@@ -158,9 +163,10 @@ jobs:
 
     - name: Download opus
       id: opus
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://github.com/xiph/opus/releases/download/v1.5.2/opus-1.5.2.tar.gz
+        sha256: 65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1
 
     - name: Extract opus
       run: |
@@ -169,9 +175,10 @@ jobs:
 
     - name: Download opusfile
       id: opusfile
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://github.com/xiph/opusfile/releases/download/v0.12/opusfile-0.12.tar.gz
+        sha256: 118d8601c12dd6a44f52423e68ca9083cc9f2bfe72da7a8c1acb22a80ae3550b
 
     - name: Extract opusfile
       run: |
@@ -180,9 +187,10 @@ jobs:
 
     - name: Download vorbis
       id: vorbis
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz
+        sha256: 0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab
 
     - name: Extract vorbis
       run: |
@@ -270,10 +278,11 @@ jobs:
 
     - name: Download premake
       id: premake
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://github.com/premake/premake-core/releases/download/v5.0.0-beta7/premake-5.0.0-beta7-windows.zip
         filename: premake5.zip
+        sha256: df900cffda613b919ff824f5c59c2e02ebbdbe3ef6d499ab9b9d1912b5ff63f6
 
     - name: Extract premake
       shell: bash
@@ -283,9 +292,10 @@ jobs:
     - name: Download irrKlang
       if: matrix.audiolib == 'irrklang'
       id: irrKlang
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://www.ambiera.at/downloads/irrKlang-32bit-1.6.0.zip
+        sha256: 49daa96c90ae96f3f49a17a2a325ce046ba12c2b722e3e922ce4472ad090360d
 
     - name: Extract irrKlang
       if: matrix.audiolib == 'irrklang'
@@ -404,7 +414,7 @@ jobs:
 
     - name: Download premake
       id: premake
-      uses: mercury233/action-cache-download-file@0e2b8bab566270adae95bd3cd298744402b667eb
+      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
       with:
         url: https://github.com/premake/premake-core/releases/download/v${{ matrix.premake-version }}/premake-${{ matrix.premake-version }}-linux.tar.gz
         filename: premake5.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,7 @@ jobs:
       with:
         url: https://github.com/premake/premake-core/releases/download/v5.0.0-beta7/premake-5.0.0-beta7-windows.zip
         filename: premake5.zip
-        sha256: df900cffda613b919ff824f5c59c2e02ebbdbe3ef6d499ab9b9d1912b5ff63f6
+        sha256: 8baec7b265fd43050f006ef47000457fa93b6fafbb1ead7e333e862a467c2e95
 
     - name: Extract premake
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Download lua
       id: lua
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://www.lua.org/ftp/lua-5.4.8.tar.gz
         sha256: 4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae
@@ -97,7 +97,7 @@ jobs:
     steps:
     - name: Download libevent
       id: libevent
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
         filename: libevent.tar.gz
@@ -110,7 +110,7 @@ jobs:
 
     - name: Download freetype
       id: freetype
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://downloads.sourceforge.net/freetype/freetype-2.14.2.tar.gz
         sha256: 752c2671f85c54a84b7f0dd2b5cd26b6b741117033886ffbc5ac89a68464b848
@@ -122,7 +122,7 @@ jobs:
 
     - name: Download libjpeg-turbo
       id: libjpeg-turbo
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.4.1/libjpeg-turbo-3.1.4.1.tar.gz
         sha256: ecae8008e2cc9ade2f2c1bb9d5e6d4fb73e7c433866a056bd82980741571a022
@@ -135,7 +135,7 @@ jobs:
 
     - name: Download sqlite
       id: sqlite
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://www.sqlite.org/2026/sqlite-amalgamation-3510300.zip
         sha256: acb1e6f5d832484bf6d32b681e858c38add8b2acdfd42ac5df24b8afb46552b4
@@ -151,7 +151,7 @@ jobs:
 
     - name: Download ogg
       id: ogg
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://github.com/xiph/ogg/releases/download/v1.3.6/libogg-1.3.6.tar.gz
         sha256: 83e6704730683d004d20e21b8f7f55dcb3383cdf84c0daedf30bde175f774638
@@ -163,7 +163,7 @@ jobs:
 
     - name: Download opus
       id: opus
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://github.com/xiph/opus/releases/download/v1.5.2/opus-1.5.2.tar.gz
         sha256: 65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1
@@ -175,7 +175,7 @@ jobs:
 
     - name: Download opusfile
       id: opusfile
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://github.com/xiph/opusfile/releases/download/v0.12/opusfile-0.12.tar.gz
         sha256: 118d8601c12dd6a44f52423e68ca9083cc9f2bfe72da7a8c1acb22a80ae3550b
@@ -187,7 +187,7 @@ jobs:
 
     - name: Download vorbis
       id: vorbis
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz
         sha256: 0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab
@@ -278,7 +278,7 @@ jobs:
 
     - name: Download premake
       id: premake
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://github.com/premake/premake-core/releases/download/v5.0.0-beta7/premake-5.0.0-beta7-windows.zip
         filename: premake5.zip
@@ -292,7 +292,7 @@ jobs:
     - name: Download irrKlang
       if: matrix.audiolib == 'irrklang'
       id: irrKlang
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://www.ambiera.at/downloads/irrKlang-32bit-1.6.0.zip
         sha256: 49daa96c90ae96f3f49a17a2a325ce046ba12c2b722e3e922ce4472ad090360d
@@ -315,7 +315,7 @@ jobs:
     - name: Download DirectX SDK
       if: matrix.nodxsdk != true && steps.dxsdk.outputs.cache-hit != 'true'
       id: dxsdk-download
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://download.microsoft.com/download/a/e/7/ae743f1f-632b-4809-87a9-aa1bb3458e31/DXSDK_Jun10.exe
         sha256: 705271dc83bfee54d9b94e028426e288d5f070784b7446d164f48ecfbb2a02cb
@@ -414,7 +414,7 @@ jobs:
 
     - name: Download premake
       id: premake
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://github.com/premake/premake-core/releases/download/v${{ matrix.premake-version }}/premake-${{ matrix.premake-version }}-linux.tar.gz
         filename: premake5.tar.gz
@@ -529,7 +529,7 @@ jobs:
 
     - name: Download premake
       id: premake
-      uses: mercury233/action-cache-download-file@3fffc760bf7b992889fcadf1055bc475b1cd7db6
+      uses: mercury233/action-cache-download-file@v1.2.0
       with:
         url: https://github.com/premake/premake-core/releases/download/v5.0.0-beta7/premake-5.0.0-beta7-macosx.tar.gz
         filename: premake5.tar.gz


### PR DESCRIPTION
https://github.com/mercury233/action-cache-download-file/releases/tag/v1.2.0

`mercury233/action-cache-download-file` now supports validating the SHA-256 hash of files, including those downloaded and those restored from cache.
By verifying the hash, it can ensure that dependencies have not been tampered with and that no random I/O errors have occurred.

Since `mercury233/action-cache-download-file` has switched to using immutable releases, it is no longer necessary to pin a specific commit; specifying the version number is sufficient.

Since the version of premake on Linux is not fixed, it is not currently being verified. I plan to compile it on the fly in the workflow when upgrading to a newer premake version in the future if official binaries are unavailable.


See also: https://github.com/mercury233/ygopro/pull/63#issuecomment-4272361423
