### PR TITLE
add workaround support for POS_REVEAL

### DIFF
--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -26,6 +26,17 @@ public:
 	static void DisconnectPlayer(DuelPlayer* dp);
 	static void HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, size_t len);
 	static size_t CreateChatPacket(unsigned char* src, int src_size, unsigned char* dst, uint16_t dst_player_type);
+	static inline bool ShouldHideFacedownCode(uint8_t position) {
+		return (position & POS_FACEDOWN) != 0 && (position & POS_REVEAL) == 0;
+	}
+	// TODO: remove this function in the next protocol version, let the client handle the POS_REVEAL flag instead.
+	static inline uint8_t StripRevealFlag(unsigned char* qbuf, size_t offset) {
+		uint32_t info = 0;
+		std::memcpy(&info, qbuf + offset, sizeof info);
+		info &= ~(static_cast<uint32_t>(POS_REVEAL) << 24);
+		std::memcpy(qbuf + offset, &info, sizeof info);
+		return static_cast<uint8_t>(info >> 24);
+	}
 	static void SendPacketToPlayer(DuelPlayer* dp, unsigned char proto) {
 		auto p = net_server_write;
 		BufferIO::Write<uint16_t>(p, 1);

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -1,3 +1,4 @@
+#include <utility>
 #include "config.h"
 #include "single_duel.h"
 #include "netserver.h"
@@ -955,10 +956,14 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			int cc = pbuf[8];
 			int cl = pbuf[9];
 			int cs = pbuf[10];
-			int cp = pbuf[11];
+			uint8_t cp = pbuf[11];
+			const bool hide_code = NetServer::ShouldHideFacedownCode(cp);
+			if (cl & LOCATION_ONFIELD)
+				cp = NetServer::StripRevealFlag(pbufw, 8);
 			pbuf += 16;
 			NetServer::SendBufferToPlayer(players[cc], STOC_GAME_MSG, offset, pbuf - offset);
-			if (!(cl & (LOCATION_GRAVE + LOCATION_OVERLAY)) && ((cl & (LOCATION_DECK + LOCATION_HAND)) || (cp & POS_FACEDOWN)))
+			if (!(cl & (LOCATION_GRAVE | LOCATION_OVERLAY))
+					&& ((cl & (LOCATION_DECK | LOCATION_HAND)) || hide_code))
 				BufferIO::Write<int32_t>(pbufw, 0);
 			NetServer::SendBufferToPlayer(players[1 - cc], STOC_GAME_MSG, offset, pbuf - offset);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
@@ -1039,10 +1044,12 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			int cc = pbuf[4];
 			/*int cl = pbuf[5];*/
 			/*int cs = pbuf[6];*/
-			int cp = pbuf[7];
+			uint8_t cp = pbuf[7];
+			const bool hide_code = NetServer::ShouldHideFacedownCode(cp);
+			cp = NetServer::StripRevealFlag(pbufw, 4);
 			pbuf += 8;
 			NetServer::SendBufferToPlayer(players[cc], STOC_GAME_MSG, offset, pbuf - offset);
-			if (cp & POS_FACEDOWN)
+			if (hide_code)
 				BufferIO::Write<int32_t>(pbufw, 0);
 			NetServer::SendBufferToPlayer(players[1 - cc], STOC_GAME_MSG, offset, pbuf - offset);
 			for(auto oit = observers.begin(); oit != observers.end(); ++oit)
@@ -1479,7 +1486,7 @@ void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 	query_buffer.resize(SIZE_QUERY_BUFFER);
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_MZONE, flag, qbuf, use_cache);
-	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
+	std::vector<std::pair<unsigned char*, int>> hidden_segments;
 	int qlen = 0;
 	while(qlen < len) {
 		const int clen = BufferIO::Read<int32_t>(qbuf);
@@ -1487,10 +1494,15 @@ void SingleDuel::RefreshMzone(int player, int flag, int use_cache) {
 		if (clen <= LEN_HEADER)
 			continue;
 		auto position = GetPosition(qbuf, 8);
-		if (position & POS_FACEDOWN)
-			std::memset(qbuf, 0, clen - 4);
+		const bool hide_code = NetServer::ShouldHideFacedownCode(position);
+		position = NetServer::StripRevealFlag(qbuf, 8);
+		if (hide_code)
+			hidden_segments.emplace_back(qbuf, clen);
 		qbuf += clen - 4;
 	}
+	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
+	for(const auto& segment : hidden_segments)
+		std::memset(segment.first, 0, segment.second - 4);
 	NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
 		NetServer::ReSendToPlayer(*pit);
@@ -1500,7 +1512,7 @@ void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 	query_buffer.resize(SIZE_QUERY_BUFFER);
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_SZONE, flag, qbuf, use_cache);
-	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
+	std::vector<std::pair<unsigned char*, int>> hidden_segments;
 	int qlen = 0;
 	while(qlen < len) {
 		const int clen = BufferIO::Read<int32_t>(qbuf);
@@ -1508,10 +1520,15 @@ void SingleDuel::RefreshSzone(int player, int flag, int use_cache) {
 		if (clen <= LEN_HEADER)
 			continue;
 		auto position = GetPosition(qbuf, 8);
-		if (position & POS_FACEDOWN)
-			std::memset(qbuf, 0, clen - 4);
+		const bool hide_code = NetServer::ShouldHideFacedownCode(position);
+		position = NetServer::StripRevealFlag(qbuf, 8);
+		if (hide_code)
+			hidden_segments.emplace_back(qbuf, clen);
 		qbuf += clen - 4;
 	}
+	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer.data(), len + 3);
+	for(const auto& segment : hidden_segments)
+		std::memset(segment.first, 0, segment.second - 4);
 	NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
 		NetServer::ReSendToPlayer(*pit);
@@ -1563,11 +1580,18 @@ void SingleDuel::RefreshSingle(int player, int location, int sequence, int flag)
 	BufferIO::Write<uint8_t>(qbuf, location);
 	BufferIO::Write<uint8_t>(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
-	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer, len + 4);
-	if (len <= LEN_HEADER)
+	if (len <= LEN_HEADER) {
+		NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer, len + 4);
 		return;
+	}
 	auto position = GetPosition(qbuf, 12);
-	if (position & POS_FACEDOWN) {
+	bool hide_code = position & POS_FACEDOWN;
+	if (location & LOCATION_ONFIELD) {
+		hide_code = NetServer::ShouldHideFacedownCode(position);
+		position = NetServer::StripRevealFlag(qbuf, 12);
+	}
+	NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, query_buffer, len + 4);
+	if (hide_code) {
 		BufferIO::Write<int32_t>(qbuf, 16);
 		BufferIO::Write<uint32_t>(qbuf, QUERY_CODE | QUERY_POSITION);
 		BufferIO::Write<uint32_t>(qbuf, 0);

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -1,3 +1,4 @@
+#include <utility>
 #include "config.h"
 #include "tag_duel.h"
 #include "netserver.h"
@@ -949,10 +950,14 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			int cc = pbuf[8];
 			int cl = pbuf[9];
 			int cs = pbuf[10];
-			int cp = pbuf[11];
+			uint8_t cp = pbuf[11];
+			const bool hide_code = NetServer::ShouldHideFacedownCode(cp);
+			if (cl & LOCATION_ONFIELD)
+				cp = NetServer::StripRevealFlag(pbufw, 8);
 			pbuf += 16;
 			NetServer::SendBufferToPlayer(cur_player[cc], STOC_GAME_MSG, offset, pbuf - offset);
-			if (!(cl & (LOCATION_GRAVE + LOCATION_OVERLAY)) && ((cl & (LOCATION_DECK + LOCATION_HAND)) || (cp & POS_FACEDOWN)))
+			if (!(cl & (LOCATION_GRAVE | LOCATION_OVERLAY))
+					&& ((cl & (LOCATION_DECK | LOCATION_HAND)) || hide_code))
 				BufferIO::Write<int32_t>(pbufw, 0);
 			for(int i = 0; i < 4; ++i)
 				if(players[i] != cur_player[cc])
@@ -1047,12 +1052,14 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			int cc = pbuf[4];
 			/*int cl = pbuf[5];*/
 			/*int cs = pbuf[6];*/
-			int cp = pbuf[7];
+			uint8_t cp = pbuf[7];
+			const bool hide_code = NetServer::ShouldHideFacedownCode(cp);
+			cp = NetServer::StripRevealFlag(pbufw, 4);
 			pbuf += 8;
 			auto pid = (cc == 0) ? 0 : 2;
 			NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, offset, pbuf - offset);
 			NetServer::ReSendToPlayer(players[pid + 1]);
-			if (cp & POS_FACEDOWN)
+			if (hide_code)
 				BufferIO::Write<int32_t>(pbufw, 0);
 			pid = 2 - pid;
 			NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, offset, pbuf - offset);
@@ -1592,9 +1599,8 @@ void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 	query_buffer.resize(SIZE_QUERY_BUFFER);
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_MZONE, flag, qbuf, use_cache);
+	std::vector<std::pair<unsigned char*, int>> hidden_segments;
 	int pid = (player == 0) ? 0 : 2;
-	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer.data(), len + 3);
-	NetServer::ReSendToPlayer(players[pid + 1]);
 	int qlen = 0;
 	while(qlen < len) {
 		int clen = BufferIO::Read<int32_t>(qbuf);
@@ -1602,10 +1608,16 @@ void TagDuel::RefreshMzone(int player, int flag, int use_cache) {
 		if (clen <= LEN_HEADER)
 			continue;
 		auto position = GetPosition(qbuf, 8);
-		if (position & POS_FACEDOWN)
-			std::memset(qbuf, 0, clen - 4);
+		const bool hide_code = NetServer::ShouldHideFacedownCode(position);
+		position = NetServer::StripRevealFlag(qbuf, 8);
+		if (hide_code)
+			hidden_segments.emplace_back(qbuf, clen);
 		qbuf += clen - 4;
 	}
+	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer.data(), len + 3);
+	NetServer::ReSendToPlayer(players[pid + 1]);
+	for(const auto& segment : hidden_segments)
+		std::memset(segment.first, 0, segment.second - 4);
 	pid = 2 - pid;
 	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	NetServer::ReSendToPlayer(players[pid + 1]);
@@ -1617,9 +1629,8 @@ void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 	query_buffer.resize(SIZE_QUERY_BUFFER);
 	auto qbuf = query_buffer.data();
 	auto len = WriteUpdateData(player, LOCATION_SZONE, flag, qbuf, use_cache);
+	std::vector<std::pair<unsigned char*, int>> hidden_segments;
 	int pid = (player == 0) ? 0 : 2;
-	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer.data(), len + 3);
-	NetServer::ReSendToPlayer(players[pid + 1]);
 	int qlen = 0;
 	while(qlen < len) {
 		int clen = BufferIO::Read<int32_t>(qbuf);
@@ -1627,10 +1638,16 @@ void TagDuel::RefreshSzone(int player, int flag, int use_cache) {
 		if (clen <= LEN_HEADER)
 			continue;
 		auto position = GetPosition(qbuf, 8);
-		if (position & POS_FACEDOWN)
-			std::memset(qbuf, 0, clen - 4);
+		const bool hide_code = NetServer::ShouldHideFacedownCode(position);
+		position = NetServer::StripRevealFlag(qbuf, 8);
+		if (hide_code)
+			hidden_segments.emplace_back(qbuf, clen);
 		qbuf += clen - 4;
 	}
+	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer.data(), len + 3);
+	NetServer::ReSendToPlayer(players[pid + 1]);
+	for(const auto& segment : hidden_segments)
+		std::memset(segment.first, 0, segment.second - 4);
 	pid = 2 - pid;
 	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer.data(), len + 3);
 	NetServer::ReSendToPlayer(players[pid + 1]);
@@ -1689,12 +1706,20 @@ void TagDuel::RefreshSingle(int player, int location, int sequence, int flag) {
 	BufferIO::Write<uint8_t>(qbuf, sequence);
 	int len = query_card(pduel, player, location, sequence, flag, qbuf, 0);
 	int pid = (player == 0) ? 0 : 2;
+	if (len <= LEN_HEADER) {
+		NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);
+		NetServer::ReSendToPlayer(players[pid + 1]);
+		return;
+	}
+	auto position = GetPosition(qbuf, 12);
+	bool hide_code = position & POS_FACEDOWN;
+	if (location & LOCATION_ONFIELD) {
+		hide_code = NetServer::ShouldHideFacedownCode(position);
+		position = NetServer::StripRevealFlag(qbuf, 12);
+	}
 	NetServer::SendBufferToPlayer(players[pid], STOC_GAME_MSG, query_buffer, len + 4);
 	NetServer::ReSendToPlayer(players[pid + 1]);
-	if (len <= LEN_HEADER)
-		return;
-	auto position = GetPosition(qbuf, 12);
-	if (position & POS_FACEDOWN) {
+	if (hide_code) {
 		BufferIO::Write<int32_t>(qbuf, 16);
 		BufferIO::Write<uint32_t>(qbuf, QUERY_CODE | QUERY_POSITION);
 		BufferIO::Write<uint32_t>(qbuf, 0);


### PR DESCRIPTION
> ocgcore: 841

ocgcore is adding `EFFECT_REVEAL_ONFIELD` in [https://github.com/Fluorohydride/ygopro-core/pull/841](https://github.com/Fluorohydride/ygopro-core/pull/841). When a card on the field is affected by this effect, its `position` may include the `POS_REVEAL` flag. The server should use this flag to decide whether a facedown card’s code can be sent to clients, but must not forward `POS_REVEAL` itself yet to avoid changing the current protocol.

replace and close #3056

Changes:
- Add `ShouldHideFacedownCode`
- Add `StripRevealFlag`
- Use them on field-card message paths to reveal card codes when `POS_REVEAL` is present
- Strip `POS_REVEAL` from outgoing client messages until the protocol is updated
