### PR TITLE
fix: prevent crash when multiple global effects trigger at the same time

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -52,6 +52,10 @@ ClientField::~ClientField() {
 		delete card;
 	}
 	overlay_cards.clear();
+	for (auto& card : limbo_temp) {
+		delete card;
+	}
+	limbo_temp.clear();
 }
 void ClientField::Clear() {
 	for(int i = 0; i < 2; ++i) {
@@ -93,6 +97,10 @@ void ClientField::Clear() {
 		delete card;
 	}
 	overlay_cards.clear();
+	for (auto& card : limbo_temp) {
+		delete card;
+	}
+	limbo_temp.clear();
 	extra_p_count[0] = 0;
 	extra_p_count[1] = 0;
 	player_desc_hints[0].clear();

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -33,6 +33,7 @@ public:
 	std::vector<ClientCard*> remove[2];
 	std::vector<ClientCard*> extra[2];
 	std::set<ClientCard*> overlay_cards;
+	std::vector<ClientCard*> limbo_temp;
 
 	std::vector<ClientCard*> summonable_cards;
 	std::vector<ClientCard*> spsummonable_cards;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1343,6 +1343,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			seq = BufferIO::Read<uint8_t>(pbuf);
 			desc = BufferIO::Read<int32_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
+			if(!pcard) {
+				pcard = new ClientCard();
+				mainGame->dField.limbo_temp.push_back(pcard);
+			}
 			int flag = 0;
 			if(code & 0x80000000) {
 				flag = EDESC_OPERATION;
@@ -1475,6 +1479,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			seq = BufferIO::Read<uint8_t>(pbuf);
 			desc = BufferIO::Read<int32_t>(pbuf);
 			pcard = mainGame->dField.GetCard(con, loc, seq);
+			if(!pcard) {
+				pcard = new ClientCard();
+				mainGame->dField.limbo_temp.push_back(pcard);
+			}
 			int flag = 0;
 			if(code & 0x80000000) {
 				flag = EDESC_OPERATION;
@@ -1752,6 +1760,10 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			ss = BufferIO::Read<uint8_t>(pbuf);
 			desc = BufferIO::Read<int32_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s, ss);
+			if(!pcard) {
+				pcard = new ClientCard();
+				mainGame->dField.limbo_temp.push_back(pcard);
+			}
 			mainGame->dField.activatable_cards.push_back(pcard);
 			mainGame->dField.activatable_descs.push_back(std::make_pair(desc, flag));
 			pcard->is_selected = false;


### PR DESCRIPTION
When multiple global effects (registered via Duel.RegisterEffect with Effect.GlobalEffect) exist at the same event timing, the engine sends MSG_SELECT_CHAIN to the client. The handler card of global effects is temp_card, which has invalid location info (controler=0xFF, location=0xFF). This causes GetCard() to return nullptr, leading to null pointer dereference crash.

Fix by creating a temporary ClientCard via limbo_temp (existing mechanism used by MSG_SELECT_CARD for location=0 cards) when GetCard returns null.

Affected message handlers:
- MSG_SELECT_BATTLECMD
- MSG_SELECT_IDLECMD
- MSG_SELECT_CHAIN