### PR TITLE
sort cards whose names exactly match the search query

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -603,5 +603,8 @@ bool DataManager::deck_sort_name(const CardDataC* p1, const CardDataC* p2) {
 		return res < 0;
 	return p1->code < p2->code;
 }
+bool DataManager::deck_sort_id(const CardDataC* p1, const CardDataC* p2) {
+	return p1->code < p2->code;
+}
 
 }

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -139,6 +139,7 @@ public:
 	static bool deck_sort_atk(const CardDataC* l1, const CardDataC* l2);
 	static bool deck_sort_def(const CardDataC* l1, const CardDataC* l2);
 	static bool deck_sort_name(const CardDataC* l1, const CardDataC* l2);
+	static bool deck_sort_id(const CardDataC* l1, const CardDataC* l2);
 
 private:
 	const wchar_t* GetMapString(const wstring_map& table, uint32_t code) const;

--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1639,6 +1639,7 @@ void DeckBuilder::SortList() {
 			++left;
 		}
 	}
+	std::sort(results.begin(), left, DataManager::deck_sort_id);
 	switch(mainGame->cbSortType->getSelected()) {
 	case 0:
 		std::sort(left, results.end(), DataManager::deck_sort_lv);


### PR DESCRIPTION
Currently, cards whose names exactly match the search query are moved to the front. However, the processing order may default to ID order, causing alternate-art cards to be handled last and finally making an alternate-art card always appear first.

This change adds a secondary sort to reorder the exact-match cards by ID, ensuring they are displayed in the correct order.