### PR TITLE
update Game::SetWindowsScale to use device->setWindowSize

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -2345,14 +2345,8 @@ void Game::SetWindowsScale(float scale) {
 	plc.length = sizeof(WINDOWPLACEMENT);
 	if(GetWindowPlacement(hWnd, &plc) && (plc.showCmd == SW_SHOWMAXIMIZED))
 		ShowWindow(hWnd, SW_RESTORE);
-	RECT rcWindow, rcClient;
-	GetWindowRect(hWnd, &rcWindow);
-	GetClientRect(hWnd, &rcClient);
-	MoveWindow(hWnd, rcWindow.left, rcWindow.top,
-		(rcWindow.right - rcWindow.left) - rcClient.right + GAME_WINDOW_WIDTH * scale,
-		(rcWindow.bottom - rcWindow.top) - rcClient.bottom + GAME_WINDOW_HEIGHT * scale,
-		true);
 #endif
+	device->setWindowSize(irr::core::dimension2du(GAME_WINDOW_WIDTH * scale, GAME_WINDOW_HEIGHT * scale));
 }
 void Game::FlashWindow() {
 #ifdef _WIN32


### PR DESCRIPTION
> irrlicht: 33

Irrlicht has it own `IrrlichtDevice::setWindowSize`, so we can use it directly.

The implement of `setWindowSize` on macOS is added in https://github.com/mercury233/irrlicht/pull/33 . Windows and Linux part are already working.