### PR TITLE
fix skipping last line in LoadStrings

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -176,6 +176,9 @@ bool DataManager::LoadStrings(irr::io::IReadFile* reader) {
 			linebuf.clear();
 		}
 	}
+	if (!linebuf.empty()) {
+		ReadStringConfLine(linebuf.data());
+	}
 	reader->drop();
 	return true;
 }


### PR DESCRIPTION
align with `LoadStrings(const char* file)` which uses `std::fgets` and will process the last line if it is not endded with line break