### PR TITLE
Fix the order of level, atk, def in strings.conf

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -419,10 +419,10 @@
 !system 1366 自动保存录像
 !system 1367 录像已自动保存为%ls.yrp
 !system 1369 提取卡组
-!system 1370 星数↑
-!system 1371 攻击↑
-!system 1372 守备↑
-!system 1373 名称↓
+!system 1370 星数↓
+!system 1371 攻击↓
+!system 1372 守备↓
+!system 1373 名称↑
 !system 1374 连接标记
 !system 1378 使用多个关键词搜索卡片
 !system 1379 启用扩展卡包调试模式


### PR DESCRIPTION
Fix #3072 

In most databases:
↑ means Ascending
↓ means Descending

ygopro uses Descending by default, so the arrow is wrong.

