### PR TITLE
Add _IRR_STATIC_LIB_ to premake

### DIFF
--- a/gframe/CGUITTFont.cpp
+++ b/gframe/CGUITTFont.cpp
@@ -28,7 +28,6 @@
    john@suckerfreegames.com
 */
 
-#define _IRR_STATIC_LIB_
 #include <irrlicht.h>
 #include "CGUITTFont.h"
 

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -1,7 +1,6 @@
 #ifndef YGOPRO_CONFIG_H
 #define YGOPRO_CONFIG_H
 
-#define _IRR_STATIC_LIB_
 #define IRR_COMPILE_WITH_DX9_DEV_PACK
 
 #include <cerrno>

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -7,6 +7,7 @@ project "YGOPro"
         openmp "On"
     end
 
+    defines { "_IRR_STATIC_LIB_" }
     files { "*.cpp", "*.h" }
     includedirs { "../ocgcore", EVENT_INCLUDE_DIR, IRRLICHT_INCLUDE_DIR, JPEG_INCLUDE_DIR, SQLITE_INCLUDE_DIR }
     links { "ocgcore", "clzma", LUA_LIB_NAME, "sqlite3", "irrlicht", JPEG_LIB_NAME, "freetype", "event" }


### PR DESCRIPTION
IrrCompileConfig.h
```cpp
// To build Irrlicht as a static library, you must define _IRR_STATIC_LIB_ in both the
// Irrlicht build, *and* in the user application, before #including <irrlicht.h>
```

`_IRR_STATIC_LIB_` must be defined before <irrlicht.h>
It should be defined in the project to avoid fighting against the include order.