### PR TITLE
add retry for choco install nasm on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,8 +282,10 @@ jobs:
             $success = $true
             break
           }
-          Write-Warning "NASM installation attempt $i failed, retrying in 10s..."
-          Start-Sleep -Seconds 10
+          if ($i -lt $maxRetries) {
+            Write-Warning "NASM installation attempt $i failed, retrying in 10s..."
+            Start-Sleep -Seconds 10
+          }
         }
         if (-not $success) {
           Write-Error "NASM installation failed after $maxRetries attempts"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,7 +273,22 @@ jobs:
     - name: Install NASM
       shell: pwsh
       run: |
-        choco install nasm -y
+        $maxRetries = 3
+        $success = $false
+        for ($i = 1; $i -le $maxRetries; $i++) {
+          $output = choco install nasm -y 2>&1
+          $output | Write-Host
+          if (Test-Path "C:\Program Files\NASM\nasm.exe") {
+            $success = $true
+            break
+          }
+          Write-Warning "NASM installation attempt $i failed, retrying in 10s..."
+          Start-Sleep -Seconds 10
+        }
+        if (-not $success) {
+          Write-Error "NASM installation failed after $maxRetries attempts"
+          exit 1
+        }
         echo "C:\Program Files\NASM" >> $env:GITHUB_PATH
 
     - name: Download premake


### PR DESCRIPTION
- chocolatey may don't return error on fail
- handle the chocolatey server issue

> Failed to fetch results from V2 feed at 'https://community.chocolatey.org/api/v2/Packages(Id='nasm',Version='3.1.0')' with following message : Response status code does not indicate success: 503 (Service Unavailable).
