### PR TITLE
add fallback for ImageManager::GetImage

### DIFF
--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -224,6 +224,8 @@ irr::video::IImage* ImageManager::GetImage(int code, irr::s32 targetWidth, irr::
 		return nullptr;
 	irr::video::IImage* img = ImageUtility::LoadJpegImage(driver, reader, targetWidth, targetHeight);
 	reader->drop();
+	if(img == nullptr) // fallback, file is ensured to be accessible already
+		img = driver->createImageFromFile(file);
 	return img;
 }
 /**


### PR DESCRIPTION
User may use a PNG image but rename it to .jpg manually. Fallback to support this case.