### PR TITLE
Fix replay response recording for retry handling

### DIFF
--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -215,9 +215,9 @@ bool Replay::RenameReplay(const wchar_t* oldname, const wchar_t* newname) {
 }
 bool Replay::ReadNextResponse(unsigned char resp[]) {
 	uint8_t len{};
-	if(!ReadData(&len, sizeof len))
+	if (!ReadData(&len, sizeof len))
 		return false;
-	if(!ReadData(resp, len))
+	if (!ReadData(resp, len))
 		return false;
 	return true;
 }

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -50,20 +50,13 @@ void Replay::WriteInt32(int32_t data, bool flush) {
 size_t Replay::WriteResponse(const void* data, size_t length) {
 	if(!is_recording || !data)
 		return 0;
-	const size_t response_length = std::min<size_t>(length, SIZE_RETURN_VALUE);
+	const size_t response_length = std::min<size_t>(length, UINT8_MAX);
 	if(!response_length)
 		return 0;
-	const bool extended = response_length > UINT8_MAX;
-	const size_t prefix_length = extended ? sizeof(uint8_t) + sizeof(uint16_t) : sizeof(uint8_t);
-	const size_t total_length = prefix_length + response_length;
+	const size_t total_length = sizeof(uint8_t) + response_length;
 	if(total_length > MAX_REPLAY_SIZE - replay_size)
 		return 0;
-	if(extended) {
-		Write<uint8_t>(0, false);
-		Write<uint16_t>(static_cast<uint16_t>(response_length), false);
-	} else {
-		Write<uint8_t>(static_cast<uint8_t>(response_length), false);
-	}
+	Write<uint8_t>(static_cast<uint8_t>(response_length), false);
 	WriteData(data, response_length);
 	return total_length;
 }
@@ -224,14 +217,9 @@ bool Replay::ReadNextResponse(unsigned char resp[]) {
 	uint8_t len{};
 	if(!ReadData(&len, sizeof len))
 		return false;
-	std::memset(resp, 0, SIZE_RETURN_VALUE);
-	if(len)
-		return ReadData(resp, len);
-	uint16_t extended_length{};
-	if(!ReadData(&extended_length, sizeof extended_length))
+	if(!ReadData(resp, len))
 		return false;
-	const size_t response_length = std::min<size_t>(extended_length, SIZE_RETURN_VALUE);
-	return ReadData(resp, response_length);
+	return true;
 }
 bool Replay::ReadName(wchar_t* data) {
 	uint16_t buffer[20]{};

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -230,16 +230,8 @@ bool Replay::ReadNextResponse(unsigned char resp[]) {
 	uint16_t extended_length{};
 	if(!ReadData(&extended_length, sizeof extended_length))
 		return false;
-	const size_t response_length = extended_length;
-	if(response_length > replay_size - data_position) {
-		can_read = false;
-		return false;
-	}
-	const size_t copy_length = std::min<size_t>(response_length, SIZE_RETURN_VALUE);
-	if(copy_length)
-		std::memcpy(resp, replay_data + data_position, copy_length);
-	data_position += response_length;
-	return true;
+	const size_t response_length = std::min<size_t>(extended_length, SIZE_RETURN_VALUE);
+	return ReadData(resp, response_length);
 }
 bool Replay::ReadName(wchar_t* data) {
 	uint16_t buffer[20]{};

--- a/gframe/replay.cpp
+++ b/gframe/replay.cpp
@@ -47,6 +47,38 @@ void Replay::WriteData(const void* data, size_t length, bool flush) {
 void Replay::WriteInt32(int32_t data, bool flush) {
 	Write<int32_t>(data, flush);
 }
+size_t Replay::WriteResponse(const void* data, size_t length) {
+	if(!is_recording || !data)
+		return 0;
+	const size_t response_length = std::min<size_t>(length, SIZE_RETURN_VALUE);
+	if(!response_length)
+		return 0;
+	const bool extended = response_length > UINT8_MAX;
+	const size_t prefix_length = extended ? sizeof(uint8_t) + sizeof(uint16_t) : sizeof(uint8_t);
+	const size_t total_length = prefix_length + response_length;
+	if(total_length > MAX_REPLAY_SIZE - replay_size)
+		return 0;
+	if(extended) {
+		Write<uint8_t>(0, false);
+		Write<uint16_t>(static_cast<uint16_t>(response_length), false);
+	} else {
+		Write<uint8_t>(static_cast<uint8_t>(response_length), false);
+	}
+	WriteData(data, response_length);
+	return total_length;
+}
+bool Replay::RemoveData(size_t length) {
+	if(!is_recording)
+		return false;
+	if(length > replay_size)
+		return false;
+	replay_size -= length;
+	if(fp) {
+		std::fflush(fp);
+		std::fseek(fp, -static_cast<long>(length), SEEK_CUR);
+	}
+	return true;
+}
 void Replay::Flush() {
 	if(!is_recording)
 		return;
@@ -189,11 +221,24 @@ bool Replay::RenameReplay(const wchar_t* oldname, const wchar_t* newname) {
 	return FileSystem::Rename(old_path, new_path);
 }
 bool Replay::ReadNextResponse(unsigned char resp[]) {
-	unsigned char len{};
-	if (!ReadData(&len, sizeof len))
+	uint8_t len{};
+	if(!ReadData(&len, sizeof len))
 		return false;
-	if (!ReadData(resp, len))
+	std::memset(resp, 0, SIZE_RETURN_VALUE);
+	if(len)
+		return ReadData(resp, len);
+	uint16_t extended_length{};
+	if(!ReadData(&extended_length, sizeof extended_length))
 		return false;
+	const size_t response_length = extended_length;
+	if(response_length > replay_size - data_position) {
+		can_read = false;
+		return false;
+	}
+	const size_t copy_length = std::min<size_t>(response_length, SIZE_RETURN_VALUE);
+	if(copy_length)
+		std::memcpy(resp, replay_data + data_position, copy_length);
+	data_position += response_length;
 	return true;
 }
 bool Replay::ReadName(wchar_t* data) {

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -63,6 +63,8 @@ public:
 		WriteData(&data, sizeof(T), flush);
 	}
 	void WriteInt32(int32_t data, bool flush = true);
+	size_t WriteResponse(const void* data, size_t length);
+	bool RemoveData(size_t length);
 	void Flush();
 	void EndRecord();
 	bool SaveReplay(const wchar_t* base_name);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -579,6 +579,10 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		unsigned char engType = BufferIO::Read<uint8_t>(pbuf);
 		switch (engType) {
 		case MSG_RETRY: {
+			if(last_replay_response_size) {
+				last_replay.RemoveData(last_replay_response_size);
+				last_replay_response_size = 0;
+			}
 			WaitforResponse(last_response);
 			NetServer::SendBufferToPlayer(players[last_response], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
@@ -1414,8 +1418,7 @@ void SingleDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int 
 	if (len > SIZE_RETURN_VALUE)
 		len = SIZE_RETURN_VALUE;
 	std::memcpy(resb, pdata, len);
-	last_replay.Write<uint8_t>(len);
-	last_replay.WriteData(resb, len);
+	last_replay_response_size = last_replay.WriteResponse(resb, len);
 	set_responseb(pduel, resb);
 	players[dp->type]->state = 0xff;
 	if(host_info.time_limit) {
@@ -1425,6 +1428,7 @@ void SingleDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int 
 		time_elapsed = 0;
 	}
 	Process();
+	last_replay_response_size = 0;
 }
 void SingleDuel::EndDuel() {
 	if(!pduel)

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -55,7 +55,7 @@ protected:
 	unsigned char last_response{ 0 };
 	std::set<DuelPlayer*> observers;
 	Replay last_replay;
-	size_t last_replay_response_size{};
+	size_t last_replay_response_size{ 0 };
 	bool match_mode{ false };
 	int match_kill{ 0 };
 	unsigned char duel_count{ 0 };

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -55,6 +55,7 @@ protected:
 	unsigned char last_response{ 0 };
 	std::set<DuelPlayer*> observers;
 	Replay last_replay;
+	size_t last_replay_response_size{};
 	bool match_mode{ false };
 	int match_kill{ 0 };
 	unsigned char duel_count{ 0 };

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -25,8 +25,7 @@ void SingleMode::StopPlay(bool is_exiting) {
 void SingleMode::SetResponse(unsigned char* resp, unsigned int len) {
 	if(!pduel)
 		return;
-	last_replay.Write<uint8_t>(len);
-	last_replay.WriteData(resp, len);
+	last_replay.WriteResponse(resp, len);
 	set_responseb(pduel, resp);
 }
 int SingleMode::SinglePlayThread() {

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -11,6 +11,7 @@ intptr_t SingleMode::pduel = 0;
 bool SingleMode::is_closing = false;
 bool SingleMode::is_continuing = false;
 Replay SingleMode::last_replay;
+size_t SingleMode::last_replay_response_size = 0;
 
 bool SingleMode::StartPlay() {
 	std::thread(SinglePlayThread).detach();
@@ -25,7 +26,7 @@ void SingleMode::StopPlay(bool is_exiting) {
 void SingleMode::SetResponse(unsigned char* resp, unsigned int len) {
 	if(!pduel)
 		return;
-	last_replay.WriteResponse(resp, len);
+	last_replay_response_size = last_replay.WriteResponse(resp, len);
 	set_responseb(pduel, resp);
 }
 int SingleMode::SinglePlayThread() {
@@ -111,6 +112,7 @@ int SingleMode::SinglePlayThread() {
 	if (len > 0)
 		is_continuing = SinglePlayAnalyze(engineBuffer.data(), len);
 	last_replay.BeginRecord();
+	last_replay_response_size = 0;
 	last_replay.WriteHeader(rh);
 	uint16_t host_name[20]{};
 	BufferIO::CopyCharArray(mainGame->dInfo.hostname, host_name);
@@ -190,6 +192,10 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 		mainGame->dInfo.curMsg = BufferIO::Read<uint8_t>(pbuf);
 		switch (mainGame->dInfo.curMsg) {
 		case MSG_RETRY: {
+			if(last_replay_response_size) {
+				last_replay.RemoveData(last_replay_response_size);
+				last_replay_response_size = 0;
+			}
 			if(!DuelClient::ClientAnalyze(offset, pbuf - offset)) {
 				mainGame->singleSignal.Reset();
 				mainGame->singleSignal.Wait();

--- a/gframe/single_mode.h
+++ b/gframe/single_mode.h
@@ -34,6 +34,7 @@ public:
 
 protected:
 	static Replay last_replay;
+	static size_t last_replay_response_size;
 };
 
 }

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -544,6 +544,10 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 		unsigned char engType = BufferIO::Read<uint8_t>(pbuf);
 		switch (engType) {
 		case MSG_RETRY: {
+			if(last_replay_response_size) {
+				last_replay.RemoveData(last_replay_response_size);
+				last_replay_response_size = 0;
+			}
 			WaitforResponse(last_response);
 			NetServer::SendBufferToPlayer(cur_player[last_response], STOC_GAME_MSG, offset, pbuf - offset);
 			return 1;
@@ -1521,8 +1525,7 @@ void TagDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len
 	if (len > SIZE_RETURN_VALUE)
 		len = SIZE_RETURN_VALUE;
 	std::memcpy(resb, pdata, len);
-	last_replay.Write<uint8_t>(len);
-	last_replay.WriteData(resb, len);
+	last_replay_response_size = last_replay.WriteResponse(resb, len);
 	set_responseb(pduel, resb);
 	players[dp->type]->state = 0xff;
 	if(host_info.time_limit) {
@@ -1533,6 +1536,7 @@ void TagDuel::GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len
 		time_elapsed = 0;
 	}
 	Process();
+	last_replay_response_size = 0;
 }
 void TagDuel::EndDuel() {
 	if(!pduel)

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -57,6 +57,7 @@ protected:
 	unsigned char hand_result[2];
 	unsigned char last_response;
 	Replay last_replay;
+	size_t last_replay_response_size{};
 	unsigned char turn_count;
 	short time_limit[2];
 	short time_elapsed;

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -57,7 +57,7 @@ protected:
 	unsigned char hand_result[2];
 	unsigned char last_response;
 	Replay last_replay;
-	size_t last_replay_response_size{};
+	size_t last_replay_response_size{ 0 };
 	unsigned char turn_count;
 	short time_limit[2];
 	short time_elapsed;


### PR DESCRIPTION
solves https://github.com/Fluorohydride/ygopro/issues/3113

Previous issue: replay response recording wrote length and payload directly at each call site, while retry handling did not remove the response that had just been recorded before the engine requested the same response again.

Impact: a replay could keep an extra stale response after `MSG_RETRY`, causing later replay playback to consume responses out of order. Oversized response payloads could also leave the encoded length and written payload size inconsistent.

Fix: centralize response recording in `Replay::WriteResponse`, cap recorded payloads to `UINT8_MAX`, and return the actual encoded byte count. Single and tag duels now remember that byte count and remove the last recorded response when `MSG_RETRY` occurs before requesting the response again.