### PR TITLE
add filtering OCG/TCG exclusive cards

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1552,7 +1552,11 @@ void DeckBuilder::FilterCards() {
 				continue;
 			if(filter_lm == 7 && !(data.ot & AVAIL_CUSTOM))
 				continue;
-			if(filter_lm == 8 && ((data.ot & AVAIL_OCGTCG) != AVAIL_OCGTCG))
+			if(filter_lm == 8 && (!(data.ot & AVAIL_OCG) || (data.ot & AVAIL_TCG)))
+				continue;
+			if(filter_lm == 9 && (!(data.ot & AVAIL_TCG) || (data.ot & AVAIL_OCG)))
+				continue;
+			if(filter_lm == 10 && ((data.ot & AVAIL_OCGTCG) != AVAIL_OCGTCG))
 				continue;
 		}
 		bool is_target = true;

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1205,7 +1205,9 @@ void Game::DrawThumb(const CardDataC* cp, irr::core::vector2di pos, const LFList
 				|| (filter_lm == 5 && !(cp->ot & AVAIL_TCG))
 				|| (filter_lm == 6 && !(cp->ot & AVAIL_SC))
 				|| (filter_lm == 7 && !(cp->ot & AVAIL_CUSTOM))
-				|| (filter_lm == 8 && (cp->ot & AVAIL_OCGTCG) != AVAIL_OCGTCG)));
+				|| (filter_lm == 8 && !(cp->ot & AVAIL_OCG))
+				|| (filter_lm == 9 && !(cp->ot & AVAIL_TCG))
+				|| (filter_lm == 10 && (cp->ot & AVAIL_OCGTCG) != AVAIL_OCGTCG)));
 	if(filter_lm >= 4) {
 		showAvail = avail;
 		showNotAvail = !avail;

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -766,6 +766,8 @@ bool Game::Initialize() {
 	cbLimit->addItem(dataManager.GetSysString(1482));
 	cbLimit->addItem(dataManager.GetSysString(1483));
 	cbLimit->addItem(dataManager.GetSysString(1484));
+	cbLimit->addItem(dataManager.GetSysString(1487));
+	cbLimit->addItem(dataManager.GetSysString(1488));
 	cbLimit->addItem(dataManager.GetSysString(1485));
 	stAttribute = env->addStaticText(dataManager.GetSysString(1319), irr::core::rect<irr::s32>(10, 22 + 50 / 6, 70, 42 + 50 / 6), false, false, wFilter);
 	cbAttribute = env->addComboBox(irr::core::rect<irr::s32>(60, 20 + 50 / 6, 195, 40 + 50 / 6), wFilter, COMBOBOX_ATTRIBUTE);

--- a/strings.conf
+++ b/strings.conf
@@ -505,6 +505,8 @@
 !system 1484 自定义卡片
 !system 1485 无独有卡
 !system 1486 所有卡片
+!system 1487 ＯＣＧ独有
+!system 1488 ＴＣＧ独有
 !system 1500 决斗结束。
 !system 1501 录像结束。
 !system 1502 连接已断开。


### PR DESCRIPTION
<img width="273" height="616" alt="image" src="https://github.com/user-attachments/assets/667b990e-8695-4069-8ed1-6cf3a576d555" />

Filtering cards that are only released in OCG/TCG, not released in TCG/OCG.