### PR TITLE
Only accept known string id in format string

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -260,7 +260,7 @@ const wchar_t* DataManager::GetText(uint32_t code) const {
 	return unknown_string;
 }
 const wchar_t* DataManager::GetDesc(uint32_t strCode) const {
-	if (strCode < (MIN_CARD_ID << 4))
+	if (strCode <= MAX_STRING_ID)
 		return GetSysString(strCode);
 	unsigned int code = (strCode >> 4) & 0x0fffffff;
 	unsigned int offset = strCode & 0xf;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -38,6 +38,7 @@ int DuelClient::match_kill = 0;
 std::vector<HostPacket> DuelClient::hosts;
 std::set<std::pair<unsigned int, unsigned short>> DuelClient::remotes;
 event* DuelClient::resp_event = 0;
+const std::set<int> DuelClient::select_effectyn_id{ 95, 96, 97, 218, 219, 220 };
 
 bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_game) {
 	if(connect_state)
@@ -955,7 +956,7 @@ void DuelClient::HandleSTOCPacketLan(unsigned char* data, int len) {
 // Analyze STOC_GAME_MSG packet
 bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 	unsigned char* pbuf = msg;
-	wchar_t textBuffer[256];
+	wchar_t textBuffer[256]{};
 	mainGame->dInfo.curMsg = BufferIO::Read<uint8_t>(pbuf);
 	if(mainGame->dInfo.curMsg != MSG_RETRY) {
 		std::memcpy(last_successful_msg, msg, len);
@@ -1526,10 +1527,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			wchar_t ynbuf[256];
 			myswprintf(ynbuf, dataManager.GetSysString(221), dataManager.FormatLocation(l, s), dataManager.GetName(code));
 			myswprintf(textBuffer, L"%ls\n%ls\n%ls", event_string, ynbuf, dataManager.GetSysString(223));
-		} else if(desc <= MAX_STRING_ID) {
+		} else if(select_effectyn_id.count(desc)) {
 			myswprintf(textBuffer, dataManager.GetSysString(desc), dataManager.GetName(code));
 		} else {
-			myswprintf(textBuffer, dataManager.GetDesc(desc), dataManager.GetName(code));
+			myswprintf(textBuffer, L"%ls", dataManager.GetDesc(desc));
 		}
 		mainGame->gMutex.lock();
 		mainGame->SetStaticText(mainGame->stQMessage, 310, mainGame->guiFont, textBuffer);
@@ -1836,14 +1837,14 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		unsigned char respbuf[SIZE_RETURN_VALUE];
 		int pzone = 0;
 		if (mainGame->dInfo.curMsg == MSG_SELECT_PLACE) {
-			if (select_hint) {
+			if (select_hint)
 				myswprintf(textBuffer, dataManager.GetSysString(569), dataManager.GetName(select_hint));
-			} else
+			else
 				myswprintf(textBuffer, dataManager.GetSysString(560));
 		} else {
-			if (select_hint) {
-				myswprintf(textBuffer, dataManager.GetDesc(select_hint));
-			} else
+			if (select_hint)
+				myswprintf(textBuffer, L"%ls", dataManager.GetDesc(select_hint));
+			else
 				myswprintf(textBuffer, dataManager.GetSysString(570));
 		}
 		select_hint = 0;

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -34,6 +34,7 @@ private:
 	static int match_kill;
 	static event* resp_event;
 	static std::set<std::pair<unsigned int, unsigned short>> remotes;
+	static const std::set<int> select_effectyn_id;
 
 public:
 	static unsigned char selftype;


### PR DESCRIPTION
# Problem
## Problem 1
If the server send MSG_SELECT_EFFECTYN with a wrong string id, the client will still use this string as the format string.
It will crash in the best cases.

## Problem 2
MSG_SELECT_EFFECTYN
MSG_SELECT_PLACE
MSG_SELECT_DISFIELD
They also accept format string from card database.
This is a very dangerous approach because card database is updated much more often and checking the strings in database is much more difficult.
Malicious format string can lead to security issues.

# Solution
```
!system 95 是否使用[%ls]的效果？
!system 96 是否使用[%ls]的效果代替破坏？
!system 97 是否把[%ls]在魔法与陷阱区域放置？
!system 218 是否使用[%ls]的效果代替支付基本分？
!system 219 是否使用[%ls]的效果代替取除超量素材？
!system 220 是否使用[%ls]的效果代替取除指示物？
```

- For MSG_SELECT_EFFECTYN, ygopro only accept known strings in `select_effectyn_id` as format string.
- Now ygopro does not accept format string from card database.


@Wind2009-Louse
@fallenstardust