### PR TITLE
Remove CTOS_DeckData  and use uint32_t array in deck loading functions

### DIFF
--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -147,11 +147,11 @@ uint32_t DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, size_t ru
 	}
 	return 0;
 }
-uint32_t DeckManager::LoadDeck(Deck& deck, uint32_t dbuf[], int mainc, int sidec, bool is_packlist) {
+uint32_t DeckManager::LoadDeck(Deck& deck, uint32_t dbuf[], uint32_t mainc, uint32_t sidec, bool is_packlist) {
 	deck.clear();
 	uint32_t errorcode = 0;
 	auto& _datas = dataManager.GetDataTable();
-	for(int i = 0; i < mainc; ++i) {
+	for(uint32_t i = 0; i < mainc; ++i) {
 		auto code = dbuf[i];
 		auto it = _datas.find(code);
 		if(it == _datas.end()) {
@@ -176,7 +176,7 @@ uint32_t DeckManager::LoadDeck(Deck& deck, uint32_t dbuf[], int mainc, int sidec
 				deck.main.push_back(&cd);
 		}
 	}
-	for(int i = 0; i < sidec; ++i) {
+	for(uint32_t i = 0; i < sidec; ++i) {
 		auto code = dbuf[mainc + i];
 		auto it = _datas.find(code);
 		if(it == _datas.end()) {
@@ -218,7 +218,7 @@ uint32_t DeckManager::LoadDeckFromStream(Deck& deck, std::istringstream& deckStr
 	}
 	return LoadDeck(deck, cardlist, mainc, sidec, is_packlist);
 }
-bool DeckManager::LoadSide(Deck& deck, uint32_t dbuf[], int mainc, int sidec) {
+bool DeckManager::LoadSide(Deck& deck, uint32_t dbuf[], uint32_t mainc, uint32_t sidec) {
 	std::unordered_map<uint32_t, int> pcount;
 	std::unordered_map<uint32_t, int> ncount;
 	for(auto card : deck.main)

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -45,9 +45,9 @@ public:
 	bool LoadCurrentDeck(int category_index, const wchar_t* category_name, const wchar_t* deckname);
 	bool LoadCurrentDeck(std::istringstream& deckStream, bool is_packlist = false);
 
-	static uint32_t LoadDeck(Deck& deck, uint32_t dbuf[], int mainc, int sidec, bool is_packlist = false);
+	static uint32_t LoadDeck(Deck& deck, uint32_t dbuf[], uint32_t mainc, uint32_t sidec, bool is_packlist = false);
 	static uint32_t LoadDeckFromStream(Deck& deck, std::istringstream& deckStream, bool is_packlist = false);
-	static bool LoadSide(Deck& deck, uint32_t dbuf[], int mainc, int sidec);
+	static bool LoadSide(Deck& deck, uint32_t dbuf[], uint32_t mainc, uint32_t sidec);
 	static void GetCategoryPath(wchar_t* ret, int index, const wchar_t* text);
 	static void GetDeckFile(wchar_t* ret, int category_index, const wchar_t* category_name, const wchar_t* deckname);
 	static FILE* OpenDeckFile(const wchar_t* file, const char* mode);

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -2,7 +2,6 @@
 #include "netserver.h"
 #include "single_duel.h"
 #include "tag_duel.h"
-#include "deck_manager.h"
 #include <thread>
 
 namespace ygo {
@@ -217,9 +216,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, size_t len
 	case CTOS_UPDATE_DECK: {
 		if(!dp->game)
 			return;
-		if (len < 1 + sizeof(int32_t) + sizeof(int32_t))
-			return;
-		if (len > 1 + sizeof(CTOS_DeckData))
+		if (len < 1 + sizeof(int32_t) * 2)
 			return;
 		duel_mode->UpdateDeck(dp, pdata, len - 1);
 		break;

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -216,7 +216,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, size_t len
 	case CTOS_UPDATE_DECK: {
 		if(!dp->game)
 			return;
-		if (len < 1 + sizeof(int32_t) * 2)
+		if (len < 1 + sizeof(uint32_t) * 2)
 			return;
 		duel_mode->UpdateDeck(dp, pdata, len - 1);
 		break;

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -133,7 +133,7 @@ void NetServer::ServerEchoRead(bufferevent *bev, void *ctx) {
 			break;
 		int read_len = evbuffer_remove(input, net_server_read, packet_len + 2);
 		if (read_len > 2)
-			HandleCTOSPacket(&users[bev], &net_server_read[2], packet_len);
+			HandleCTOSPacket(&users[bev], &net_server_read[2], read_len - 2);
 		len -= packet_len + 2;
 	}
 }

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -124,7 +124,7 @@ void NetServer::ServerAcceptError(evconnlistener* listener, void* ctx) {
 */
 void NetServer::ServerEchoRead(bufferevent *bev, void *ctx) {
 	evbuffer* input = bufferevent_get_input(bev);
-	int len = evbuffer_get_length(input);
+	size_t len = evbuffer_get_length(input);
 	if (len < 2)
 		return;
 	uint16_t packet_len = 0;
@@ -134,7 +134,7 @@ void NetServer::ServerEchoRead(bufferevent *bev, void *ctx) {
 			break;
 		int read_len = evbuffer_remove(input, net_server_read, packet_len + 2);
 		if (read_len > 2)
-			HandleCTOSPacket(&users[bev], &net_server_read[2], read_len - 2);
+			HandleCTOSPacket(&users[bev], &net_server_read[2], packet_len);
 		len -= packet_len + 2;
 	}
 }
@@ -182,7 +182,7 @@ void NetServer::DisconnectPlayer(DuelPlayer* dp) {
 		users.erase(bit);
 	}
 }
-void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
+void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, size_t len) {
 	auto pdata = data;
 	unsigned char pktType = BufferIO::Read<uint8_t>(pdata);
 	if((pktType != CTOS_SURRENDER) && (pktType != CTOS_CHAT) && (dp->state == 0xff || (dp->state && dp->state != pktType)))
@@ -191,7 +191,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_RESPONSE: {
 		if(!dp->game || !duel_mode->pduel)
 			return;
-		if (len < 1 + (int)sizeof(unsigned char))
+		if (len < 1 + sizeof(unsigned char))
 			return;
 		duel_mode->GetResponse(dp, pdata, len - 1);
 		break;
@@ -217,9 +217,9 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_UPDATE_DECK: {
 		if(!dp->game)
 			return;
-		if (len < 1 + (int)sizeof(int32_t) + (int)sizeof(int32_t))
+		if (len < 1 + sizeof(int32_t) + sizeof(int32_t))
 			return;
-		if (len > 1 + (int)sizeof(CTOS_DeckData))
+		if (len > 1 + sizeof(CTOS_DeckData))
 			return;
 		duel_mode->UpdateDeck(dp, pdata, len - 1);
 		break;
@@ -227,7 +227,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_HAND_RESULT: {
 		if(!dp->game)
 			return;
-		if (len < 1 + (int)sizeof(CTOS_HandResult))
+		if (len < 1 + sizeof(CTOS_HandResult))
 			return;
 		CTOS_HandResult packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -238,7 +238,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_TP_RESULT: {
 		if(!dp->game)
 			return;
-		if (len < 1 + (int)sizeof(CTOS_TPResult))
+		if (len < 1 + sizeof(CTOS_TPResult))
 			return;
 		CTOS_TPResult packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -247,7 +247,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 		break;
 	}
 	case CTOS_PLAYER_INFO: {
-		if (len < 1 + (int)sizeof(CTOS_PlayerInfo))
+		if (len < 1 + sizeof(CTOS_PlayerInfo))
 			return;
 		CTOS_PlayerInfo packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -268,7 +268,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_CREATE_GAME: {
 		if(dp->game || duel_mode)
 			return;
-		if (len < 1 + (int)sizeof(CTOS_CreateGame))
+		if (len < 1 + sizeof(CTOS_CreateGame))
 			return;
 		CTOS_CreateGame packet;
 		std::memcpy(&packet, pdata, sizeof packet);
@@ -316,7 +316,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_JOIN_GAME: {
 		if (!duel_mode)
 			return;
-		if (len < 1 + (int)sizeof(CTOS_JoinGame))
+		if (len < 1 + sizeof(CTOS_JoinGame))
 			return;
 		duel_mode->JoinGame(dp, pdata, false);
 		break;
@@ -355,7 +355,7 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len) {
 	case CTOS_HS_KICK: {
 		if (!duel_mode || duel_mode->pduel)
 			return;
-		if (len < 1 + (int)sizeof(CTOS_Kick))
+		if (len < 1 + sizeof(CTOS_Kick))
 			return;
 		CTOS_Kick packet;
 		std::memcpy(&packet, pdata, sizeof packet);

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -32,7 +32,7 @@ public:
 	static void ServerEchoEvent(bufferevent* bev, short events, void* ctx);
 	static int ServerThread();
 	static void DisconnectPlayer(DuelPlayer* dp);
-	static void HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, int len);
+	static void HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, size_t len);
 	static size_t CreateChatPacket(unsigned char* src, int src_size, unsigned char* dst, uint16_t dst_player_type);
 	static void SendPacketToPlayer(DuelPlayer* dp, unsigned char proto) {
 		auto p = net_server_write;

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -54,13 +54,6 @@ struct HostRequest {
 check_trivially_copyable(HostRequest);
 static_assert(sizeof(HostRequest) == 2, "size mismatch: HostRequest");
 
-struct CTOS_DeckData {
-	int32_t mainc{};
-	int32_t sidec{};
-	uint32_t list[MAINC_MAX + SIDEC_MAX]{};
-};
-check_trivially_copyable(CTOS_DeckData);
-
 struct CTOS_HandResult {
 	uint8_t res{};
 };
@@ -221,7 +214,7 @@ public:
 	virtual void ToObserver(DuelPlayer* dp) = 0;
 	virtual void PlayerReady(DuelPlayer* dp, bool is_ready) = 0;
 	virtual void PlayerKick(DuelPlayer* dp, unsigned char pos) = 0;
-	virtual void UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) = 0;
+	virtual void UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len) = 0;
 	virtual void StartDuel(DuelPlayer* dp) = 0;
 	virtual void HandResult(DuelPlayer* dp, unsigned char res) = 0;
 	virtual void TPResult(DuelPlayer* dp, unsigned char tp) = 0;
@@ -256,7 +249,7 @@ public:
 #define NETPLAYER_TYPE_OBSERVER		7
 
 #define CTOS_RESPONSE		0x1		// byte array
-#define CTOS_UPDATE_DECK	0x2		// CTOS_DeckData
+#define CTOS_UPDATE_DECK	0x2		// uint32_t mainc, uint32_t sidec, uint32_t[mainc+sidec]
 #define CTOS_HAND_RESULT	0x3		// CTOS_HandResult
 #define CTOS_TP_RESULT		0x4		// CTOS_TPResult
 #define CTOS_PLAYER_INFO	0x10	// CTOS_PlayerInfo

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -278,6 +278,8 @@ void SingleDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
 void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
 	if(dp->type > 1 || ready[dp->type])
 		return;
+	if (len < sizeof(uint32_t) * 2)
+		return;
 	bool valid = true;
 	uint32_t mainc = BufferIO::Read<uint32_t>(pdata);
 	uint32_t sidec = BufferIO::Read<uint32_t>(pdata);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -275,19 +275,17 @@ void SingleDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
 		return;
 	LeaveGame(players[pos]);
 }
-void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
+void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
 	if(dp->type > 1 || ready[dp->type])
 		return;
-	if (len < 8 || len > sizeof(CTOS_DeckData))
-		return;
 	bool valid = true;
-	CTOS_DeckData deckbuf;
-	std::memcpy(&deckbuf, pdata, len);
-	if (deckbuf.mainc < 0 || deckbuf.mainc > MAINC_MAX)
+	uint32_t mainc = BufferIO::Read<uint32_t>(pdata);
+	uint32_t sidec = BufferIO::Read<uint32_t>(pdata);
+	if (mainc > MAINC_MAX)
 		valid = false;
-	else if (deckbuf.sidec < 0 || deckbuf.sidec > SIDEC_MAX)
+	else if (sidec > SIDEC_MAX)
 		valid = false;
-	else if (len < (2 + deckbuf.mainc + deckbuf.sidec) * (int)sizeof(int32_t))
+	else if (len < (2 + mainc + sidec) * sizeof(uint32_t))
 		valid = false;
 	if (!valid) {
 		STOC_ErrorMsg scem;
@@ -296,10 +294,12 @@ void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 		NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
 		return;
 	}
+	uint32_t deckbuf[MAINC_MAX + SIDEC_MAX];
+	std::memcpy(deckbuf, pdata, (mainc + sidec) * sizeof(uint32_t));
 	if(duel_count == 0) {
-		deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec);
+		deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf, mainc, sidec);
 	} else {
-		if(DeckManager::LoadSide(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec)) {
+		if(DeckManager::LoadSide(pdeck[dp->type], deckbuf, mainc, sidec)) {
 			ready[dp->type] = true;
 			NetServer::SendPacketToPlayer(dp, STOC_DUEL_START);
 			if(ready[0] && ready[1]) {

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -19,7 +19,7 @@ public:
 	void ToObserver(DuelPlayer* dp) override;
 	void PlayerReady(DuelPlayer* dp, bool is_ready) override;
 	void PlayerKick(DuelPlayer* dp, unsigned char pos) override;
-	void UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) override;
+	void UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len) override;
 	void StartDuel(DuelPlayer* dp) override;
 	void HandResult(DuelPlayer* dp, unsigned char res) override;
 	void TPResult(DuelPlayer* dp, unsigned char tp) override;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -267,10 +267,8 @@ void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len)
 		valid = false;
 	else if (sidec > SIDEC_MAX)
 		valid = false;
-	else if (len < (2 + mainc + sidec) * sizeof(int32_t))
+	else if (len < (2 + mainc + sidec) * sizeof(uint32_t))
 		valid = false;
-	uint32_t deckbuf[MAINC_MAX + SIDEC_MAX];
-	std::memcpy(deckbuf, pdata, (mainc + sidec) * sizeof(uint32_t));
 	if (!valid) {
 		STOC_ErrorMsg scem;
 		scem.msg = ERRMSG_DECKERROR;
@@ -278,6 +276,8 @@ void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len)
 		NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
 		return;
 	}
+	uint32_t deckbuf[MAINC_MAX + SIDEC_MAX];
+	std::memcpy(deckbuf, pdata, (mainc + sidec) * sizeof(uint32_t));
 	deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf, mainc, sidec);
 }
 void TagDuel::StartDuel(DuelPlayer* dp) {

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -260,6 +260,8 @@ void TagDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
 void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
 	if(dp->type > 3 || ready[dp->type])
 		return;
+	if (len < sizeof(uint32_t) * 2)
+		return;
 	bool valid = true;
 	uint32_t mainc = BufferIO::Read<uint32_t>(pdata);
 	uint32_t sidec = BufferIO::Read<uint32_t>(pdata);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -257,20 +257,20 @@ void TagDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
 		return;
 	LeaveGame(players[pos]);
 }
-void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
+void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
 	if(dp->type > 3 || ready[dp->type])
 		return;
-	if (len < 8 || len > sizeof(CTOS_DeckData))
-		return;
 	bool valid = true;
-	CTOS_DeckData deckbuf;
-	std::memcpy(&deckbuf, pdata, len);
-	if (deckbuf.mainc < 0 || deckbuf.mainc > MAINC_MAX)
+	uint32_t mainc = BufferIO::Read<uint32_t>(pdata);
+	uint32_t sidec = BufferIO::Read<uint32_t>(pdata);
+	if (mainc > MAINC_MAX)
 		valid = false;
-	else if (deckbuf.sidec < 0 || deckbuf.sidec > SIDEC_MAX)
+	else if (sidec > SIDEC_MAX)
 		valid = false;
-	else if (len < (2 + deckbuf.mainc + deckbuf.sidec) * (int)sizeof(int32_t))
+	else if (len < (2 + mainc + sidec) * sizeof(int32_t))
 		valid = false;
+	uint32_t deckbuf[MAINC_MAX + SIDEC_MAX];
+	std::memcpy(deckbuf, pdata, (mainc + sidec) * sizeof(uint32_t));
 	if (!valid) {
 		STOC_ErrorMsg scem;
 		scem.msg = ERRMSG_DECKERROR;
@@ -278,7 +278,7 @@ void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) {
 		NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
 		return;
 	}
-	deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf.list, deckbuf.mainc, deckbuf.sidec);
+	deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf, mainc, sidec);
 }
 void TagDuel::StartDuel(DuelPlayer* dp) {
 	if(dp != host_player)

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -19,7 +19,7 @@ public:
 	void ToObserver(DuelPlayer* dp) override;
 	void PlayerReady(DuelPlayer* dp, bool is_ready) override;
 	void PlayerKick(DuelPlayer* dp, unsigned char pos) override;
-	void UpdateDeck(DuelPlayer* dp, unsigned char* pdata, int len) override;
+	void UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len) override;
 	void StartDuel(DuelPlayer* dp) override;
 	void HandResult(DuelPlayer* dp, unsigned char res) override;
 	void TPResult(DuelPlayer* dp, unsigned char tp) override;


### PR DESCRIPTION
# Problem
struct CTOS_DeckData is unnecessary, and it only make the deck loading more complicated.


# Solution
CTOS_UPDATE_DECK
Now it use an ordinary uint32_t array.

The format remains unchanged:
uint32_t mainc, uint32_t sidec, uint32_t[mainc+sidec]
