### PR TITLE
2026.5 tcg banlist

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -1,4 +1,5 @@
-#[2026.4][2026.2 TCG][2026.1][2025.10][2025.7][2025.4][2025.1][2024.10][2024.7][2024.4][2024.1][2023.10][2023.7][2023.4][2023.1][2022.10][2022.7][2022.4][2022.1][2021.10][2021.7][2021.4][2021.1][2020.10][2020.7][2020.4][2020.1][2019.10][2019.7][2019.4][2019.1][2018.10][2018.7][2018.4][2018.1][2017.10][2017.7][2017.4][2017.1][2016.10][2016.7][2016.4][2016.1][2015.10][2015.4][2015.1][2014.10][2014.7][2014.4][2014.2][2013.9][2025.10 TCG][2025.9 TCG][2025.4 TCG][2024.12 TCG][2024.9 TCG][2024.4 TCG][2024.1 TCG][2023.9 TCG][2023.6 TCG][2023.2 TCG][2022.12 TCG][2022.10 TCG][2022.5 TCG][2022.2 TCG][2021.10 TCG][2021.7 TCG][2021.3 TCG][2020.12 TCG][2020.9 TCG][2020.6 TCG][2020.4 TCG][2020.1 TCG][2019.10 TCG][2019.7 TCG][2019.4 TCG][2019.1 TCG][2018.12 TCG][2018.9 TCG][2018.5 TCG][2018.2 TCG][2017.11 TCG][2017.9 TCG][2017.6 TCG][2017.3 TCG][2016.8 TCG][2016.4 TCG][2015.11 TCG][2015.7 TCG][2015.4 TCG][2015.1 TCG][2014.10 TCG][2014.7 TCG][2014.4 TCG][2014.1.1 TCG][2013.10.11 TCG][2013.3.1][2012.9.1][2012.3.1][2011.9.1]
+#[2026.4][2026.5 TCG][2026.1][2025.10][2025.7][2025.4][2025.1][2024.10][2024.7][2024.4][2024.1][2023.10][2023.7][2023.4][2023.1][2022.10][2022.7][2022.4][2022.1][2021.10][2021.7][2021.4][2021.1][2020.10][2020.7][2020.4][2020.1][2019.10][2019.7][2019.4][2019.1][2018.10][2018.7][2018.4][2018.1][2017.10][2017.7][2017.4][2017.1][2016.10][2016.7][2016.4][2016.1][2015.10][2015.4][2015.1][2014.10][2014.7][2014.4][2014.2][2013.9]
+#[2026.2 TCG][2025.10 TCG][2025.9 TCG][2025.4 TCG][2024.12 TCG][2024.9 TCG][2024.4 TCG][2024.1 TCG][2023.9 TCG][2023.6 TCG][2023.2 TCG][2022.12 TCG][2022.10 TCG][2022.5 TCG][2022.2 TCG][2021.10 TCG][2021.7 TCG][2021.3 TCG][2020.12 TCG][2020.9 TCG][2020.6 TCG][2020.4 TCG][2020.1 TCG][2019.10 TCG][2019.7 TCG][2019.4 TCG][2019.1 TCG][2018.12 TCG][2018.9 TCG][2018.5 TCG][2018.2 TCG][2017.11 TCG][2017.9 TCG][2017.6 TCG][2017.3 TCG][2016.8 TCG][2016.4 TCG][2015.11 TCG][2015.7 TCG][2015.4 TCG][2015.1 TCG][2014.10 TCG][2014.7 TCG][2014.4 TCG][2014.1.1 TCG][2013.10.11 TCG][2013.3.1][2012.9.1][2012.3.1][2011.9.1]
 !2026.4
 #forbidden
 20292186 0 --アーティファクト－デスサイズ
@@ -197,7 +198,7 @@
 40366667 2 --霊王の波動
 21076084 2 --トリックスター・リンカーネイション
 
-!2026.2 TCG
+!2026.5 TCG
 #forbidden
 62320425 0 --Agido the Ancient Sentinel
 06728559 0 --Archnemeses Protos
@@ -213,18 +214,19 @@
 15341821 0 --Dandylion
 08903700 0 --Djinn Releaser of Rituals
 51858306 0 --Eclipse Wyvern
-55623480 0 --Fairy Tail - Snow
 78706415 0 --Fiber Jar
 93369354 0 --Fishborg Blaster
 42009836 0 --Fossil Dyna Pachycephalo
 55204071 0 --Gimmick Puppet Nightmare
 75732622 0 --Grinder Golem
 41855169 0 --Jowgen the Spiritualist
+47960073 0 --K9-04 Noroi
 25926710 0 --Kelbek the Ancient Vanguard
 57421866 0 --Level Eater
 34206604 0 --Magical Scientist
 23434538 0 --Maxx "C"
 96782886 0 --Mind Master
+61049315 0 --Naturia Rosewhip
 23558733 0 --Phoenixian Cluster Amaryllis
 01357146 0 --Ronintoadin
 91258852 0 --SPYRAL Master Plan
@@ -265,6 +267,7 @@
 21044178 0 --Abyss Dweller
 00440556 0 --Bahamut Shark
 27552504 0 --Beatrice, Lady of the Eternal
+03685372 0 --CXyz Gimmick Puppet Fanatix Machinix
 38273745 0 --Evilswarm Ouroboros
 48626373 0 --Kashtira Arise-Heart
 11398059 0 --King of the Feral Imps
@@ -293,13 +296,11 @@
 35059553 0 --Kaiser Colosseum
 85602018 0 --Last Will
 34906152 0 --Mass Driver
-46411259 0 --Metamorphosis
 41482598 0 --Mirage of Nightmare
 76375976 0 --Mystic Mine
 89023486 0 --Original Sinful Spoils - Snake-Eye
 74191942 0 --Painful Choice
 55144522 0 --Pot of Greed
-70828912 0 --Premature Burial
 63789924 0 --Smoke Grenade of the Thief
 54447022 0 --Soul Charge
 42829885 0 --The Forceful Sentry
@@ -326,13 +327,16 @@
 76794549 1 --Astrograph Sorcerer
 06637331 1 --Bystial Druiswurm
 33854624 1 --Bystial Magnamhut
+31425736 1 --Cupsy☆Yummy
 91800273 1 --Dimension Shifter
 07375867 1 --Dracotail Mululu
 33396948 1 --Exodia the Forbidden One
 34022970 1 --Ext Ryzeal
+55623480 1 --Fairy Tail - Snow
 63542003 1 --Keldo the Sacred Protector
 28642461 1 --K9-66a Jokul
 32061192 1 --Maliss <P> Dormouse
+69272449 1 --Maliss <P> White Rabbit
 36521307 1 --Mathmech Circular
 38572779 1 --Miscellaneousaurus
 99937011 1 --Mudora the Sword Oracle
@@ -354,6 +358,7 @@
 65563871 1 --Sunvine Healer
 30581601 1 --Yummy★Snatchy
 13332685 1 --Ame no Habakiri no Mitsurugi
+31603289 1 --Cupsy★Yummy Way
 74586817 1 --PSY-Framelord Omega
 90953320 1 --T.G. Hyper Librarian
 00581014 1 --Daigusto Emeral
@@ -362,6 +367,7 @@
 34909328 1 --Ryzeal Detonator
 80181649 1 --"A Case for K9"
 85106525 1 --Bonfire
+44362883 1 --Branded Fusion
 07394770 1 --Brilliant Fusion
 24224830 1 --Called by the Grave
 72892473 1 --Card Destruction
@@ -381,12 +387,16 @@
 93946239 1 --Into the Void
 06153210 1 --Ketu Dracotail
 71650854 1 --Magical Mid-Breaker Field
+46411259 1 --Metamorphosis
 43040603 1 --Monster Gate
 83764718 1 --Monster Reborn
 72537897 1 --Obedience Schooled
 33782437 1 --One Day of Peace
 02295440 1 --One for One
 84211599 1 --Pot of Prosperity
+70828912 1 --Premature Burial
+67115133 1 --Radiant Typhoon Chant
+32548318 1 --Rahu Dracotail
 58577036 1 --Reasoning
 32807846 1 --Reinforcement of the Army
 66730191 1 --Sangen Kaimen
@@ -395,6 +405,7 @@
 73468603 1 --Set Rotation
 52340444 1 --Sky Striker Mecha - Hornet Drones
 71344451 1 --Slash Draw
+99243014 1 --Synchro Overtake
 73628505 1 --Terraforming
 11110587 1 --That Grass Looks Greener
 25311006 1 --Triple Tactics Talent
@@ -407,12 +418,12 @@
 41420027 1 --Solemn Judgment
 24207889 1 --There Can Be Only One
 #semi limit
+75003700 2 --Dracotail Lukias
 94145021 2 --Droll & Lock Bird
 08633261 2 --Ice Ryzeal
-69272449 2 --Maliss <P> White Rabbit
 35844557 2 --Sword Ryzeal
 41165831 2 --Unchained Soul of Sharvara
-44362883 2 --Branded Fusion
+33760966 2 --Dracotail Arthalion
 68337209 2 --Maliss in Underground
 55584558 2 --Purrely Delicious Memory
 21347668 2 --Purrely Sleepy Memory
@@ -8910,6 +8921,227 @@
 29843091 2 --おジャマトリオ
 53582587 2 --激流葬
 29401950 2 --奈落の落とし穴
+
+!2026.2 TCG
+#forbidden
+62320425 0 --Agido the Ancient Sentinel
+06728559 0 --Archnemeses Protos
+80237445 0 --Artifact Mjollnir
+20292186 0 --Artifact Scythe
+19740112 0 --Barrier Statue of the Drought
+47961808 0 --Barrier Statue of the Inferno
+73356503 0 --Barrier Statue of the Stormwinds
+10963799 0 --Barrier Statue of the Torrent
+09929398 0 --Blackwing - Gofu the Vague Shadow
+94689206 0 --Block Dragon
+69015963 0 --Cyber-Stein
+15341821 0 --Dandylion
+08903700 0 --Djinn Releaser of Rituals
+51858306 0 --Eclipse Wyvern
+55623480 0 --Fairy Tail - Snow
+78706415 0 --Fiber Jar
+93369354 0 --Fishborg Blaster
+42009836 0 --Fossil Dyna Pachycephalo
+55204071 0 --Gimmick Puppet Nightmare
+75732622 0 --Grinder Golem
+41855169 0 --Jowgen the Spiritualist
+25926710 0 --Kelbek the Ancient Vanguard
+57421866 0 --Level Eater
+34206604 0 --Magical Scientist
+23434538 0 --Maxx "C"
+96782886 0 --Mind Master
+23558733 0 --Phoenixian Cluster Amaryllis
+01357146 0 --Ronintoadin
+91258852 0 --SPYRAL Master Plan
+88071625 0 --The Tyrant Neptune
+44910027 0 --Victory Dragon
+17412721 0 --Elder Entity Norden
+43387895 0 --Supreme King Dragon Starving Venom
+92731385 0 --Tearlaments Kitkallos
+04280258 0 --Apollousa, Bow of the Goddess
+50588353 0 --Crystron Halqifibrax
+98095162 0 --Curious, the Lightsworn Dominion
+59537380 0 --Guardragon Agarpain
+86148577 0 --Guardragon Elpy
+24094258 0 --Heavymetalfoes Electrumite
+59934749 0 --Isolde, Two Tales of the Noble Knights
+39064822 0 --Knightmare Goblin
+65330383 0 --Knightmare Gryphon
+03679218 0 --Knightmare Mermaid
+30342076 0 --Link Decoder
+85243784 0 --Linkross
+95454996 0 --Maliss <Q> White Binder
+44097050 0 --Mecha Phantom Beast Auroradon
+71818935 0 --Moon of the Closed Heaven
+25725326 0 --Prank-Kids Meow-Meow-Mu
+70369116 0 --Predaplant Verte Anaconda
+72330894 0 --Simorgh, Bird of Sovereignty
+59859086 0 --Splash Mage
+27381364 0 --Spright Elf
+33918636 0 --Superheavy Samurai Scarecrow
+22593417 0 --Topologic Gumblar Dragon
+83152482 0 --Union Carrier
+84815190 0 --Baronne de Fleur
+27548199 0 --Borreload Savage Dragon
+03040496 0 --Chaos Ruler, the Chaotic Magical Dragon
+79606837 0 --Herald of the Arc Light
+62242678 0 --Hot Red Dragon Archfiend King Calamity
+63101919 0 --Tempest Magician
+21044178 0 --Abyss Dweller
+00440556 0 --Bahamut Shark
+27552504 0 --Beatrice, Lady of the Eternal
+38273745 0 --Evilswarm Ouroboros
+48626373 0 --Kashtira Arise-Heart
+11398059 0 --King of the Feral Imps
+34086406 0 --Lavalval Chain
+04423206 0 --M-X-Saber Invoker
+54719828 0 --Number 16: Shock Master
+10389142 0 --Number 42: Galaxy Tomahawk
+35772782 0 --Number 67: Pair-a-Dice Smasher
+63504681 0 --Number 86: Heroic Champion - Rhongomyniad
+95474755 0 --Number 89: Diablosis the Mind Hacker
+58820923 0 --Number 95: Galaxy-Eyes Dark Matter Dragon
+52653092 0 --Number S0: Utopic ZEXAL
+34945480 0 --Outer Entity Azathot
+88581108 0 --True King of All Calamities
+81122844 0 --Wind-Up Carrier Zenmaity
+85115440 0 --Zoodiac Broadbull
+69243953 0 --Butterfly Dagger - Elma
+57953380 0 --Card of Safe Return
+60682203 0 --Cold Wave
+17375316 0 --Confiscation
+44763025 0 --Delinquent Duo
+23557835 0 --Dimension Fusion
+42703248 0 --Giant Trunade
+79571449 0 --Graceful Charity
+19613556 0 --Heavy Storm
+35059553 0 --Kaiser Colosseum
+85602018 0 --Last Will
+34906152 0 --Mass Driver
+46411259 0 --Metamorphosis
+41482598 0 --Mirage of Nightmare
+76375976 0 --Mystic Mine
+89023486 0 --Original Sinful Spoils - Snake-Eye
+74191942 0 --Painful Choice
+55144522 0 --Pot of Greed
+70828912 0 --Premature Burial
+63789924 0 --Smoke Grenade of the Thief
+54447022 0 --Soul Charge
+42829885 0 --The Forceful Sentry
+43262273 0 --Appointer of the Red Lotus
+01041278 0 --Branded Expulsion
+83326048 0 --Dimensional Barrier
+87639778 0 --Harpie's Feather Storm
+61740673 0 --Imperial Order
+28566710 0 --Last Turn
+23002292 0 --Red Reboot
+27174286 0 --Return from the Different Dimension
+93016201 0 --Royal Oppression
+57585212 0 --Self-Destruct Button
+03280747 0 --Sixth Sense
+23516703 0 --Summon Limit
+64697231 0 --Trap Dustshoot
+80604091 0 --Ultimate Offering
+05851097 0 --Vanity's Emptiness
+#limit
+07902349 1 --Left Arm of the Forbidden One
+44519536 1 --Left Leg of the Forbidden One
+70903634 1 --Right Arm of the Forbidden One
+08124921 1 --Right Leg of the Forbidden One
+76794549 1 --Astrograph Sorcerer
+06637331 1 --Bystial Druiswurm
+33854624 1 --Bystial Magnamhut
+91800273 1 --Dimension Shifter
+07375867 1 --Dracotail Mululu
+33396948 1 --Exodia the Forbidden One
+34022970 1 --Ext Ryzeal
+63542003 1 --Keldo the Sacred Protector
+28642461 1 --K9-66a Jokul
+32061192 1 --Maliss <P> Dormouse
+36521307 1 --Mathmech Circular
+38572779 1 --Miscellaneousaurus
+99937011 1 --Mudora the Sword Oracle
+38814750 1 --PSY-Framegear Gamma
+20663556 1 --Substitoad
+37961969 1 --Tearlaments Havnis
+74078255 1 --Tearlaments Merrli
+00572850 1 --Tearlaments Scheiren
+91810826 1 --Tenpai Dragon Chundra
+93156774 1 --Vanquish Soul Hollie Sue
+78872731 1 --Zoodiac Ratpier
+46640168 1 --Fiendsmith's Lacrima
+39512984 1 --Gem-Knight Master Diamond
+80453041 1 --Phantom of Yubel
+41999284 1 --Linkuriboh
+73539069 1 --Striker Dragon
+61665245 1 --Summon Sorceress
+93896655 1 --Sunavalon Dryas
+65563871 1 --Sunvine Healer
+30581601 1 --Yummy★Snatchy
+13332685 1 --Ame no Habakiri no Mitsurugi
+74586817 1 --PSY-Framelord Omega
+90953320 1 --T.G. Hyper Librarian
+00581014 1 --Daigusto Emeral
+75433814 1 --Number 40: Gimmick Puppet of Strings
+69170557 1 --Number C40: Gimmick Puppet of Dark Strings
+34909328 1 --Ryzeal Detonator
+80181649 1 --"A Case for K9"
+85106525 1 --Bonfire
+07394770 1 --Brilliant Fusion
+24224830 1 --Called by the Grave
+72892473 1 --Card Destruction
+59750328 1 --Card of Demise
+91623717 1 --Chain Strike
+99266988 1 --Chaos Space
+67616300 1 --Chicken Game
+65681983 1 --Crossout Designator
+15854426 1 --Divine Wind of Mist Valley
+95308449 1 --Final Countdown
+81439173 1 --Foolish Burial
+27970830 1 --Gateway of the Six
+75500286 1 --Gold Sarcophagus
+18144506 1 --Harpie's Feather Duster
+66957584 1 --Infernity Launcher
+01845204 1 --Instant Fusion
+93946239 1 --Into the Void
+06153210 1 --Ketu Dracotail
+71650854 1 --Magical Mid-Breaker Field
+43040603 1 --Monster Gate
+83764718 1 --Monster Reborn
+72537897 1 --Obedience Schooled
+33782437 1 --One Day of Peace
+02295440 1 --One for One
+84211599 1 --Pot of Prosperity
+58577036 1 --Reasoning
+32807846 1 --Reinforcement of the Army
+66730191 1 --Sangen Kaimen
+30336082 1 --Sangen Summoning
+24940422 1 --Sekka's Light
+73468603 1 --Set Rotation
+52340444 1 --Sky Striker Mecha - Hornet Drones
+71344451 1 --Slash Draw
+73628505 1 --Terraforming
+11110587 1 --That Grass Looks Greener
+25311006 1 --Triple Tactics Talent
+58921041 1 --Anti-Spell Fragrance
+53334471 1 --Gozen Match
+32723153 1 --Magical Explosion
+03734202 1 --Naturia Sacred Tree
+90846359 1 --Rivalry of Warlords
+82732705 1 --Skill Drain
+41420027 1 --Solemn Judgment
+24207889 1 --There Can Be Only One
+#semi limit
+94145021 2 --Droll & Lock Bird
+08633261 2 --Ice Ryzeal
+69272449 2 --Maliss <P> White Rabbit
+35844557 2 --Sword Ryzeal
+41165831 2 --Unchained Soul of Sharvara
+44362883 2 --Branded Fusion
+68337209 2 --Maliss in Underground
+55584558 2 --Purrely Delicious Memory
+21347668 2 --Purrely Sleepy Memory
+92107604 2 --Runick Fountain
 
 !2025.10 TCG
 #forbidden


### PR DESCRIPTION
Created by Claude Sonnet 4.5
The list is more than 1024 characters long, and it is divided into 2 lines now.
```
2026.5 TCG.txt
It is the previous yugioh TCG banlist.
The format is
${id} ${limit number} --${English name}
The order is exactly the same as the previous banlist on the official website.

name_table_en
the [cid, name] pairs

cid_table
the [id, cid] pairs

https://www.yugioh-card.com/en/limited/list_2026-05-18/
This is the new banlist.
Please update the banlist in the following order
- Find the rows with Remark
- Find cid in name_table_en by its English name
- Find id in cid_table by its cid
- Insert or remove the cards, so that the order stays exactly the same as the new banlist
- The English name in each line should be the name in name_table_en
```