### PR TITLE
use std::array for query buffers

### DIFF
--- a/gframe/network.h
+++ b/gframe/network.h
@@ -197,9 +197,9 @@ struct DuelPlayer {
 	bufferevent* bev{};
 };
 
-inline unsigned int GetPosition(unsigned char* qbuf) {
+inline unsigned int GetPosition(unsigned char* qbuf, size_t offset) {
 	unsigned int info = 0;
-	std::memcpy(&info, qbuf + 2 * sizeof(uint32_t), sizeof info);	// skip flag, code
+	std::memcpy(&info, qbuf + offset, sizeof info);
 	return info >> 24;
 }
 

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -197,9 +197,9 @@ struct DuelPlayer {
 	bufferevent* bev{};
 };
 
-inline unsigned int GetPosition(unsigned char* qbuf, size_t offset) {
+inline unsigned int GetPosition(unsigned char* qbuf) {
 	unsigned int info = 0;
-	std::memcpy(&info, qbuf + offset, sizeof info);
+	std::memcpy(&info, qbuf + 2 * sizeof(uint32_t), sizeof info);	// skip flag, code
 	return info >> 24;
 }
 

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include "config.h"
 #include "single_duel.h"
 #include "netserver.h"
@@ -1465,7 +1466,7 @@ void SingleDuel::TimeConfirm(DuelPlayer* dp) {
 	if(time_elapsed < 10)
 		time_elapsed = 0;
 }
-inline int SingleDuel::WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache) {
+inline int SingleDuel::WriteUpdateData(int player, int location, unsigned int flag, unsigned char*& qbuf, int use_cache) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
 	BufferIO::Write<uint8_t>(qbuf, MSG_UPDATE_DATA);
 	BufferIO::Write<uint8_t>(qbuf, player);
@@ -1474,8 +1475,7 @@ inline int SingleDuel::WriteUpdateData(int& player, int location, int& flag, uns
 	return len;
 }
 void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
-	std::vector<unsigned char> query_buffer;
-	query_buffer.resize(SIZE_QUERY_BUFFER);
+	std::array<unsigned char, SIZE_QUERY_BUFFER> query_buffer;
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_MZONE, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
@@ -1495,8 +1495,7 @@ void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 		NetServer::ReSendToPlayer(*pit);
 }
 void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
-	std::vector<unsigned char> query_buffer;
-	query_buffer.resize(SIZE_QUERY_BUFFER);
+	std::array<unsigned char, SIZE_QUERY_BUFFER> query_buffer;
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_SZONE, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
@@ -1516,8 +1515,7 @@ void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 		NetServer::ReSendToPlayer(*pit);
 }
 void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
-	std::vector<unsigned char> query_buffer;
-	query_buffer.resize(SIZE_QUERY_BUFFER);
+	std::array<unsigned char, SIZE_QUERY_BUFFER> query_buffer;
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_HAND, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
@@ -1537,8 +1535,7 @@ void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
 		NetServer::ReSendToPlayer(*pit);
 }
 void SingleDuel::RefreshGrave(int player, int flag, int use_cache) {
-	std::vector<unsigned char> query_buffer;
-	query_buffer.resize(SIZE_QUERY_BUFFER);
+	std::array<unsigned char, SIZE_QUERY_BUFFER> query_buffer;
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_GRAVE, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, query_buffer.data(), len + 3);
@@ -1547,8 +1544,7 @@ void SingleDuel::RefreshGrave(int player, int flag, int use_cache) {
 		NetServer::ReSendToPlayer(*pit);
 }
 void SingleDuel::RefreshExtra(int player, int flag, int use_cache) {
-	std::vector<unsigned char> query_buffer;
-	query_buffer.resize(SIZE_QUERY_BUFFER);
+	std::array<unsigned char, SIZE_QUERY_BUFFER> query_buffer;
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_EXTRA, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1485,7 +1485,7 @@ void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = GetPosition(qbuf);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1505,7 +1505,7 @@ void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = GetPosition(qbuf);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1525,7 +1525,7 @@ void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
 		qlen += slen;
 		if (slen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = GetPosition(qbuf);
 		if(!(position & POS_FACEUP))
 			std::memset(qbuf, 0, slen - 4);
 		qbuf += slen - 4;
@@ -1562,7 +1562,7 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	if (len <= LEN_HEADER)
 		return;
 	const int clen = BufferIO::Read<int32_t>(qbuf);
-	auto position = GetPosition(qbuf, 8);
+	auto position = GetPosition(qbuf);
 	if (position & POS_FACEDOWN) {
 		BufferIO::Write<int32_t>(qbuf, QUERY_CODE);
 		BufferIO::Write<int32_t>(qbuf, 0);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1485,7 +1485,7 @@ void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf);
+		auto position = GetPosition(qbuf, 8);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1505,7 +1505,7 @@ void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf);
+		auto position = GetPosition(qbuf, 8);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1525,7 +1525,7 @@ void SingleDuel::RefreshHand(int player, int flag, int use_cache) {
 		qlen += slen;
 		if (slen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf);
+		auto position = GetPosition(qbuf, 8);
 		if(!(position & POS_FACEUP))
 			std::memset(qbuf, 0, slen - 4);
 		qbuf += slen - 4;
@@ -1562,7 +1562,7 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	if (len <= LEN_HEADER)
 		return;
 	const int clen = BufferIO::Read<int32_t>(qbuf);
-	auto position = GetPosition(qbuf);
+	auto position = GetPosition(qbuf, 8);
 	if (position & POS_FACEDOWN) {
 		BufferIO::Write<int32_t>(qbuf, QUERY_CODE);
 		BufferIO::Write<int32_t>(qbuf, 0);

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -43,7 +43,7 @@ public:
 	static void SingleTimer(evutil_socket_t fd, short events, void* arg);
 
 private:
-	int WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache);
+	int WriteUpdateData(int player, int location, unsigned int flag, unsigned char*& qbuf, int use_cache);
 	
 protected:
 	DuelPlayer* players[2]{};

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1597,11 +1597,11 @@ void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 	NetServer::ReSendToPlayer(players[pid + 1]);
 	int qlen = 0;
 	while(qlen < len) {
-		int clen = BufferIO::Read<int32_t>(qbuf);
+		const int clen = BufferIO::Read<int32_t>(qbuf);
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = GetPosition(qbuf);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1621,11 +1621,11 @@ void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 	NetServer::ReSendToPlayer(players[pid + 1]);
 	int qlen = 0;
 	while(qlen < len) {
-		int clen = BufferIO::Read<int32_t>(qbuf);
+		const int clen = BufferIO::Read<int32_t>(qbuf);
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = GetPosition(qbuf);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1643,11 +1643,11 @@ void TagDuel::RefreshHand(int player, int flag, int use_cache) {
 	NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	int qlen = 0;
 	while(qlen < len) {
-		int slen = BufferIO::Read<int32_t>(qbuf);
+		const int slen = BufferIO::Read<int32_t>(qbuf);
 		qlen += slen;
 		if (slen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf, 8);
+		auto position = GetPosition(qbuf);
 		if(!(position & POS_FACEUP))
 			std::memset(qbuf, 0, slen - 4);
 		qbuf += slen - 4;
@@ -1684,7 +1684,8 @@ void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	BufferIO::Write<uint8_t>(qbuf, location);
 	BufferIO::Write<uint8_t>(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
-	auto position = GetPosition(qbuf, 12);
+	const int clen = BufferIO::Read<int32_t>(qbuf);
+	auto position = GetPosition(qbuf);
 	if(location & LOCATION_ONFIELD) {
 		int pid = (player == 0) ? 0 : 2;
 		NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1597,11 +1597,11 @@ void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 	NetServer::ReSendToPlayer(players[pid + 1]);
 	int qlen = 0;
 	while(qlen < len) {
-		const int clen = BufferIO::Read<int32_t>(qbuf);
+		int clen = BufferIO::Read<int32_t>(qbuf);
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf);
+		auto position = GetPosition(qbuf, 8);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1621,11 +1621,11 @@ void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 	NetServer::ReSendToPlayer(players[pid + 1]);
 	int qlen = 0;
 	while(qlen < len) {
-		const int clen = BufferIO::Read<int32_t>(qbuf);
+		int clen = BufferIO::Read<int32_t>(qbuf);
 		qlen += clen;
 		if (clen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf);
+		auto position = GetPosition(qbuf, 8);
 		if (position & POS_FACEDOWN)
 			std::memset(qbuf, 0, clen - 4);
 		qbuf += clen - 4;
@@ -1643,11 +1643,11 @@ void TagDuel::RefreshHand(int player, int flag, int use_cache) {
 	NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	int qlen = 0;
 	while(qlen < len) {
-		const int slen = BufferIO::Read<int32_t>(qbuf);
+		int slen = BufferIO::Read<int32_t>(qbuf);
 		qlen += slen;
 		if (slen <= LEN_HEADER)
 			continue;
-		auto position = GetPosition(qbuf);
+		auto position = GetPosition(qbuf, 8);
 		if(!(position & POS_FACEUP))
 			std::memset(qbuf, 0, slen - 4);
 		qbuf += slen - 4;
@@ -1684,8 +1684,7 @@ void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	BufferIO::Write<uint8_t>(qbuf, location);
 	BufferIO::Write<uint8_t>(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
-	const int clen = BufferIO::Read<int32_t>(qbuf);
-	auto position = GetPosition(qbuf);
+	auto position = GetPosition(qbuf, 12);
 	if(location & LOCATION_ONFIELD) {
 		int pid = (player == 0) ? 0 : 2;
 		NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include "config.h"
 #include "tag_duel.h"
 #include "netserver.h"
@@ -1579,7 +1580,7 @@ void TagDuel::TimeConfirm(DuelPlayer* dp) {
 	if(time_elapsed < 10)
 		time_elapsed = 0;
 }
-inline int TagDuel::WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache) {
+inline int TagDuel::WriteUpdateData(int player, int location, unsigned int flag, unsigned char*& qbuf, int use_cache) {
 	flag |= (QUERY_CODE | QUERY_POSITION);
 	BufferIO::Write<uint8_t>(qbuf, MSG_UPDATE_DATA);
 	BufferIO::Write<uint8_t>(qbuf, player);
@@ -1588,8 +1589,7 @@ inline int TagDuel::WriteUpdateData(int& player, int location, int& flag, unsign
 	return len;
 }
 void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
-	std::vector<unsigned char> query_buffer;
-	query_buffer.resize(SIZE_QUERY_BUFFER);
+	std::array<unsigned char, SIZE_QUERY_BUFFER> query_buffer;
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_MZONE, flag, qbuf, use_cache);
 	int pid = (player == 0) ? 0 : 2;
@@ -1613,8 +1613,7 @@ void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 		NetServer::ReSendToPlayer(*pit);
 }
 void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
-	std::vector<unsigned char> query_buffer;
-	query_buffer.resize(SIZE_QUERY_BUFFER);
+	std::array<unsigned char, SIZE_QUERY_BUFFER> query_buffer;
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_SZONE, flag, qbuf, use_cache);
 	int pid = (player == 0) ? 0 : 2;
@@ -1638,8 +1637,7 @@ void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 		NetServer::ReSendToPlayer(*pit);
 }
 void TagDuel::RefreshHand(int player, int flag, int use_cache) {
-	std::vector<unsigned char> query_buffer;
-	query_buffer.resize(SIZE_QUERY_BUFFER);
+	std::array<unsigned char, SIZE_QUERY_BUFFER> query_buffer;
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_HAND, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
@@ -1661,8 +1659,7 @@ void TagDuel::RefreshHand(int player, int flag, int use_cache) {
 		NetServer::ReSendToPlayer(*pit);
 }
 void TagDuel::RefreshGrave(int player, int flag, int use_cache) {
-	std::vector<unsigned char> query_buffer;
-	query_buffer.resize(SIZE_QUERY_BUFFER);
+	std::array<unsigned char, SIZE_QUERY_BUFFER> query_buffer;
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_GRAVE, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, query_buffer.data(), len + 3);
@@ -1673,8 +1670,7 @@ void TagDuel::RefreshGrave(int player, int flag, int use_cache) {
 		NetServer::ReSendToPlayer(*pit);
 }
 void TagDuel::RefreshExtra(int player, int flag, int use_cache) {
-	std::vector<unsigned char> query_buffer;
-	query_buffer.resize(SIZE_QUERY_BUFFER);
+	std::array<unsigned char, SIZE_QUERY_BUFFER> query_buffer;
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_EXTRA, flag, qbuf, use_cache);
 	NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, query_buffer.data(), len + 3);

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -43,7 +43,7 @@ public:
 	static void TagTimer(evutil_socket_t fd, short events, void* arg);
 
 private:
-	int WriteUpdateData(int& player, int location, int& flag, unsigned char*& qbuf, int& use_cache);
+	int WriteUpdateData(int player, int location, unsigned int flag, unsigned char*& qbuf, int use_cache);
 	
 protected:
 	DuelPlayer* players[4];


### PR DESCRIPTION
## update WriteUpdateData parameters 
Remove unnecessary reference parameters.

## use std::array for query buffers in SingleDuel and TagDuel 
16K buffer should be allocated on stack.


## About GetPosition
ocgcore packs 4 bytes into 1 uint32, and the result of `get_infos` is an array of int32/uint32.
Reading the bytes in `info` directly is wrong.

get_infos
Header:
uint32_t clen
length of this card

uint32_t flag
query flag

Content:
Array of uint32_t or int32_t


The flag `QUERY_CODE`. `QUERY_POSITION` is always set in WriteUpdateData
So the first 4 uint32 is always:
Header:
clen
flag

Content:
uint32_t code 
the result of QUERY_CODE

uint32_t info 
the result of QUERY_POSITION
from `get_info_location`

After reading clen, qbuf is at the beginning of flag.
GetPosition always skip the next 2 uint32 (flag, code) and read info directly.



