### PR TITLE
workaround fix for handling overlay cards during reconnection

### DIFF
--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -141,6 +141,16 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 	if(flag & QUERY_OVERLAY_CARD) {
 		int count = BufferIO::Read<int32_t>(buf);
 		for(int i = 0; i < count; ++i) {
+			if(i >= overlayed.size()) {
+				ClientCard* xcard = new ClientCard;
+				overlayed.push_back(xcard);
+				mainGame->dField.overlay_cards.insert(xcard);
+				xcard->overlayTarget = this;
+				xcard->location = LOCATION_OVERLAY;
+				xcard->sequence = (unsigned char)(overlayed.size() - 1);
+				xcard->owner = controler; // not accurate
+				xcard->controler = controler;
+			}
 			overlayed[i]->SetCode(BufferIO::Read<int32_t>(buf));
 		}
 	}


### PR DESCRIPTION
Some modified server implementations have added reconnection support after network disconnection or client crash.

When a client reconnects, those servers use MSG_RELOAD_FIELD to reconstruct the game state.

However, it only initializes overlay cards for monsters in the main monster zone (mzone), not the extra deck. During Xyz summon, overlay materials are added to the Xyz monster before it moves to mzone. If the connection is lost before this movement, the Xyz monster in the extra deck has overlay cards, but their ClientCard objects don't exist on the client side. RefreshExtra sends the overlay card data via QUERY_OVERLAY_CARD, causing an out-of-bounds access and crash when trying to access non-existent overlayed array elements.

This fix dynamically creates overlay card objects in UpdateInfo when they don't exist yet, mirroring the approach used in MSG_RELOAD_FIELD for mzone overlay cards. This prevents the crash and allows the client to recover.

<img width="829" height="736" alt="img" src="https://github.com/user-attachments/assets/93d12414-ba71-44b4-9bdb-9f89f9740353" />
