### PR TITLE
Use std::vector in EndDuel for SingleDuel and TagDuel 

### DIFF
--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -36,7 +36,7 @@ void Replay::WriteData(const void* data, size_t length, bool flush) {
 		return;
 	if (replay_size + length > MAX_REPLAY_SIZE)
 		return;
-	std::memcpy(&replay_data[replay_size], data, length);
+	std::memcpy(replay_data + replay_size, data, length);
 	replay_size += length;
 	std::fwrite(data, length, 1, fp);
 	if(flush)

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -36,7 +36,7 @@ void Replay::WriteData(const void* data, size_t length, bool flush) {
 		return;
 	if (replay_size + length > MAX_REPLAY_SIZE)
 		return;
-	std::memcpy(replay_data + replay_size, data, length);
+	std::memcpy(&replay_data[replay_size], data, length);
 	replay_size += length;
 	std::fwrite(data, length, 1, fp);
 	if(flush)

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -191,7 +191,7 @@ bool Replay::ReadData(void* data, size_t length) {
 		return false;
 	}
 	if (length)
-		std::memcpy(data, &replay_data[data_position], length);
+		std::memcpy(data, replay_data + data_position, length);
 	data_position += length;
 	return true;
 }

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -19,10 +19,6 @@ namespace ygo {
 #define REPLAY_ID_YRP1	0x31707279
 #define REPLAY_ID_YRP2	0x32707279
 
-// max size
-constexpr int MAX_REPLAY_SIZE = 0x80000;
-constexpr int MAX_COMP_SIZE = UINT16_MAX + 1;
-
 struct ReplayHeader {
 	uint32_t id{};
 	uint32_t version{};
@@ -48,6 +44,10 @@ struct DuelParameters {
 	int32_t draw_count{};
 	uint32_t duel_flag{};
 };
+
+// max size
+constexpr int MAX_REPLAY_SIZE = 0x80000;
+constexpr int MAX_COMP_SIZE = UINT16_MAX - 1 - sizeof(ExtendedReplayHeader); // UINT16_MAX - 1 = MAX_DATA_SIZE;
 
 class Replay {
 public:

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1429,11 +1429,9 @@ void SingleDuel::EndDuel() {
 		return;
 	last_replay.EndRecord();
 	std::vector<unsigned char> replay_buffer;
-	replay_buffer.resize(sizeof last_replay.pheader + last_replay.comp_size);
-	size_t position = 0;
-	std::memcpy(replay_buffer.data(), &last_replay.pheader, sizeof last_replay.pheader);
-	position += sizeof last_replay.pheader;
-	std::memcpy(&replay_buffer[position], last_replay.comp_data, last_replay.comp_size);
+	replay_buffer.reserve(sizeof last_replay.pheader + last_replay.comp_size);
+	BufferIO::VectorWrite(replay_buffer, last_replay.pheader);
+	BufferIO::VectorWriteBlock(replay_buffer, last_replay.comp_data, last_replay.comp_size);
 	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replay_buffer.data(), replay_buffer.size());
 	NetServer::ReSendToPlayer(players[1]);
 	for(auto oit = observers.begin(); oit != observers.end(); ++oit)

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1428,11 +1428,13 @@ void SingleDuel::EndDuel() {
 	if(!pduel)
 		return;
 	last_replay.EndRecord();
-	char replaybuf[0x2000], *pbuf = replaybuf;
-	std::memcpy(pbuf, &last_replay.pheader, sizeof last_replay.pheader);
-	pbuf += sizeof last_replay.pheader;
-	std::memcpy(pbuf, last_replay.comp_data, last_replay.comp_size);
-	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replaybuf, sizeof last_replay.pheader + last_replay.comp_size);
+	std::vector<unsigned char> replay_buffer;
+	replay_buffer.resize(sizeof last_replay.pheader + last_replay.comp_size);
+	size_t position = 0;
+	std::memcpy(replay_buffer.data(), &last_replay.pheader, sizeof last_replay.pheader);
+	position += sizeof last_replay.pheader;
+	std::memcpy(&replay_buffer[position], last_replay.comp_data, last_replay.comp_size);
+	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replay_buffer.data(), replay_buffer.size());
 	NetServer::ReSendToPlayer(players[1]);
 	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 		NetServer::ReSendToPlayer(*oit);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1536,11 +1536,13 @@ void TagDuel::EndDuel() {
 	if(!pduel)
 		return;
 	last_replay.EndRecord();
-	char replaybuf[0x2000], *pbuf = replaybuf;
-	std::memcpy(pbuf, &last_replay.pheader, sizeof last_replay.pheader);
-	pbuf += sizeof last_replay.pheader;
-	std::memcpy(pbuf, last_replay.comp_data, last_replay.comp_size);
-	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replaybuf, sizeof last_replay.pheader + last_replay.comp_size);
+	std::vector<unsigned char> replaybuf;
+	replaybuf.resize(sizeof last_replay.pheader + last_replay.comp_size);
+	size_t position = 0;
+	std::memcpy(replaybuf.data(), &last_replay.pheader, sizeof last_replay.pheader);
+	position += sizeof last_replay.pheader;
+	std::memcpy(&replaybuf[position], last_replay.comp_data, last_replay.comp_size);
+	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replaybuf.data(), replaybuf.size());
 	NetServer::ReSendToPlayer(players[1]);
 	NetServer::ReSendToPlayer(players[2]);
 	NetServer::ReSendToPlayer(players[3]);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1536,13 +1536,11 @@ void TagDuel::EndDuel() {
 	if(!pduel)
 		return;
 	last_replay.EndRecord();
-	std::vector<unsigned char> replaybuf;
-	replaybuf.resize(sizeof last_replay.pheader + last_replay.comp_size);
-	size_t position = 0;
-	std::memcpy(replaybuf.data(), &last_replay.pheader, sizeof last_replay.pheader);
-	position += sizeof last_replay.pheader;
-	std::memcpy(&replaybuf[position], last_replay.comp_data, last_replay.comp_size);
-	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replaybuf.data(), replaybuf.size());
+	std::vector<unsigned char> replay_buffer;
+	replay_buffer.reserve(sizeof last_replay.pheader + last_replay.comp_size);
+	BufferIO::VectorWrite(replay_buffer, last_replay.pheader);
+	BufferIO::VectorWriteBlock(replay_buffer, last_replay.comp_data, last_replay.comp_size);
+	NetServer::SendBufferToPlayer(players[0], STOC_REPLAY, replay_buffer.data(), replay_buffer.size());
 	NetServer::ReSendToPlayer(players[1]);
 	NetServer::ReSendToPlayer(players[2]);
 	NetServer::ReSendToPlayer(players[3]);


### PR DESCRIPTION
- Raw pointer
Moving raw pointer is considered a bad practice now, and it is unnecessary for an array or vector.
Updating BufferIO::VectorWriteBlock would be better.

- new/delete
Using new/delete directly is considered a bad practice now.
Using std::vector for dynamic size buffer would be better.