### PR TITLE
add vs2026 win7 support

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -124,6 +124,8 @@ newoption { trigger = "vorbis-lib-dir", category = "YGOPro - miniaudio", descrip
 newoption { trigger = "ogg-include-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
 newoption { trigger = "ogg-lib-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
 
+newoption { trigger = "vs2026-win7-support", category = "YGOPro", description = "Enable Windows 7 support (toolset v143) for Visual Studio 2026" }
+
 newoption { trigger = "mac-arm", category = "YGOPro", description = "Cross Compile for Apple Silicon Mac" }
 newoption { trigger = "mac-intel", category = "YGOPro", description = "Cross Compile for Intel Mac" }
 
@@ -292,6 +294,10 @@ if USE_SIMD == "avx2" or USE_SIMD == "neon" then
     USE_SIMD = "best"
 end
 
+if os.istarget("windows") and GetParam("vs2026-win7-support") then
+    WIN7_SUPPORT = true
+end
+
 if os.istarget("macosx") then
     if GetParam("mac-arm") then
         MAC_ARM = true
@@ -319,6 +325,11 @@ workspace "YGOPro"
         systemversion "latest"
         startproject "YGOPro"
         defines { "WINVER=0x0601" } -- WIN7
+
+    if WIN7_SUPPORT then
+        filter { "system:windows", "action:vs2026" }
+            toolset "v143"
+    end
 
     filter { "system:windows", "action:vs*" }
         platforms { "Win32", "x64", "ARM64" }


### PR DESCRIPTION
The default MSVC toolset (v145) in Visual Studio 2026 has dropped support for Windows 7 ([https://developercommunity.visualstudio.com/t/11046188#T-N11047955](https://developercommunity.visualstudio.com/t/11046188#T-N11047955)).

Therefore, if anyone need to continue supporting Windows 7 in VS2026, they must install the older toolset (v143) and specify it in the project.