### PR TITLE
update brew install libevent in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,8 +635,7 @@ jobs:
     - name: Install dependencies
       if: matrix.static-link != true
       run: |
-        brew install opus opusfile libvorbis zlib
-#        brew install sqlite libx11 freetype libevent libjpeg-turbo libpng xz
+        brew install sqlite libx11 freetype libevent libjpeg-turbo libpng zlib xz opus opusfile libvorbis
 
     - name: Install NASM
       if: matrix.static-link == true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,6 +635,7 @@ jobs:
     - name: Install dependencies
       if: matrix.static-link != true
       run: |
+        brew update
         brew install sqlite libx11 freetype libevent libjpeg-turbo libpng zlib xz opus opusfile libvorbis
 
     - name: Install NASM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,7 +635,8 @@ jobs:
     - name: Install dependencies
       if: matrix.static-link != true
       run: |
-        brew install sqlite libx11 freetype libevent libjpeg-turbo libpng zlib xz opus opusfile libvorbis
+        brew install libevent opus opusfile libvorbis zlib
+#        brew install sqlite libx11 freetype libjpeg-turbo libpng xz
 
     - name: Install NASM
       if: matrix.static-link == true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,7 +635,6 @@ jobs:
     - name: Install dependencies
       if: matrix.static-link != true
       run: |
-        brew update
         brew install sqlite libx11 freetype libevent libjpeg-turbo libpng zlib xz opus opusfile libvorbis
 
     - name: Install NASM


### PR DESCRIPTION
* The macOS images provided by GitHub no longer come with `libevent` preinstalled via Homebrew, as noted in [this issue](https://github.com/actions/runner-images/issues/14170). It now needs to be installed manually.
* ~~After [a recent Homebrew update](https://github.com/Homebrew/brew/pull/22434), it is now safe to directly list all required Homebrew formulae without triggering warnings for packages that are already installed.~~ This change should be rolled out the next time GitHub updates its macOS images, and I'll open pull request again by then.