### PR TITLE
Refactor DuelClient, NetServer static variables

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1,5 +1,7 @@
 #include <algorithm>
+#include <set>
 #include <thread>
+#include <random>
 #include "config.h"
 #include "duelclient.h"
 #include "client_card.h"
@@ -13,32 +15,35 @@
 
 namespace ygo {
 
-unsigned DuelClient::connect_state = 0;
-unsigned char DuelClient::response_buf[SIZE_RETURN_VALUE];
-size_t DuelClient::response_len = 0;
-unsigned int DuelClient::watching = 0;
-unsigned char DuelClient::selftype = 0;
-bool DuelClient::is_host = false;
-event_base* DuelClient::client_base = 0;
-bufferevent* DuelClient::client_bev = 0;
-unsigned char DuelClient::duel_client_write[SIZE_NETWORK_BUFFER];
-bool DuelClient::is_closing = false;
-bool DuelClient::is_swapping = false;
-int DuelClient::select_hint = 0;
-int DuelClient::select_unselect_hint = 0;
-int DuelClient::last_select_hint = 0;
-unsigned char DuelClient::last_successful_msg[SIZE_NETWORK_BUFFER];
-size_t DuelClient::last_successful_msg_length = 0;
-wchar_t DuelClient::event_string[256];
-std::mt19937 DuelClient::rnd;
-std::uniform_real_distribution<float> DuelClient::real_dist;
+namespace {
+	unsigned connect_state{};
+	unsigned char response_buf[SIZE_RETURN_VALUE]{};
+	size_t response_len{};
+	unsigned int watching{};
+	bool is_host{};
+	event_base* client_base{};
+	bool is_closing{};
+	bool is_swapping{};
+	int select_hint{};
+	int select_unselect_hint{};
+	int last_select_hint{};
+	unsigned char last_successful_msg[SIZE_NETWORK_BUFFER]{};
+	size_t last_successful_msg_length{};
+	wchar_t event_string[256]{};
+	std::mt19937 rnd{};
+	std::uniform_real_distribution<float> real_dist{};
 
-bool DuelClient::is_refreshing = false;
-int DuelClient::match_kill = 0;
+	bool is_refreshing{};
+	int match_kill{};
+	std::set<std::pair<unsigned int, unsigned short>> remotes{};
+	event* resp_event{};
+	const std::set<int> select_effectyn_id{ 95, 96, 97, 218, 219, 220 };
+}
+
+bufferevent* DuelClient::client_bev = 0;
+unsigned char DuelClient::duel_client_write[SIZE_NETWORK_BUFFER]{};
+unsigned char DuelClient::selftype = 0;
 std::vector<HostPacket> DuelClient::hosts;
-std::set<std::pair<unsigned int, unsigned short>> DuelClient::remotes;
-event* DuelClient::resp_event = 0;
-const std::set<int> DuelClient::select_effectyn_id{ 95, 96, 97, 218, 219, 220 };
 
 bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_game) {
 	if(connect_state)

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -2,9 +2,7 @@
 #define DUELCLIENT_H
 
 #include <vector>
-#include <set>
-#include <random>
-#include "config.h"
+#include "bufferio.h"
 #include "deck.h"
 #include "network.h"
 
@@ -12,29 +10,8 @@ namespace ygo {
 
 class DuelClient {
 private:
-	static unsigned int connect_state;
-	static unsigned char response_buf[SIZE_RETURN_VALUE];
-	static size_t response_len;
-	static unsigned int watching;
-	static bool is_host;
-	static event_base* client_base;
 	static bufferevent* client_bev;
 	static unsigned char duel_client_write[SIZE_NETWORK_BUFFER];
-	static bool is_closing;
-	static bool is_swapping;
-	static int select_hint;
-	static int select_unselect_hint;
-	static int last_select_hint;
-	static unsigned char last_successful_msg[SIZE_NETWORK_BUFFER];
-	static size_t last_successful_msg_length;
-	static wchar_t event_string[256];
-	static std::mt19937 rnd;
-	static std::uniform_real_distribution<float> real_dist;
-	static bool is_refreshing;
-	static int match_kill;
-	static event* resp_event;
-	static std::set<std::pair<unsigned int, unsigned short>> remotes;
-	static const std::set<int> select_effectyn_id;
 
 public:
 	static unsigned char selftype;

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -4,6 +4,7 @@
 #include "tag_duel.h"
 #include "deck_manager.h"
 #include <thread>
+#include <unordered_map>
 
 namespace ygo {
 

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -6,15 +6,19 @@
 #include <thread>
 
 namespace ygo {
-std::unordered_map<bufferevent*, DuelPlayer> NetServer::users;
-unsigned short NetServer::server_port = 0;
-event_base* NetServer::net_evbase = 0;
-event* NetServer::broadcast_ev = 0;
-evconnlistener* NetServer::listener = 0;
-DuelMode* NetServer::duel_mode = 0;
-unsigned char NetServer::net_server_write[SIZE_NETWORK_BUFFER];
-unsigned char NetServer::net_server_read[SIZE_NETWORK_BUFFER];
-size_t NetServer::last_sent = 0;
+
+namespace{
+	std::unordered_map<bufferevent*, DuelPlayer> users{};
+	unsigned short server_port{};
+	event_base* net_evbase{};
+	event* broadcast_ev {};
+	evconnlistener* listener{};
+	DuelMode* duel_mode{};
+	unsigned char net_server_read[SIZE_NETWORK_BUFFER]{};
+}
+
+unsigned char NetServer::net_server_write[SIZE_NETWORK_BUFFER]{};
+size_t NetServer::last_sent{};
 
 bool NetServer::StartServer(unsigned short port) {
 	if(net_evbase)
@@ -32,7 +36,7 @@ bool NetServer::StartServer(unsigned short port) {
 	                                   LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, -1, (sockaddr*)&sin, sizeof(sin));
 	if(!listener) {
 		event_base_free(net_evbase);
-		net_evbase = 0;
+		net_evbase = nullptr;
 		return false;
 	}
 	evconnlistener_set_error_cb(listener, ServerAcceptError);
@@ -74,7 +78,7 @@ void NetServer::StopBroadcast() {
 	event_get_assignment(broadcast_ev, 0, &fd, 0, 0, 0);
 	evutil_closesocket(fd);
 	event_free(broadcast_ev);
-	broadcast_ev = 0;
+	broadcast_ev = nullptr;
 }
 void NetServer::StopListen() {
 	evconnlistener_disable(listener);
@@ -156,21 +160,21 @@ int NetServer::ServerThread() {
 	}
 	users.clear();
 	evconnlistener_free(listener);
-	listener = 0;
+	listener = nullptr;
 	if(broadcast_ev) {
 		evutil_socket_t fd;
 		event_get_assignment(broadcast_ev, 0, &fd, 0, 0, 0);
 		evutil_closesocket(fd);
 		event_free(broadcast_ev);
-		broadcast_ev = 0;
+		broadcast_ev = nullptr;
 	}
 	if(duel_mode) {
 		event_free(duel_mode->etimer);
 		delete duel_mode;
 	}
-	duel_mode = 0;
+	duel_mode = nullptr;
 	event_base_free(net_evbase);
-	net_evbase = 0;
+	net_evbase = nullptr;
 	return 0;
 }
 void NetServer::DisconnectPlayer(DuelPlayer* dp) {

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -1,7 +1,6 @@
 #ifndef NETSERVER_H
 #define NETSERVER_H
 
-#include <unordered_map>
 #include "bufferio.h"
 #include "network.h"
 

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -2,21 +2,14 @@
 #define NETSERVER_H
 
 #include <unordered_map>
-#include "config.h"
+#include "bufferio.h"
 #include "network.h"
 
 namespace ygo {
 
 class NetServer {
 private:
-	static std::unordered_map<bufferevent*, DuelPlayer> users;
-	static unsigned short server_port;
-	static event_base* net_evbase;
-	static event* broadcast_ev;
-	static evconnlistener* listener;
-	static DuelMode* duel_mode;
 	static unsigned char net_server_write[SIZE_NETWORK_BUFFER];
-	static unsigned char net_server_read[SIZE_NETWORK_BUFFER];
 	static size_t last_sent;
 
 public:


### PR DESCRIPTION
class DuelClient
class NetServer
Most of the private variables can be moved to the unnamed namespace in the cpp file.
The header file can be simplified.