### PR TITLE
revert locking mutex in EGET_SCROLL_BAR_CHANGED

### DIFF
--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -887,7 +887,6 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 			}
 			case SCROLL_CARD_SELECT: {
 				int pos = mainGame->scrCardList->getPos() / 10;
-				mainGame->gMutex.lock();
 				for(int i = 0; i < 5; ++i) {
 					// draw selectable_cards[i + pos] in btnCardSelect[i]
 					mainGame->stCardPos[i]->enableOverrideColor(false);
@@ -954,12 +953,10 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 							mainGame->stCardPos[i]->setBackgroundColor(0xffffffff);
 					}
 				}
-				mainGame->gMutex.unlock();
 				break;
 			}
 			case SCROLL_CARD_DISPLAY: {
 				int pos = mainGame->scrDisplayList->getPos() / 10;
-				mainGame->gMutex.lock();
 				for(int i = 0; i < 5; ++i) {
 					// draw display_cards[i + pos] in btnCardDisplay[i]
 					mainGame->stDisplayPos[i]->enableOverrideColor(false);
@@ -1004,7 +1001,6 @@ bool ClientField::OnEvent(const irr::SEvent& event) {
 							mainGame->stDisplayPos[i]->setBackgroundColor(0xffffffff);
 					}
 				}
-				mainGame->gMutex.unlock();
 				break;
 			}
 			break;


### PR DESCRIPTION
`CGUIScrollBar::OnPostRender` may create `EGET_SCROLL_BAR_CHANGED` during `env->drawAll` which is called with `gMutex` locked. So adding lock in [a commit in #3014](https://github.com/Fluorohydride/ygopro/pull/3014/changes/dd26d3c67824150a9bd8c765b6f577b0ddf27d90) seems incorrect.

This is a workaround.

To reproduce: Click at the blank area of the scrollbar of selecting card dialog.