### PR TITLE
Refactor ClientCard memory management 

### DIFF
--- a/gframe/client_card.cpp
+++ b/gframe/client_card.cpp
@@ -5,6 +5,8 @@
 
 namespace ygo {
 
+ClientCard::ClientCard(ClientField* field) : field_(field) {
+}
 ClientCard::~ClientCard() {
 	ClearTarget();
 	if (equipTarget) {
@@ -41,7 +43,7 @@ void ClientCard::SetCode(unsigned int x) {
 	}
 	code = x;
 	if (location == LOCATION_HAND) {
-		mainGame->dField.MoveCard(this, 5);
+		field_->MoveCard(this, 5);
 	}
 }
 void ClientCard::UpdateInfo(unsigned char* buf) {
@@ -60,7 +62,7 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 		int pdata = (BufferIO::Read<int32_t>(buf) >> 24) & 0xff;
 		if((location & (LOCATION_EXTRA | LOCATION_REMOVED)) && pdata != position) {
 			position = pdata;
-			mainGame->dField.MoveCard(this, 1);
+			field_->MoveCard(this, 1);
 		} else
 			position = pdata;
 	}
@@ -118,7 +120,7 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 		unsigned int l = BufferIO::Read<uint8_t>(buf);
 		int s = BufferIO::Read<uint8_t>(buf);
 		BufferIO::Read<uint8_t>(buf);
-		ClientCard* ecard = mainGame->dField.GetCard(mainGame->LocalPlayer(c), l, s);
+		ClientCard* ecard = field_->GetCard(mainGame->LocalPlayer(c), l, s);
 		if (ecard) {
 			equipTarget = ecard;
 			ecard->equipped.insert(this);
@@ -131,7 +133,7 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 			unsigned int l = BufferIO::Read<uint8_t>(buf);
 			int s = BufferIO::Read<uint8_t>(buf);
 			BufferIO::Read<uint8_t>(buf);
-			ClientCard* tcard = mainGame->dField.GetCard(mainGame->LocalPlayer(c), l, s);
+			ClientCard* tcard = field_->GetCard(mainGame->LocalPlayer(c), l, s);
 			if (tcard) {
 				cardTarget.insert(tcard);
 				tcard->ownerTarget.insert(this);
@@ -142,9 +144,9 @@ void ClientCard::UpdateInfo(unsigned char* buf) {
 		int count = BufferIO::Read<int32_t>(buf);
 		for(int i = 0; i < count; ++i) {
 			if(i >= overlayed.size()) {
-				ClientCard* xcard = new ClientCard;
+				ClientCard* xcard = field_->CreateCard();
 				overlayed.push_back(xcard);
-				mainGame->dField.overlay_cards.insert(xcard);
+				field_->overlay_cards.insert(xcard);
 				xcard->overlayTarget = this;
 				xcard->location = LOCATION_OVERLAY;
 				xcard->sequence = (unsigned char)(overlayed.size() - 1);

--- a/gframe/client_card.h
+++ b/gframe/client_card.h
@@ -73,13 +73,16 @@ public:
 	wchar_t lscstring[16]{};
 	wchar_t rscstring[16]{};
 
-	ClientCard() = default;
+	ClientCard(ClientField* field);
 	~ClientCard();
 	void SetCode(unsigned int x);
 	void UpdateInfo(unsigned char* buf);
 	void ClearTarget();
 	void ClearData();
 	static bool client_card_sort(ClientCard* c1, ClientCard* c2);
+
+private:
+	ClientField* field_{};
 };
 
 }

--- a/gframe/client_card.h
+++ b/gframe/client_card.h
@@ -8,6 +8,8 @@
 
 namespace ygo {
 
+class ClientField;
+
 class ClientCard {
 public:
 	irr::core::matrix4 mTransform;

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -99,6 +99,18 @@ ClientCard* ClientField::CreateCard() {
 	cards_.push_back(std::move(card));
 	return raw_ptr;
 }
+void ClientField::DestroyCard(ClientCard* pcard) {
+	if (!pcard)
+		return;
+	auto it = std::find_if(cards_.begin(), cards_.end(),
+		[pcard](const std::unique_ptr<ClientCard>& ptr) {
+			return ptr.get() == pcard;
+		});
+	if (it != cards_.end()) {
+		std::swap(*it, cards_.back());
+		cards_.pop_back();
+	}
+}
 ClientCard* ClientField::GetCard(int controler, int location, int sequence, int sub_seq) {
 	std::vector<ClientCard*>* lst = 0;
 	bool is_xyz = (location & LOCATION_OVERLAY) != 0;

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -19,69 +19,36 @@ ClientField::ClientField() {
 }
 ClientField::~ClientField() {
 	for (int i = 0; i < 2; ++i) {
-		for (auto& card : deck[i]) {
-			delete card;
-		}
 		deck[i].clear();
-		for (auto& card : hand[i]) {
-			delete card;
-		}
 		hand[i].clear();
 		for (auto& card : mzone[i]) {
-			delete card;
 			card = nullptr;
 		}
 		for (auto& card : szone[i]) {
-			delete card;
 			card = nullptr;
 		}
-		for (auto& card : grave[i]) {
-			delete card;
-		}
 		grave[i].clear();
-		for (auto& card : remove[i]) {
-			delete card;
-		}
 		remove[i].clear();
-		for (auto& card : extra[i]) {
-			delete card;
-		}
 		extra[i].clear();
 	}
-	for (auto& card : overlay_cards) {
-		delete card;
-	}
 	overlay_cards.clear();
+	for (auto pcard : cards_) {
+		delete pcard;
+	}
+	cards_.clear();
 }
 void ClientField::Clear() {
 	for(int i = 0; i < 2; ++i) {
-		for (auto& card : deck[i]) {
-			delete card;
-		}
 		deck[i].clear();
-		for (auto& card : hand[i]) {
-			delete card;
-		}
 		hand[i].clear();
 		for (auto& card : mzone[i]) {
-			delete card;
 			card = nullptr;
 		}
 		for (auto& card : szone[i]) {
-			delete card;
 			card = nullptr;
 		}
-		for (auto& card : grave[i]) {
-			delete card;
-		}
 		grave[i].clear();
-		for (auto& card : remove[i]) {
-			delete card;
-		}
 		remove[i].clear();
-		for (auto& card : extra[i]) {
-			delete card;
-		}
 		extra[i].clear();
 		deck_act[i] = false;
 		grave_act[i] = false;
@@ -89,9 +56,10 @@ void ClientField::Clear() {
 		extra_act[i] = false;
 		pzone_act[i] = false;
 	}
-	for (auto& card : overlay_cards) {
-		delete card;
+	for(auto pcard : cards_) {
+		delete pcard;
 	}
+	cards_.clear();
 	overlay_cards.clear();
 	extra_p_count[0] = 0;
 	extra_p_count[1] = 0;
@@ -123,7 +91,7 @@ void ClientField::Clear() {
 void ClientField::Initial(int player, int deckc, int extrac, int sidec) {
 	auto load_location = [&](std::vector<ClientCard*>& container, int count, uint8_t location) {
 		for(int i = 0; i < count; ++i) {
-			ClientCard* pcard = new ClientCard;
+			ClientCard* pcard = CreateCard();
 			container.push_back(pcard);
 			pcard->owner = player;
 			pcard->controler = player;
@@ -147,6 +115,11 @@ void ClientField::ResetSequence(std::vector<ClientCard*>& list, bool reset_heigh
 			pcard->mTransform.setTranslation(pcard->curPos);
 		}
 	}
+}
+ClientCard* ClientField::CreateCard() {
+	ClientCard* pcard = new ClientCard(this);
+	cards_.push_back(pcard);
+	return pcard;
 }
 ClientCard* ClientField::GetCard(int controler, int location, int sequence, int sub_seq) {
 	std::vector<ClientCard*>* lst = 0;

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -103,6 +103,7 @@ ClientCard* ClientField::CreateCard() {
 void ClientField::DestroyCard(ClientCard* pcard) {
 	if (!pcard)
 		return;
+	overlay_cards.erase(pcard);
 	auto it = std::find_if(cards_.begin(), cards_.end(),
 		[pcard](const std::unique_ptr<ClientCard>& ptr) {
 			return ptr.get() == pcard;

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -17,26 +17,6 @@ ClientField::ClientField() {
 	}
 	rnd.seed(std::random_device()());
 }
-ClientField::~ClientField() {
-	for (int i = 0; i < 2; ++i) {
-		deck[i].clear();
-		hand[i].clear();
-		for (auto& card : mzone[i]) {
-			card = nullptr;
-		}
-		for (auto& card : szone[i]) {
-			card = nullptr;
-		}
-		grave[i].clear();
-		remove[i].clear();
-		extra[i].clear();
-	}
-	overlay_cards.clear();
-	for (auto pcard : cards_) {
-		delete pcard;
-	}
-	cards_.clear();
-}
 void ClientField::Clear() {
 	for(int i = 0; i < 2; ++i) {
 		deck[i].clear();
@@ -55,9 +35,6 @@ void ClientField::Clear() {
 		remove_act[i] = false;
 		extra_act[i] = false;
 		pzone_act[i] = false;
-	}
-	for(auto pcard : cards_) {
-		delete pcard;
 	}
 	cards_.clear();
 	overlay_cards.clear();
@@ -117,9 +94,10 @@ void ClientField::ResetSequence(std::vector<ClientCard*>& list, bool reset_heigh
 	}
 }
 ClientCard* ClientField::CreateCard() {
-	ClientCard* pcard = new ClientCard(this);
-	cards_.push_back(pcard);
-	return pcard;
+	auto card = std::make_unique<ClientCard>(this);
+	ClientCard* raw_ptr = card.get();
+	cards_.push_back(std::move(card));
+	return raw_ptr;
 }
 ClientCard* ClientField::GetCard(int controler, int location, int sequence, int sub_seq) {
 	std::vector<ClientCard*>* lst = 0;

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -17,6 +17,7 @@ ClientField::ClientField() {
 	}
 	rnd.seed(std::random_device()());
 }
+ClientField::~ClientField() = default;
 void ClientField::Clear() {
 	for(int i = 0; i < 2; ++i) {
 		deck[i].clear();

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -95,10 +95,8 @@ void ClientField::ResetSequence(std::vector<ClientCard*>& list, bool reset_heigh
 	}
 }
 ClientCard* ClientField::CreateCard() {
-	auto card = std::make_unique<ClientCard>(this);
-	ClientCard* raw_ptr = card.get();
-	cards_.push_back(std::move(card));
-	return raw_ptr;
+	cards_.emplace_back(std::make_unique<ClientCard>(this));
+	return cards_.back().get();
 }
 void ClientField::DestroyCard(ClientCard* pcard) {
 	if (!pcard)

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -94,7 +94,7 @@ public:
 	std::mt19937 rnd;
 
 	ClientField();
-	~ClientField() override = default;
+	~ClientField() override;
 	void Clear();
 	void Initial(int player, int deckc, int extrac, int sidec = 0);
 	ClientCard* CreateCard();

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -96,6 +96,7 @@ public:
 	~ClientField() override;
 	void Clear();
 	void Initial(int player, int deckc, int extrac, int sidec = 0);
+	ClientCard* CreateCard();
 	void ResetSequence(std::vector<ClientCard*>& list, bool reset_height);
 	ClientCard* GetCard(int controler, int location, int sequence, int sub_seq = 0);
 	void AddCard(ClientCard* pcard, int controler, int location, int sequence);
@@ -158,6 +159,9 @@ public:
 	void SetResponseSelectedCards() const;
 	void SetResponseSelectedOption() const;
 	void CancelOrFinish();
+
+private:
+	std::vector<ClientCard*> cards_;
 };
 
 }

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -98,6 +98,7 @@ public:
 	void Clear();
 	void Initial(int player, int deckc, int extrac, int sidec = 0);
 	ClientCard* CreateCard();
+	void DestroyCard(ClientCard* pcard);
 	void ResetSequence(std::vector<ClientCard*>& list, bool reset_height);
 	ClientCard* GetCard(int controler, int location, int sequence, int sub_seq = 0);
 	void AddCard(ClientCard* pcard, int controler, int location, int sequence);

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <memory>
 
 namespace ygo {
 
@@ -93,7 +94,7 @@ public:
 	std::mt19937 rnd;
 
 	ClientField();
-	~ClientField() override;
+	~ClientField() override = default;
 	void Clear();
 	void Initial(int player, int deckc, int extrac, int sidec = 0);
 	ClientCard* CreateCard();
@@ -161,7 +162,7 @@ public:
 	void CancelOrFinish();
 
 private:
-	std::vector<ClientCard*> cards_;
+	std::vector<std::unique_ptr<ClientCard>> cards_;
 };
 
 }

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2604,7 +2604,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 		}
 		int appear = mainGame->gameConf.quick_animation ? 12 : 20;
 		if (pl == 0) {
-			ClientCard* pcard = new ClientCard;
+			ClientCard* pcard = mainGame->dField.CreateCard();
 			pcard->position = cp;
 			pcard->SetCode(code);
 			if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
@@ -3820,7 +3820,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			}
 		} else {
 			while(mainGame->dField.deck[player].size() < mcount) {
-				ClientCard* ccard = new ClientCard;
+				ClientCard* ccard = mainGame->dField.CreateCard();
 				ccard->controler = player;
 				ccard->location = LOCATION_DECK;
 				ccard->sequence = (unsigned char)mainGame->dField.deck[player].size();
@@ -3835,7 +3835,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			}
 		} else {
 			while(mainGame->dField.hand[player].size() < hcount) {
-				ClientCard* ccard = new ClientCard;
+				ClientCard* ccard = mainGame->dField.CreateCard();
 				ccard->controler = player;
 				ccard->location = LOCATION_HAND;
 				ccard->sequence = (unsigned char)mainGame->dField.hand[player].size();
@@ -3850,7 +3850,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			}
 		} else {
 			while(mainGame->dField.extra[player].size() < ecount) {
-				ClientCard* ccard = new ClientCard;
+				ClientCard* ccard = mainGame->dField.CreateCard();
 				ccard->controler = player;
 				ccard->location = LOCATION_EXTRA;
 				ccard->sequence = (unsigned char)mainGame->dField.extra[player].size();
@@ -3905,13 +3905,13 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			for(int seq = 0; seq < 7; ++seq) {
 				val = BufferIO::Read<uint8_t>(pbuf);
 				if(val) {
-					ClientCard* ccard = new ClientCard;
+					ClientCard* ccard = mainGame->dField.CreateCard();
 					mainGame->dField.AddCard(ccard, p, LOCATION_MZONE, seq);
 					ccard->position = BufferIO::Read<uint8_t>(pbuf);
 					val = BufferIO::Read<uint8_t>(pbuf);
 					if(val) {
 						for(int xyz = 0; xyz < val; ++xyz) {
-							ClientCard* xcard = new ClientCard;
+							ClientCard* xcard = mainGame->dField.CreateCard();
 							ccard->overlayed.push_back(xcard);
 							mainGame->dField.overlay_cards.insert(xcard);
 							xcard->overlayTarget = ccard;
@@ -3926,34 +3926,34 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			for(int seq = 0; seq < 8; ++seq) {
 				val = BufferIO::Read<uint8_t>(pbuf);
 				if(val) {
-					ClientCard* ccard = new ClientCard;
+					ClientCard* ccard = mainGame->dField.CreateCard();
 					mainGame->dField.AddCard(ccard, p, LOCATION_SZONE, seq);
 					ccard->position = BufferIO::Read<uint8_t>(pbuf);
 				}
 			}
 			val = BufferIO::Read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
-				ClientCard* ccard = new ClientCard;
+				ClientCard* ccard = mainGame->dField.CreateCard();
 				mainGame->dField.AddCard(ccard, p, LOCATION_DECK, seq);
 			}
 			val = BufferIO::Read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
-				ClientCard* ccard = new ClientCard;
+				ClientCard* ccard = mainGame->dField.CreateCard();
 				mainGame->dField.AddCard(ccard, p, LOCATION_HAND, seq);
 			}
 			val = BufferIO::Read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
-				ClientCard* ccard = new ClientCard;
+				ClientCard* ccard = mainGame->dField.CreateCard();
 				mainGame->dField.AddCard(ccard, p, LOCATION_GRAVE, seq);
 			}
 			val = BufferIO::Read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
-				ClientCard* ccard = new ClientCard;
+				ClientCard* ccard = mainGame->dField.CreateCard();
 				mainGame->dField.AddCard(ccard, p, LOCATION_REMOVED, seq);
 			}
 			val = BufferIO::Read<uint8_t>(pbuf);
 			for(int seq = 0; seq < val; ++seq) {
-				ClientCard* ccard = new ClientCard;
+				ClientCard* ccard = mainGame->dField.CreateCard();
 				mainGame->dField.AddCard(ccard, p, LOCATION_EXTRA, seq);
 			}
 			val = BufferIO::Read<uint8_t>(pbuf);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2632,7 +2632,6 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 					mainGame->dField.hovered_card = 0;
 			} else
 				mainGame->dField.RemoveCard(pc, pl, ps);
-			mainGame->dField.DestroyCard(pcard);
 		} else {
 			if (!(pl & LOCATION_OVERLAY) && !(cl & LOCATION_OVERLAY)) {
 				ClientCard* pcard = mainGame->dField.GetCard(pc, pl, ps);
@@ -3814,7 +3813,6 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			while(mainGame->dField.deck[player].size() > mcount) {
 				ClientCard* ccard = mainGame->dField.deck[player].back();
 				mainGame->dField.deck[player].pop_back();
-				mainGame->dField.DestroyCard(ccard);
 			}
 		} else {
 			while(mainGame->dField.deck[player].size() < mcount) {
@@ -3829,7 +3827,6 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			while(mainGame->dField.hand[player].size() > hcount) {
 				ClientCard* ccard = mainGame->dField.hand[player].back();
 				mainGame->dField.hand[player].pop_back();
-				mainGame->dField.DestroyCard(ccard);
 			}
 		} else {
 			while(mainGame->dField.hand[player].size() < hcount) {
@@ -3844,7 +3841,6 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			while(mainGame->dField.extra[player].size() > ecount) {
 				ClientCard* ccard = mainGame->dField.extra[player].back();
 				mainGame->dField.extra[player].pop_back();
-				mainGame->dField.DestroyCard(ccard);
 			}
 		} else {
 			while(mainGame->dField.extra[player].size() < ecount) {

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2632,6 +2632,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 					mainGame->dField.hovered_card = 0;
 			} else
 				mainGame->dField.RemoveCard(pc, pl, ps);
+			mainGame->dField.DestroyCard(pcard);
 		} else {
 			if (!(pl & LOCATION_OVERLAY) && !(cl & LOCATION_OVERLAY)) {
 				ClientCard* pcard = mainGame->dField.GetCard(pc, pl, ps);
@@ -3813,6 +3814,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			while(mainGame->dField.deck[player].size() > mcount) {
 				ClientCard* ccard = mainGame->dField.deck[player].back();
 				mainGame->dField.deck[player].pop_back();
+				mainGame->dField.DestroyCard(ccard);
 			}
 		} else {
 			while(mainGame->dField.deck[player].size() < mcount) {
@@ -3827,6 +3829,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			while(mainGame->dField.hand[player].size() > hcount) {
 				ClientCard* ccard = mainGame->dField.hand[player].back();
 				mainGame->dField.hand[player].pop_back();
+				mainGame->dField.DestroyCard(ccard);
 			}
 		} else {
 			while(mainGame->dField.hand[player].size() < hcount) {
@@ -3841,6 +3844,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			while(mainGame->dField.extra[player].size() > ecount) {
 				ClientCard* ccard = mainGame->dField.extra[player].back();
 				mainGame->dField.extra[player].pop_back();
+				mainGame->dField.DestroyCard(ccard);
 			}
 		} else {
 			while(mainGame->dField.extra[player].size() < ecount) {

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -2622,8 +2622,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			if (code != 0 && pcard->code != code)
 				pcard->SetCode(code);
 			pcard->ClearTarget();
-			for(auto eqit = pcard->equipped.begin(); eqit != pcard->equipped.end(); ++eqit)
-				(*eqit)->equipTarget = 0;
+			for (auto& equip_card : pcard->equipped)
+				equip_card->equipTarget = nullptr;
 			if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
 				mainGame->dField.FadeCard(pcard, 5, appear);
 				mainGame->WaitFrameSignal(appear);
@@ -2634,7 +2634,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 					mainGame->dField.hovered_card = 0;
 			} else
 				mainGame->dField.RemoveCard(pc, pl, ps);
-			delete pcard;
+			mainGame->dField.DestroyCard(pcard);
 		} else {
 			if (!(pl & LOCATION_OVERLAY) && !(cl & LOCATION_OVERLAY)) {
 				ClientCard* pcard = mainGame->dField.GetCard(pc, pl, ps);
@@ -3814,9 +3814,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			mainGame->gMutex.lock();
 		if(mainGame->dField.deck[player].size() > mcount) {
 			while(mainGame->dField.deck[player].size() > mcount) {
-				ClientCard* ccard = *mainGame->dField.deck[player].rbegin();
+				ClientCard* ccard = mainGame->dField.deck[player].back();
 				mainGame->dField.deck[player].pop_back();
-				delete ccard;
+				mainGame->dField.DestroyCard(ccard);
 			}
 		} else {
 			while(mainGame->dField.deck[player].size() < mcount) {
@@ -3829,9 +3829,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 		}
 		if(mainGame->dField.hand[player].size() > hcount) {
 			while(mainGame->dField.hand[player].size() > hcount) {
-				ClientCard* ccard = *mainGame->dField.hand[player].rbegin();
+				ClientCard* ccard = mainGame->dField.hand[player].back();
 				mainGame->dField.hand[player].pop_back();
-				delete ccard;
+				mainGame->dField.DestroyCard(ccard);
 			}
 		} else {
 			while(mainGame->dField.hand[player].size() < hcount) {
@@ -3844,9 +3844,9 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 		}
 		if(mainGame->dField.extra[player].size() > ecount) {
 			while(mainGame->dField.extra[player].size() > ecount) {
-				ClientCard* ccard = *mainGame->dField.extra[player].rbegin();
+				ClientCard* ccard = mainGame->dField.extra[player].back();
 				mainGame->dField.extra[player].pop_back();
-				delete ccard;
+				mainGame->dField.DestroyCard(ccard);
 			}
 		} else {
 			while(mainGame->dField.extra[player].size() < ecount) {


### PR DESCRIPTION
# Problem
```cpp
case MSG_MOVE: {
		unsigned int code = BufferIO::Read<int32_t>(pbuf);
		int pc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
		unsigned int pl = BufferIO::Read<uint8_t>(pbuf);
		int ps = BufferIO::Read<uint8_t>(pbuf);
		unsigned int pp = BufferIO::Read<uint8_t>(pbuf);
		int cc = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
		unsigned int cl = BufferIO::Read<uint8_t>(pbuf);
		int cs = BufferIO::Read<uint8_t>(pbuf);
		unsigned int cp = BufferIO::Read<uint8_t>(pbuf);
		int reason = BufferIO::Read<int32_t>(pbuf);
		if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
			if(cl & LOCATION_REMOVED && pl != cl)
				soundManager.PlaySoundEffect(SOUND_BANISHED);
			else if(reason & REASON_DESTROY && pl != cl)
				soundManager.PlaySoundEffect(SOUND_DESTROYED);
		}
		int appear = mainGame->gameConf.quick_animation ? 12 : 20;
		if (pl == 0) {
			ClientCard* pcard = new ClientCard;
			pcard->position = cp;
			pcard->SetCode(code);
			if(!mainGame->dInfo.isReplay || !mainGame->dInfo.isReplaySkiping) {
				mainGame->gMutex.lock();
				mainGame->dField.AddCard(pcard, cc, cl, cs);
				mainGame->gMutex.unlock();
				mainGame->dField.GetCardLocation(pcard, &pcard->curPos, &pcard->curRot, true);
				pcard->curAlpha = 5;
				mainGame->dField.FadeCard(pcard, 255, appear);
				mainGame->WaitFrameSignal(appear);
			} else
				mainGame->dField.AddCard(pcard, cc, cl, cs);
		}
```
```cpp
void ClientField::AddCard(ClientCard* pcard, int controler, int location, int sequence) {
	pcard->controler = controler;
	pcard->location = location;
	pcard->sequence = sequence;
	switch(location) {
	case LOCATION_DECK: {
		if (sequence != 0 || deck[controler].size() == 0) {
			deck[controler].push_back(pcard);
		} else {
			deck[controler].insert(deck[controler].begin(), pcard);
		}
		ResetSequence(deck[controler], true);
		pcard->is_reversed = false;
		pcard->ClearData();
		pcard->ClearTarget();
		SetShowMark(pcard, false);
		break;
	}
	case LOCATION_HAND: {
		hand[controler].push_back(pcard);
		ResetSequence(hand[controler], false);
		break;
	}
	case LOCATION_MZONE: {
		mzone[controler][sequence] = pcard;
		break;
	}
	case LOCATION_SZONE: {
		szone[controler][sequence] = pcard;
		break;
	}
	case LOCATION_GRAVE: {
		grave[controler].push_back(pcard);
		pcard->sequence = (unsigned char)(grave[controler].size() - 1);
		break;
	}
	case LOCATION_REMOVED: {
		remove[controler].push_back(pcard);
		pcard->sequence = (unsigned char)(remove[controler].size() - 1);
		break;
	}
	case LOCATION_EXTRA: {
		if(extra_p_count[controler] == 0 || (pcard->position & POS_FACEUP)) {
			extra[controler].push_back(pcard);
		} else {
			size_t faceup_begin = extra[controler].size() - extra_p_count[controler];
			extra[controler].insert(extra[controler].begin() + faceup_begin, pcard);
		}
		ResetSequence(extra[controler], true);
		if (pcard->position & POS_FACEUP)
			extra_p_count[controler]++;
		break;
	}
	}
}
```
MSG_MOVE, pl = 0
If `cl` is wrong, `dField.AddCard` will fail.
The pointer `pcard` will not be placed to any container, and it is lost after leaving the block.
It will causes memory leak.

# Reason
All `ClientCard` object should be managed by `ClientField`, instead of creating new `ClientCard` object at any place.

# Solution
## ClientField
```cpp
std::vector<std::unique_ptr<ClientCard>> cards_;
```
Now it will keep track of `ClientCard` unique_ptr in the private member `cards_`.


## ClientCard
Now it has a pointer to the `ClientField` object.



@Wind2009-Louse 



