### PR TITLE
fix RefreshSingle

### DIFF
--- a/gframe/network.h
+++ b/gframe/network.h
@@ -197,12 +197,6 @@ struct DuelPlayer {
 	bufferevent* bev{};
 };
 
-inline unsigned int GetPosition(unsigned char* qbuf, size_t offset) {
-	unsigned int info = 0;
-	std::memcpy(&info, qbuf + offset, sizeof info);
-	return info >> 24;
-}
-
 class DuelMode {
 public:
 	DuelMode() = default;

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -197,6 +197,12 @@ struct DuelPlayer {
 	bufferevent* bev{};
 };
 
+inline unsigned int GetPosition(unsigned char* qbuf, size_t offset) {
+	unsigned int info = 0;
+	std::memcpy(&info, qbuf + offset, sizeof info);
+	return info >> 24;
+}
+
 class DuelMode {
 public:
 	DuelMode() = default;

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1485,7 +1485,7 @@ void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = qbuf[11];
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1506,7 +1506,7 @@ void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = qbuf[11];
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1527,7 +1527,7 @@ void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
 		qlen += slen;
 		if (slen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = qbuf[11];
 		if(!(position & POS_FACEUP))
 			std::memset(qbuf, 0, slen - 4);
 		qbuf += slen - 4;
@@ -1566,7 +1566,7 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	if (len <= LEN_HEADER)
 		return;
 	const int clen = BufferIO::Read<int32_t>(qbuf);
-	auto position = GetPosition(qbuf, 8);
+	auto position = qbuf[11];
 	if (position & POS_FACEDOWN) {
 		BufferIO::Write<int32_t>(qbuf, QUERY_CODE);
 		BufferIO::Write<int32_t>(qbuf, 0);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1565,12 +1565,13 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer, len + 4);
 	if (len <= LEN_HEADER)
 		return;
-	const int clen = BufferIO::Read<int32_t>(qbuf);
-	auto position = qbuf[11];
+	auto position = qbuf[15];
 	if (position & POS_FACEDOWN) {
-		BufferIO::Write<int32_t>(qbuf, QUERY_CODE);
-		BufferIO::Write<int32_t>(qbuf, 0);
-		std::memset(qbuf, 0, clen - 12);
+		BufferIO::Write<int32_t>(qbuf, 16);
+		BufferIO::Write<uint32_t>(qbuf, QUERY_CODE | QUERY_POSITION);
+		BufferIO::Write<uint32_t>(qbuf, 0);
+		// keep the 4 bytes position data
+		len = 16;
 	}
 	NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, query_buffer, len + 4);
 	for (auto pit = observers.begin(); pit != observers.end(); ++pit)

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1485,7 +1485,7 @@ void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = qbuf[11];
+		auto position = GetPosition(qbuf, 8);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1506,7 +1506,7 @@ void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = qbuf[11];
+		auto position = GetPosition(qbuf, 8);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1527,7 +1527,7 @@ void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
 		qlen += slen;
 		if (slen <= LEN_HEADER)
 			continue;
-		auto position = qbuf[11];
+		auto position = GetPosition(qbuf, 8);
 		if(!(position & POS_FACEUP))
 			std::memset(qbuf, 0, slen - 4);
 		qbuf += slen - 4;
@@ -1565,7 +1565,7 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer, len + 4);
 	if (len <= LEN_HEADER)
 		return;
-	auto position = qbuf[15];
+	auto position = GetPosition(qbuf, 12);
 	if (position & POS_FACEDOWN) {
 		BufferIO::Write<int32_t>(qbuf, 16);
 		BufferIO::Write<uint32_t>(qbuf, QUERY_CODE | QUERY_POSITION);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1601,7 +1601,7 @@ void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = qbuf[11];
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1626,7 +1626,7 @@ void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = qbuf[11];
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1649,7 +1649,7 @@ void TagDuel::RefreshHand(int player, int flag, int use_cache) {
 		qlen += slen;
 		if (slen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = qbuf[11];
 		if(!(position & POS_FACEUP))
 			std::memset(qbuf, 0, slen - 4);
 		qbuf += slen - 4;
@@ -1688,7 +1688,8 @@ void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	BufferIO::Write<uint8_t>(qbuf, location);
 	BufferIO::Write<uint8_t>(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
-	auto position = GetPosition(qbuf, 12);
+	const int clen = BufferIO::Read<int32_t>(qbuf);
+	auto position = qbuf[11];
 	if(location & LOCATION_ONFIELD) {
 		int pid = (player == 0) ? 0 : 2;
 		NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1601,7 +1601,7 @@ void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = qbuf[11];
+		auto position = GetPosition(qbuf, 8);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1626,7 +1626,7 @@ void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = qbuf[11];
+		auto position = GetPosition(qbuf, 8);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1649,7 +1649,7 @@ void TagDuel::RefreshHand(int player, int flag, int use_cache) {
 		qlen += slen;
 		if (slen <= LEN_HEADER)
 			continue;
-		auto position = qbuf[11];
+		auto position = GetPosition(qbuf, 8);
 		if(!(position & POS_FACEUP))
 			std::memset(qbuf, 0, slen - 4);
 		qbuf += slen - 4;
@@ -1693,7 +1693,7 @@ void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	NetServer::ReSendToPlayer(players[pid + 1]);
 	if (len <= LEN_HEADER)
 		return;
-	auto position = qbuf[15];
+	auto position = GetPosition(qbuf, 12);
 	if (position & POS_FACEDOWN) {
 		BufferIO::Write<int32_t>(qbuf, 16);
 		BufferIO::Write<uint32_t>(qbuf, QUERY_CODE | QUERY_POSITION);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1688,33 +1688,24 @@ void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	BufferIO::Write<uint8_t>(qbuf, location);
 	BufferIO::Write<uint8_t>(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
-	const int clen = BufferIO::Read<int32_t>(qbuf);
-	auto position = qbuf[11];
-	if(location & LOCATION_ONFIELD) {
-		int pid = (player == 0) ? 0 : 2;
-		NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);
-		NetServer::ReSendToPlayer(players[pid + 1]);
-		if(position & POS_FACEUP) {
-			pid = 2 - pid;
-			NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);
-			NetServer::ReSendToPlayer(players[pid + 1]);
-			for(auto pit = observers.begin(); pit != observers.end(); ++pit)
-				NetServer::ReSendToPlayer(*pit);
-		}
-	} else {
-		int pid = (player == 0) ? 0 : 2;
-		NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);
-		NetServer::ReSendToPlayer(players[pid + 1]);
-		if(location == LOCATION_REMOVED && (position & POS_FACEDOWN))
-			return;
-		if (location & 0x90) {
-			for(int i = 0; i < 4; ++i)
-				if(players[i] != cur_player[player])
-					NetServer::ReSendToPlayer(players[i]);
-			for(auto pit = observers.begin(); pit != observers.end(); ++pit)
-				NetServer::ReSendToPlayer(*pit);
-		}
+	int pid = (player == 0) ? 0 : 2;
+	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);
+	NetServer::ReSendToPlayer(players[pid + 1]);
+	if (len <= LEN_HEADER)
+		return;
+	auto position = qbuf[15];
+	if (position & POS_FACEDOWN) {
+		BufferIO::Write<int32_t>(qbuf, 16);
+		BufferIO::Write<uint32_t>(qbuf, QUERY_CODE | QUERY_POSITION);
+		BufferIO::Write<uint32_t>(qbuf, 0);
+		// keep the 4 bytes position data
+		len = 16;
 	}
+	pid = 2 - pid;
+	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);
+	NetServer::ReSendToPlayer(players[pid + 1]);
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+		NetServer::ReSendToPlayer(*pit);
 }
 uint32_t TagDuel::MessageHandler(intptr_t fduel, uint32_t type) {
 	char msgbuf[1024];


### PR DESCRIPTION
* ~~Removed the `GetPosition` function~~
  ~~The codebase makes extensive use of hard-coded magic-number indices, and retrieving a card position is no exception. Since this function still requires a magic-number parameter, it reduces readability rather than improving it.~~

* Changed the handling of face-down cards in `SingleDuel::RefreshSingle` from preserving only `QUERY_CODE` to preserving `QUERY_POSITION`
  Position information is also worth refreshing. In addition, the full query buffer is no longer erased and sent; only the initial portion is transmitted.

* Synchronized `TagDuel::RefreshSingle` with `SingleDuel` and removed legacy logic
  The [face-down card handling logic](https://github.com/Fluorohydride/ygopro/commit/ee5fea7e0297af10cd3035d095858684c2247a73) in `SingleDuel::RefreshSingle` appears didn't cause any problem, so `TagDuel` can be simplified accordingly. Also fixed an issue where data was being sent to 3 instead of 2 players.
