### PR TITLE
Prevent overwriting existing system/victory strings in ReadStringConfLine

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -191,7 +191,8 @@ void DataManager::ReadStringConfLine(const char* linebuf) {
 		if (std::sscanf(&linebuf[7], "%d %240[^\n]", &value, strbuf) != 2)
 			return;
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
-		_sysStrings[value] = strBuffer;
+		if (!_sysStrings.count(value))
+			_sysStrings[value] = strBuffer;
 	} else if(!std::strcmp(strbuf, "victory")) {
 		if (std::sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2)
 			return;

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -183,7 +183,7 @@ void DataManager::ReadStringConfLine(const char* linebuf) {
 	if(linebuf[0] != '!')
 		return;
 	char strbuf[TEXT_LINE_SIZE]{};
-	unsigned int value{};
+	uint32_t value{};
 	wchar_t strBuffer[4096]{};
 	if (std::sscanf(linebuf, "!%63s", strbuf) != 1)
 		return;

--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -183,21 +183,20 @@ void DataManager::ReadStringConfLine(const char* linebuf) {
 	if(linebuf[0] != '!')
 		return;
 	char strbuf[TEXT_LINE_SIZE]{};
-	int value{};
+	unsigned int value{};
 	wchar_t strBuffer[4096]{};
 	if (std::sscanf(linebuf, "!%63s", strbuf) != 1)
 		return;
 	if(!std::strcmp(strbuf, "system")) {
-		if (std::sscanf(&linebuf[7], "%d %240[^\n]", &value, strbuf) != 2)
+		if (std::sscanf(&linebuf[7], "%u %240[^\n]", &value, strbuf) != 2)
 			return;
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
-		if (!_sysStrings.count(value))
-			_sysStrings[value] = strBuffer;
+		_sysStrings.emplace(value, strBuffer);
 	} else if(!std::strcmp(strbuf, "victory")) {
 		if (std::sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2)
 			return;
 		BufferIO::DecodeUTF8(strbuf, strBuffer);
-		_victoryStrings[value] = strBuffer;
+		_victoryStrings.emplace(value, strBuffer);
 	} else if(!std::strcmp(strbuf, "counter")) {
 		if (std::sscanf(&linebuf[8], "%x %240[^\n]", &value, strbuf) != 2)
 			return;


### PR DESCRIPTION
ygopro puts a lot of format strings in system strings,
These strings should not be overwritten by expansion files.
