### PR TITLE
Remove delimiter from getline in deck_manager

### DIFF
--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -200,7 +200,7 @@ uint32_t DeckManager::LoadDeckFromStream(Deck& deck, std::istringstream& deckStr
 	uint32_t cardlist[PACK_MAX_SIZE]{};
 	bool is_side = false;
 	std::string linebuf;
-	while (std::getline(deckStream, linebuf, '\n') && ct < PACK_MAX_SIZE) {
+	while (std::getline(deckStream, linebuf) && ct < PACK_MAX_SIZE) {
 		if (linebuf[0] == '!') {
 			is_side = true;
 			continue;


### PR DESCRIPTION
 ```cpp
template<class charT, class traits, class Allocator>
basic_istream<charT, traits>& getline(basic_istream<charT, traits>& is, basic_string<charT, traits, Allocator>& str);
```
Returns: getline(is, str, is.widen(’\n’))

```cpp
// istream
char_type widen(char c) const;
```
Returns: use_facet<ctype<char_type>>(getloc()).widen(c)


```cpp
// ctype<char>
char widen(char c) const;
```
Returns: do_widen(c)

```cpp
charT do_widen(char c) const;
```
Effects: Applies the simplest reasonable transformation from a char value or sequence of char values to the corresponding charT value or values.
The only characters for which unique transformations are required are those in the basic source character set (5.3).

For `ctype<char>`, `do_widen` returns the char itself.
`\n` is default newline character and can be omitted.
