### PR TITLE
Use a static buffer in DuelClient::ClientRead

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -33,6 +33,7 @@ namespace {
 	wchar_t event_string[256]{};
 	std::mt19937 rnd{};
 	std::uniform_real_distribution<float> real_dist{};
+	unsigned char duel_client_read[SIZE_NETWORK_BUFFER]{};
 
 	bool is_refreshing{};
 	int match_kill{};
@@ -110,7 +111,6 @@ void DuelClient::ClientRead(bufferevent* bev, void* ctx) {
 	size_t len = evbuffer_get_length(input);
 	if (len < 2)
 		return;
-	unsigned char* duel_client_read = new unsigned char[SIZE_NETWORK_BUFFER];
 	uint16_t packet_len = 0;
 	while (len >= 2) {
 		evbuffer_copyout(input, &packet_len, sizeof packet_len);
@@ -121,7 +121,6 @@ void DuelClient::ClientRead(bufferevent* bev, void* ctx) {
 			HandleSTOCPacketLan(&duel_client_read[2], read_len - 2);
 		len -= packet_len + 2;
 	}
-	delete[] duel_client_read;
 }
 void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 	if (events & BEV_EVENT_CONNECTED) {

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -245,14 +245,13 @@ void DuelClient::ClientEvent(bufferevent* bev, short events, void* ctx) {
 		event_base_loopexit(client_base, 0);
 	}
 }
-int DuelClient::ClientThread() {
+void DuelClient::ClientThread() {
 	event_base_dispatch(client_base);
 	bufferevent_free(client_bev);
 	event_base_free(client_base);
 	client_bev = 0;
 	client_base = 0;
 	connect_state = 0;
-	return 0;
 }
 void DuelClient::HandleSTOCPacketLan(unsigned char* data, size_t len) {
 	unsigned char* pdata = data;

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -20,7 +20,7 @@ public:
 	static void StopClient(bool is_exiting = false);
 	static void ClientRead(bufferevent* bev, void* ctx);
 	static void ClientEvent(bufferevent* bev, short events, void* ctx);
-	static int ClientThread();
+	static void ClientThread();
 	static void HandleSTOCPacketLan(unsigned char* data, size_t len);
 	static bool ClientAnalyze(unsigned char* msg, size_t len);
 	static void SwapField();

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -152,7 +152,7 @@ void NetServer::ServerEchoEvent(bufferevent* bev, short events, void* ctx) {
 			DisconnectPlayer(dp);
 	}
 }
-int NetServer::ServerThread() {
+void NetServer::ServerThread() {
 	event_base_dispatch(net_evbase);
 	for(auto bit = users.begin(); bit != users.end(); ++bit) {
 		bufferevent_disable(bit->first, EV_READ);
@@ -175,7 +175,6 @@ int NetServer::ServerThread() {
 	duel_mode = nullptr;
 	event_base_free(net_evbase);
 	net_evbase = nullptr;
-	return 0;
 }
 void NetServer::DisconnectPlayer(DuelPlayer* dp) {
 	auto bit = users.find(dp->bev);

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -22,7 +22,7 @@ public:
 	static void ServerAcceptError(evconnlistener *listener, void* ctx);
 	static void ServerEchoRead(bufferevent* bev, void* ctx);
 	static void ServerEchoEvent(bufferevent* bev, short events, void* ctx);
-	static int ServerThread();
+	static void ServerThread();
 	static void DisconnectPlayer(DuelPlayer* dp);
 	static void HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, size_t len);
 	static size_t CreateChatPacket(unsigned char* src, int src_size, unsigned char* dst, uint16_t dst_player_type);


### PR DESCRIPTION
Use a static buffer in DuelClient::ClientRead
Like ServerEchoRead

Change return type of ClientThread and ServerThread to void
It is misleading because std::thread will ignore the return value. 