### PR TITLE
fix spawn fail in BUTTON_BOT_START

### DIFF
--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -352,6 +352,17 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				if (!Game::SpawnAsync(executableName, processArgs)) {
 					DuelClient::StopClient();
 					NetServer::StopServer();
+					mainGame->btnCreateHost->setEnabled(true);
+					mainGame->btnJoinHost->setEnabled(true);
+					mainGame->btnJoinCancel->setEnabled(true);
+					mainGame->btnStartBot->setEnabled(true);
+					mainGame->btnBotCancel->setEnabled(true);
+					mainGame->HideElement(mainGame->wHostPrepare);
+					if(!mainGame->wSinglePlay->isVisible())
+						mainGame->ShowElement(mainGame->wSinglePlay);
+					mainGame->wChat->setVisible(false);
+					soundManager.PlaySoundEffect(SOUND_INFO);
+					mainGame->env->addMessageBox(L"", dataManager.GetSysString(1401));
 					break;
 				}
 				mainGame->btnStartBot->setEnabled(false);


### PR DESCRIPTION
Previously, this failure path only called `StopServer`. When the server shut down, the client would encounter an error or timeout, allowing it to restore the UI. Although the [recently](https://github.com/Fluorohydride/ygopro/pull/3109) added `StopClient` is semantically clearer, it may does not trigger the client's failure path, so the UI is not restored.