### PR TITLE
Prevent opening hand result changes before duel start

### DIFF
--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -354,9 +354,11 @@ void SingleDuel::StartDuel(DuelPlayer* dp) {
 	duel_stage = DUEL_STAGE_FINGER;
 }
 void SingleDuel::HandResult(DuelPlayer* dp, unsigned char res) {
-	if(res > 3)
+	if(res == 0 || res > 3)
 		return;
 	if(dp->state != CTOS_HAND_RESULT)
+		return;
+	if(hand_result[dp->type])
 		return;
 	hand_result[dp->type] = res;
 	if(hand_result[0] && hand_result[1]) {

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -354,13 +354,12 @@ void SingleDuel::StartDuel(DuelPlayer* dp) {
 	duel_stage = DUEL_STAGE_FINGER;
 }
 void SingleDuel::HandResult(DuelPlayer* dp, unsigned char res) {
-	if(res == 0 || res > 3)
+	if(res == 0 || res > 3 || dp->state != CTOS_HAND_RESULT)
 		return;
-	if(dp->state != CTOS_HAND_RESULT)
+	auto player = dp->type;
+	if(hand_result[player])
 		return;
-	if(hand_result[dp->type])
-		return;
-	hand_result[dp->type] = res;
+	hand_result[player] = res;
 	if(hand_result[0] && hand_result[1]) {
 		STOC_HandResult schr;
 		schr.res1 = hand_result[0];

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -320,12 +320,12 @@ void TagDuel::StartDuel(DuelPlayer* dp) {
 	duel_stage = DUEL_STAGE_FINGER;
 }
 void TagDuel::HandResult(DuelPlayer* dp, unsigned char res) {
-	if(res > 3 || dp->state != CTOS_HAND_RESULT)
+	if(res == 0 || res > 3 || dp->state != CTOS_HAND_RESULT)
 		return;
-	if(dp->type == 0)
-		hand_result[0] = res;
-	else
-		hand_result[1] = res;
+	auto player = (dp->type & 0x2) >> 1;
+	if(hand_result[player])
+		return;
+	hand_result[player] = res;
 	if(hand_result[0] && hand_result[1]) {
 		STOC_HandResult schr;
 		schr.res1 = hand_result[0];


### PR DESCRIPTION
## Summary
- Reject `0` as an invalid opening hand result.
- Ignore repeated opening hand result packets once a side has already submitted.
- Use the tag duel team bit to resolve which side's hand result is being submitted.

## Notes
This keeps the opening rock-paper-scissors result stable after the first valid submission, while still allowing a new submission round after a draw resets the stored results.