### PR TITLE
fix macOS bundle working directory

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -2339,8 +2339,19 @@ irr::core::recti Game::ResizeFit(irr::s32 x, irr::s32 y, irr::s32 x2, irr::s32 y
 
 void Game::FixMacOSBundleWorkingDirectory() {
 #ifdef __APPLE__
-	CFURLRef bundle_url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
+	CFBundleRef main_bundle = CFBundleGetMainBundle();
+	if(!main_bundle) {
+		return;
+	}
+	CFURLRef bundle_url = CFBundleCopyBundleURL(main_bundle);
+	if(!bundle_url) {
+		return;
+	}
 	CFURLRef bundle_base_url = CFURLCreateCopyDeletingLastPathComponent(nullptr, bundle_url);
+	if(!bundle_base_url) {
+		CFRelease(bundle_url);
+		return;
+	}
 	CFStringRef bundle_ext = CFURLCopyPathExtension(bundle_url);
 	if(bundle_ext) {
 		char path[PATH_MAX];

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -15,6 +15,9 @@
 #ifdef _WIN32
 #include <timeapi.h>
 #endif
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#endif
 
 #if defined(__SSE2__) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2) || \
 	defined(__x86_64__) || defined(_M_X64) || defined(__x86_64) || defined(_M_AMD64)
@@ -78,6 +81,9 @@ bool Game::Initialize() {
 		params.DriverType = irr::video::EDT_OPENGL;
 	params.WindowSize = irr::core::dimension2d<irr::u32>(gameConf.window_width, gameConf.window_height);
 	device = irr::createDeviceEx(params);
+#ifdef __APPLE__
+	FixMacOSBundleWorkingDirectory();
+#endif
 	if(!device) {
 		ErrorLog("Failed to create Irrlicht Engine device!");
 		return false;
@@ -2329,6 +2335,24 @@ irr::core::recti Game::ResizeFit(irr::s32 x, irr::s32 y, irr::s32 x2, irr::s32 y
 	x2 = x2 * mul;
 	y2 = y2 * mul;
 	return irr::core::recti(x, y, x2, y2);
+}
+
+void Game::FixMacOSBundleWorkingDirectory() {
+#ifdef __APPLE__
+	CFURLRef bundle_url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
+	CFURLRef bundle_base_url = CFURLCreateCopyDeletingLastPathComponent(nullptr, bundle_url);
+	CFStringRef bundle_ext = CFURLCopyPathExtension(bundle_url);
+	if(bundle_ext) {
+		char path[PATH_MAX];
+		if(CFStringCompare(bundle_ext, CFSTR("app"), kCFCompareCaseInsensitive) == kCFCompareEqualTo
+			&& CFURLGetFileSystemRepresentation(bundle_base_url, true, (UInt8*)path, PATH_MAX)) {
+			chdir(path);
+		}
+		CFRelease(bundle_ext);
+	}
+	CFRelease(bundle_url);
+	CFRelease(bundle_base_url);
+#endif //__APPLE__
 }
 void Game::SetWindowsIcon() {
 #ifdef _WIN32

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -260,6 +260,7 @@ public:
 	irr::core::vector2di ResizeCardMid(irr::s32 x, irr::s32 y, irr::s32 midx, irr::s32 midy);
 	irr::core::recti ResizeFit(irr::s32 x, irr::s32 y, irr::s32 x2, irr::s32 y2);
 
+	static void FixMacOSBundleWorkingDirectory();
 	void SetWindowsIcon();
 	void SetWindowsScale(float scale);
 	void FlashWindow();

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -4,9 +4,6 @@
 #include <event2/thread.h>
 #include <clocale>
 #include <memory>
-#ifdef __APPLE__
-#import <CoreFoundation/CoreFoundation.h>
-#endif
 
 #if defined(_WIN32) && (!defined(WDK_NTDDI_VERSION) || (WDK_NTDDI_VERSION < 0x0A000005)) // Redstone 4, Version 1803, Build 17134.
 #error "This program requires the Windows 10 SDK version 1803 or above to compile on Windows. Otherwise, non-ASCII characters will not be displayed or processed correctly."
@@ -30,19 +27,7 @@ int main(int argc, char* argv[]) {
 	std::setlocale(LC_CTYPE, "");
 #endif
 #ifdef __APPLE__
-	CFURLRef bundle_url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
-	CFURLRef bundle_base_url = CFURLCreateCopyDeletingLastPathComponent(nullptr, bundle_url);
-	CFStringRef bundle_ext = CFURLCopyPathExtension(bundle_url);
-	if (bundle_ext) {
-		char path[PATH_MAX];
-		if (CFStringCompare(bundle_ext, CFSTR("app"), kCFCompareCaseInsensitive) == kCFCompareEqualTo
-			&& CFURLGetFileSystemRepresentation(bundle_base_url, true, (UInt8*)path, PATH_MAX)) {
-			chdir(path);
-		}
-		CFRelease(bundle_ext);
-	}
-	CFRelease(bundle_url);
-	CFRelease(bundle_base_url);
+	ygo::Game::FixMacOSBundleWorkingDirectory();
 #endif //__APPLE__
 #ifdef _WIN32
 	if (argc == 2 && (ygo::IsExtension(argv[1], ".ydk") || ygo::IsExtension(argv[1], ".yrp"))) { // open file from explorer


### PR DESCRIPTION
irrlicht 1.9 is setting working directory to `/Contents/Resources` forcely
https://github.com/mercury233/irrlicht/blob/main/source/Irrlicht/CIrrDeviceOSX.mm#L728