### PR TITLE
fix race between `CTOS_UPDATE_DECK` and `CTOS_HS_READY`

### DIFF
--- a/gframe/network.h
+++ b/gframe/network.h
@@ -330,6 +330,10 @@ public:
 #define MODE_MATCH		0x1
 #define MODE_TAG		0x2
 
+#define DECKSTATUS_EMPTY		0
+#define DECKSTATUS_REJECTED		1
+#define DECKSTATUS_CONFIRMED	2
+
 #define DUEL_STAGE_BEGIN		0
 #define DUEL_STAGE_FINGER		1
 #define DUEL_STAGE_FIRSTGO		2

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -13,6 +13,18 @@ SingleDuel::SingleDuel(bool is_match) {
 	match_mode = is_match;
 }
 SingleDuel::~SingleDuel() = default;
+void SingleDuel::SetPlayerReady(DuelPlayer* dp, bool is_ready) {
+	if(ready[dp->type] == is_ready)
+		return;
+	ready[dp->type] = is_ready;
+	STOC_HS_PlayerChange scpc;
+	scpc.status = (dp->type << 4) | (is_ready ? PLAYERCHANGE_READY : PLAYERCHANGE_NOTREADY);
+	NetServer::SendPacketToPlayer(players[dp->type], STOC_HS_PLAYER_CHANGE, scpc);
+	if(players[1 - dp->type])
+		NetServer::SendPacketToPlayer(players[1 - dp->type], STOC_HS_PLAYER_CHANGE, scpc);
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
+}
 void SingleDuel::Chat(DuelPlayer* dp, unsigned char* pdata, int len) {
 	unsigned char scc[SIZE_STOC_CHAT];
 	const auto scc_size = NetServer::CreateChatPacket(pdata, len, scc, dp->type);
@@ -86,6 +98,9 @@ void SingleDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater)
 			dp->type = NETPLAYER_TYPE_PLAYER2;
 			sctc.type |= NETPLAYER_TYPE_PLAYER2;
 		}
+		pending_ready[dp->type] = false;
+		deck_status[dp->type] = DECKSTATUS_EMPTY;
+		pdeck[dp->type].clear();
 	} else {
 		observers.insert(dp);
 		dp->type = NETPLAYER_TYPE_OBSERVER;
@@ -151,6 +166,9 @@ void SingleDuel::LeaveGame(DuelPlayer* dp) {
 			STOC_HS_PlayerChange scpc;
 			players[dp->type] = 0;
 			ready[dp->type] = false;
+			pending_ready[dp->type] = false;
+			deck_status[dp->type] = DECKSTATUS_EMPTY;
+			pdeck[dp->type].clear();
 			scpc.status = (dp->type << 4) | PLAYERCHANGE_LEAVE;
 			if(players[0] && dp->type != 0)
 				NetServer::SendPacketToPlayer(players[0], STOC_HS_PLAYER_CHANGE, scpc);
@@ -203,6 +221,9 @@ void SingleDuel::ToDuelist(DuelPlayer* dp) {
 		dp->type = NETPLAYER_TYPE_PLAYER2;
 		scpe.pos = 1;
 	}
+	pending_ready[dp->type] = false;
+	deck_status[dp->type] = DECKSTATUS_EMPTY;
+	pdeck[dp->type].clear();
 	STOC_HS_WatchChange scwc;
 	scwc.watch_count = (unsigned short)observers.size();
 	NetServer::SendPacketToPlayer(players[0], STOC_HS_PLAYER_ENTER, scpe);
@@ -232,6 +253,9 @@ void SingleDuel::ToObserver(DuelPlayer* dp) {
 		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
 	players[dp->type] = 0;
 	ready[dp->type] = false;
+	pending_ready[dp->type] = false;
+	deck_status[dp->type] = DECKSTATUS_EMPTY;
+	pdeck[dp->type].clear();
 	dp->type = NETPLAYER_TYPE_OBSERVER;
 	observers.insert(dp);
 	STOC_TypeChange sctc;
@@ -241,36 +265,34 @@ void SingleDuel::ToObserver(DuelPlayer* dp) {
 void SingleDuel::PlayerReady(DuelPlayer* dp, bool is_ready) {
 	if(dp->type > 1)
 		return;
-	if(ready[dp->type] == is_ready)
+	if(duel_stage != DUEL_STAGE_BEGIN)
 		return;
-	if(is_ready) {
-		uint32_t deckerror = 0;
-		if(!host_info.no_check_deck) {
-			if(deck_error[dp->type]) {
-				deckerror = (DECKERROR_UNKNOWNCARD << 28) | deck_error[dp->type];
-			} else {
-				deckerror = deckManager.CheckDeck(pdeck[dp->type], host_info.lflist, host_info.rule);
-			}
-		}
-		if(deckerror) {
-			STOC_HS_PlayerChange scpc;
-			scpc.status = (dp->type << 4) | PLAYERCHANGE_NOTREADY;
-			NetServer::SendPacketToPlayer(dp, STOC_HS_PLAYER_CHANGE, scpc);
-			STOC_ErrorMsg scem;
-			scem.msg = ERRMSG_DECKERROR;
-			scem.code = deckerror;
-			NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
-			return;
-		}
+	if(!is_ready) {
+		pending_ready[dp->type] = false;
+		deck_status[dp->type] = DECKSTATUS_EMPTY;
+		pdeck[dp->type].clear();
+		SetPlayerReady(dp, false);
+		return;
 	}
-	ready[dp->type] = is_ready;
-	STOC_HS_PlayerChange scpc;
-	scpc.status = (dp->type << 4) | (is_ready ? PLAYERCHANGE_READY : PLAYERCHANGE_NOTREADY);
-	NetServer::SendPacketToPlayer(players[dp->type], STOC_HS_PLAYER_CHANGE, scpc);
-	if(players[1 - dp->type])
-		NetServer::SendPacketToPlayer(players[1 - dp->type], STOC_HS_PLAYER_CHANGE, scpc);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
-		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
+	if(ready[dp->type])
+		return;
+	if(deck_status[dp->type] != DECKSTATUS_CONFIRMED) {
+		if(deck_status[dp->type] == DECKSTATUS_REJECTED) {
+			// A rejected deck consumes one ready request; the next deck-only update must not inherit it.
+			deck_status[dp->type] = DECKSTATUS_EMPTY;
+			pending_ready[dp->type] = false;
+		} else {
+			if(pending_ready[dp->type])
+				return;
+			pending_ready[dp->type] = true;
+		}
+		STOC_HS_PlayerChange scpc;
+		scpc.status = (dp->type << 4) | PLAYERCHANGE_NOTREADY;
+		NetServer::SendPacketToPlayer(dp, STOC_HS_PLAYER_CHANGE, scpc);
+		return;
+	}
+	pending_ready[dp->type] = false;
+	SetPlayerReady(dp, true);
 }
 void SingleDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
 	if(pos > 1 || dp != host_player || dp == players[pos] || !players[pos])
@@ -278,32 +300,72 @@ void SingleDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
 	LeaveGame(players[pos]);
 }
 void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
-	if(dp->type > 1 || ready[dp->type])
+	if(dp->type > 1)
+		return;
+	if(duel_stage != DUEL_STAGE_BEGIN && duel_stage != DUEL_STAGE_SIDING)
+		return;
+	if(ready[dp->type])
 		return;
 	if (len < sizeof(uint32_t) * 2)
 		return;
-	bool valid = true;
 	uint32_t mainc = BufferIO::Read<uint32_t>(pdata);
 	uint32_t sidec = BufferIO::Read<uint32_t>(pdata);
+	bool deck_failed = false;
+	uint32_t deckerror = 0;
 	if (mainc > MAINC_MAX)
-		valid = false;
+		deck_failed = true;
 	else if (sidec > SIDEC_MAX)
-		valid = false;
+		deck_failed = true;
 	else if (len < (2 + mainc + sidec) * sizeof(uint32_t))
-		valid = false;
-	if (!valid) {
-		STOC_ErrorMsg scem;
-		scem.msg = ERRMSG_DECKERROR;
-		scem.code = 0;
-		NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
-		return;
-	}
+		deck_failed = true;
 	uint32_t deckbuf[MAINC_MAX + SIDEC_MAX];
-	std::memcpy(deckbuf, pdata, (mainc + sidec) * sizeof(uint32_t));
-	if(duel_count == 0) {
-		deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf, mainc, sidec);
+	if(!deck_failed)
+		std::memcpy(deckbuf, pdata, (mainc + sidec) * sizeof(uint32_t));
+	if(duel_stage == DUEL_STAGE_BEGIN) {
+		Deck new_deck;
+		if(!deck_failed) {
+			uint32_t load_error = DeckManager::LoadDeck(new_deck, deckbuf, mainc, sidec);
+			if(!host_info.no_check_deck) {
+				// no_check_deck silently ignores unknown cards. In that case, the size of new_deck will not equal mainc + sidec.
+				if(load_error) {
+					deckerror = (DECKERROR_UNKNOWNCARD << 28) | load_error;
+					deck_failed = true;
+				} else if(new_deck.main.size() + new_deck.extra.size() != mainc || new_deck.side.size() != sidec) {
+					deckerror = 0;
+					deck_failed = true;
+				} else {
+					deckerror = deckManager.CheckDeck(new_deck, host_info.lflist, host_info.rule);
+					deck_failed = deckerror != 0;
+				}
+			}
+		}
+		if(deck_failed) {
+			pending_ready[dp->type] = false;
+			deck_status[dp->type] = DECKSTATUS_REJECTED;
+			STOC_ErrorMsg scem;
+			scem.msg = ERRMSG_DECKERROR;
+			scem.code = deckerror;
+			NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
+			return;
+		} else {
+			pdeck[dp->type] = std::move(new_deck);
+			deck_status[dp->type] = DECKSTATUS_CONFIRMED;
+			if(pending_ready[dp->type]) {
+				pending_ready[dp->type] = false;
+				SetPlayerReady(dp, true);
+			}
+		}
 	} else {
+		if(deck_failed) {
+			STOC_ErrorMsg scem;
+			scem.msg = ERRMSG_DECKERROR;
+			scem.code = deckerror;
+			NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
+			return;
+		}
 		if(DeckManager::LoadSide(pdeck[dp->type], deckbuf, mainc, sidec)) {
+			pending_ready[dp->type] = false;
+			deck_status[dp->type] = DECKSTATUS_EMPTY;
 			ready[dp->type] = true;
 			NetServer::SendPacketToPlayer(dp, STOC_DUEL_START);
 			if(ready[0] && ready[1]) {
@@ -323,7 +385,9 @@ void SingleDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int l
 void SingleDuel::StartDuel(DuelPlayer* dp) {
 	if(dp != host_player)
 		return;
-	if(!ready[0] || !ready[1])
+	if(duel_stage != DUEL_STAGE_BEGIN)
+		return;
+	if(!ready[0] || !ready[1] || deck_status[0] != DECKSTATUS_CONFIRMED || deck_status[1] != DECKSTATUS_CONFIRMED)
 		return;
 	NetServer::StopListen();
 	//NetServer::StopBroadcast();
@@ -540,6 +604,10 @@ void SingleDuel::DuelEndProc() {
 			}
 			ready[0] = false;
 			ready[1] = false;
+			pending_ready[0] = false;
+			deck_status[0] = DECKSTATUS_EMPTY;
+			pending_ready[1] = false;
+			deck_status[1] = DECKSTATUS_EMPTY;
 			players[0]->state = CTOS_UPDATE_DECK;
 			players[1]->state = CTOS_UPDATE_DECK;
 			NetServer::SendPacketToPlayer(players[0], STOC_CHANGE_SIDE);

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -44,14 +44,16 @@ public:
 	static void SingleTimer(evutil_socket_t fd, short events, void* arg);
 
 private:
+	void SetPlayerReady(DuelPlayer* dp, bool is_ready);
 	int WriteUpdateData(int player, int location, unsigned int flag, unsigned char*& qbuf, int use_cache);
 	
 protected:
 	DuelPlayer* players[2]{};
 	DuelPlayer* pplayer[2]{};
 	bool ready[2]{};
+	bool pending_ready[2]{};
+	unsigned char deck_status[2]{};
 	Deck pdeck[2];
-	int deck_error[2]{};
 	unsigned char hand_result[2]{};
 	unsigned char last_response{ 0 };
 	std::set<DuelPlayer*> observers;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -11,6 +11,18 @@ namespace ygo {
 
 TagDuel::TagDuel() = default;
 TagDuel::~TagDuel() = default;
+void TagDuel::SetPlayerReady(DuelPlayer* dp, bool is_ready) {
+	if(ready[dp->type] == is_ready)
+		return;
+	ready[dp->type] = is_ready;
+	STOC_HS_PlayerChange scpc;
+	scpc.status = (dp->type << 4) | (is_ready ? PLAYERCHANGE_READY : PLAYERCHANGE_NOTREADY);
+	for(int i = 0; i < 4; ++i)
+		if(players[i])
+			NetServer::SendPacketToPlayer(players[i], STOC_HS_PLAYER_CHANGE, scpc);
+	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
+		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
+}
 void TagDuel::Chat(DuelPlayer* dp, unsigned char* pdata, int len) {
 	unsigned char scc[SIZE_STOC_CHAT];
 	const auto scc_size = NetServer::CreateChatPacket(pdata, len, scc, dp->type);
@@ -79,6 +91,9 @@ void TagDuel::JoinGame(DuelPlayer* dp, unsigned char* pdata, bool is_creater) {
 		players[scpe.pos] = dp;
 		dp->type = scpe.pos;
 		sctc.type |= scpe.pos;
+		pending_ready[dp->type] = false;
+		deck_status[dp->type] = DECKSTATUS_EMPTY;
+		pdeck[dp->type].clear();
 	} else {
 		observers.insert(dp);
 		dp->type = NETPLAYER_TYPE_OBSERVER;
@@ -132,6 +147,9 @@ void TagDuel::LeaveGame(DuelPlayer* dp) {
 			STOC_HS_PlayerChange scpc;
 			players[dp->type] = 0;
 			ready[dp->type] = false;
+			pending_ready[dp->type] = false;
+			deck_status[dp->type] = DECKSTATUS_EMPTY;
+			pdeck[dp->type].clear();
 			scpc.status = (dp->type << 4) | PLAYERCHANGE_LEAVE;
 			for(int i = 0; i < 4; ++i)
 				if(players[i])
@@ -161,6 +179,9 @@ void TagDuel::ToDuelist(DuelPlayer* dp) {
 		else
 			dp->type = 3;
 		players[dp->type] = dp;
+		pending_ready[dp->type] = false;
+		deck_status[dp->type] = DECKSTATUS_EMPTY;
+		pdeck[dp->type].clear();
 		scpe.pos = dp->type;
 		STOC_HS_WatchChange scwc;
 		scwc.watch_count = (unsigned short)observers.size();
@@ -179,11 +200,12 @@ void TagDuel::ToDuelist(DuelPlayer* dp) {
 	} else {
 		if(ready[dp->type])
 			return;
+		unsigned char oldtype = dp->type;
 		unsigned char dptype = (dp->type + 1) % 4;
 		while(players[dptype])
 			dptype = (dptype + 1) % 4;
 		STOC_HS_PlayerChange scpc;
-		scpc.status = (dp->type << 4) | dptype;
+		scpc.status = (oldtype << 4) | dptype;
 		for(int i = 0; i < 4; ++i)
 			if(players[i])
 				NetServer::SendPacketToPlayer(players[i], STOC_HS_PLAYER_CHANGE, scpc);
@@ -192,8 +214,14 @@ void TagDuel::ToDuelist(DuelPlayer* dp) {
 		STOC_TypeChange sctc;
 		sctc.type = (dp == host_player ? 0x10 : 0) | dptype;
 		NetServer::SendPacketToPlayer(dp, STOC_TYPE_CHANGE, sctc);
+		pending_ready[oldtype] = false;
+		deck_status[oldtype] = DECKSTATUS_EMPTY;
+		pdeck[oldtype].clear();
+		pending_ready[dptype] = false;
+		deck_status[dptype] = DECKSTATUS_EMPTY;
+		pdeck[dptype].clear();
 		players[dptype] = dp;
-		players[dp->type] = 0;
+		players[oldtype] = 0;
 		dp->type = dptype;
 	}
 }
@@ -209,6 +237,9 @@ void TagDuel::ToObserver(DuelPlayer* dp) {
 		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
 	players[dp->type] = 0;
 	ready[dp->type] = false;
+	pending_ready[dp->type] = false;
+	deck_status[dp->type] = DECKSTATUS_EMPTY;
+	pdeck[dp->type].clear();
 	dp->type = NETPLAYER_TYPE_OBSERVER;
 	observers.insert(dp);
 	STOC_TypeChange sctc;
@@ -216,36 +247,36 @@ void TagDuel::ToObserver(DuelPlayer* dp) {
 	NetServer::SendPacketToPlayer(dp, STOC_TYPE_CHANGE, sctc);
 }
 void TagDuel::PlayerReady(DuelPlayer* dp, bool is_ready) {
-	if(dp->type > 3 || ready[dp->type] == is_ready)
+	if(dp->type > 3)
 		return;
-	if(is_ready) {
-		uint32_t deckerror = 0;
-		if(!host_info.no_check_deck) {
-			if(deck_error[dp->type]) {
-				deckerror = (DECKERROR_UNKNOWNCARD << 28) | deck_error[dp->type];
-			} else {
-				deckerror = deckManager.CheckDeck(pdeck[dp->type], host_info.lflist, host_info.rule);
-			}
-		}
-		if(deckerror) {
-			STOC_HS_PlayerChange scpc;
-			scpc.status = (dp->type << 4) | PLAYERCHANGE_NOTREADY;
-			NetServer::SendPacketToPlayer(dp, STOC_HS_PLAYER_CHANGE, scpc);
-			STOC_ErrorMsg scem;
-			scem.msg = ERRMSG_DECKERROR;
-			scem.code = deckerror;
-			NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
-			return;
-		}
+	if(duel_stage != DUEL_STAGE_BEGIN)
+		return;
+	if(!is_ready) {
+		pending_ready[dp->type] = false;
+		deck_status[dp->type] = DECKSTATUS_EMPTY;
+		pdeck[dp->type].clear();
+		SetPlayerReady(dp, false);
+		return;
 	}
-	ready[dp->type] = is_ready;
-	STOC_HS_PlayerChange scpc;
-	scpc.status = (dp->type << 4) | (is_ready ? PLAYERCHANGE_READY : PLAYERCHANGE_NOTREADY);
-	for(int i = 0; i < 4; ++i)
-		if(players[i])
-			NetServer::SendPacketToPlayer(players[i], STOC_HS_PLAYER_CHANGE, scpc);
-	for(auto pit = observers.begin(); pit != observers.end(); ++pit)
-		NetServer::SendPacketToPlayer(*pit, STOC_HS_PLAYER_CHANGE, scpc);
+	if(ready[dp->type])
+		return;
+	if(deck_status[dp->type] != DECKSTATUS_CONFIRMED) {
+		if(deck_status[dp->type] == DECKSTATUS_REJECTED) {
+			// A rejected deck consumes one ready request; the next deck-only update must not inherit it.
+			deck_status[dp->type] = DECKSTATUS_EMPTY;
+			pending_ready[dp->type] = false;
+		} else {
+			if(pending_ready[dp->type])
+				return;
+			pending_ready[dp->type] = true;
+		}
+		STOC_HS_PlayerChange scpc;
+		scpc.status = (dp->type << 4) | PLAYERCHANGE_NOTREADY;
+		NetServer::SendPacketToPlayer(dp, STOC_HS_PLAYER_CHANGE, scpc);
+		return;
+	}
+	pending_ready[dp->type] = false;
+	SetPlayerReady(dp, true);
 }
 void TagDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
 	if(pos > 3 || dp != host_player || dp == players[pos] || !players[pos])
@@ -253,35 +284,66 @@ void TagDuel::PlayerKick(DuelPlayer* dp, unsigned char pos) {
 	LeaveGame(players[pos]);
 }
 void TagDuel::UpdateDeck(DuelPlayer* dp, unsigned char* pdata, unsigned int len) {
-	if(dp->type > 3 || ready[dp->type])
+	if(dp->type > 3 || duel_stage != DUEL_STAGE_BEGIN)
+		return;
+	if(ready[dp->type])
 		return;
 	if (len < sizeof(uint32_t) * 2)
 		return;
-	bool valid = true;
 	uint32_t mainc = BufferIO::Read<uint32_t>(pdata);
 	uint32_t sidec = BufferIO::Read<uint32_t>(pdata);
+	bool deck_failed = false;
+	uint32_t deckerror = 0;
 	if (mainc > MAINC_MAX)
-		valid = false;
+		deck_failed = true;
 	else if (sidec > SIDEC_MAX)
-		valid = false;
+		deck_failed = true;
 	else if (len < (2 + mainc + sidec) * sizeof(uint32_t))
-		valid = false;
-	if (!valid) {
+		deck_failed = true;
+	Deck new_deck;
+	if(!deck_failed) {
+		uint32_t deckbuf[MAINC_MAX + SIDEC_MAX];
+		std::memcpy(deckbuf, pdata, (mainc + sidec) * sizeof(uint32_t));
+		uint32_t load_error = DeckManager::LoadDeck(new_deck, deckbuf, mainc, sidec);
+		if(!host_info.no_check_deck) {
+			// no_check_deck silently ignores unknown cards. In that case, the size of new_deck will not equal mainc + sidec.
+			if(load_error) {
+				deckerror = (DECKERROR_UNKNOWNCARD << 28) | load_error;
+				deck_failed = true;
+			} else if(new_deck.main.size() + new_deck.extra.size() != mainc || new_deck.side.size() != sidec) {
+				deckerror = 0;
+				deck_failed = true;
+			} else {
+				deckerror = deckManager.CheckDeck(new_deck, host_info.lflist, host_info.rule);
+				deck_failed = deckerror != 0;
+			}
+		}
+	}
+	if(deck_failed) {
+		pending_ready[dp->type] = false;
+		deck_status[dp->type] = DECKSTATUS_REJECTED;
 		STOC_ErrorMsg scem;
 		scem.msg = ERRMSG_DECKERROR;
-		scem.code = 0;
+		scem.code = deckerror;
 		NetServer::SendPacketToPlayer(dp, STOC_ERROR_MSG, scem);
 		return;
+	} else {
+		pdeck[dp->type] = std::move(new_deck);
+		deck_status[dp->type] = DECKSTATUS_CONFIRMED;
+		if(pending_ready[dp->type]) {
+			pending_ready[dp->type] = false;
+			SetPlayerReady(dp, true);
+		}
 	}
-	uint32_t deckbuf[MAINC_MAX + SIDEC_MAX];
-	std::memcpy(deckbuf, pdata, (mainc + sidec) * sizeof(uint32_t));
-	deck_error[dp->type] = DeckManager::LoadDeck(pdeck[dp->type], deckbuf, mainc, sidec);
 }
 void TagDuel::StartDuel(DuelPlayer* dp) {
 	if(dp != host_player)
 		return;
-	if(!ready[0] || !ready[1] || !ready[2] || !ready[3])
+	if(duel_stage != DUEL_STAGE_BEGIN)
 		return;
+	for(int i = 0; i < 4; ++i)
+		if(!ready[i] || deck_status[i] != DECKSTATUS_CONFIRMED)
+			return;
 	NetServer::StopListen();
 	//NetServer::StopBroadcast();
 	for(int i = 0; i < 4; ++i)

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -44,6 +44,7 @@ public:
 	static void TagTimer(evutil_socket_t fd, short events, void* arg);
 
 private:
+	void SetPlayerReady(DuelPlayer* dp, bool is_ready);
 	int WriteUpdateData(int player, int location, unsigned int flag, unsigned char*& qbuf, int use_cache);
 	
 protected:
@@ -52,9 +53,10 @@ protected:
 	DuelPlayer* cur_player[2]{};
 	std::set<DuelPlayer*> observers;
 	bool ready[4]{};
+	bool pending_ready[4]{};
+	unsigned char deck_status[4]{};
 	bool surrender[4]{};
 	Deck pdeck[4];
-	int deck_error[4]{};
 	unsigned char hand_result[2]{};
 	unsigned char last_response{ 0 };
 	Replay last_replay;


### PR DESCRIPTION
Close #2849

Currently, the server expects the client to send `CTOS_UPDATE_DECK` before `CTOS_HS_READY`, so the deck is validated before the player is marked ready. In practice, the client sends both messages back to back.

If, because of a modified client/server implementation or special deck validation requirements, the server processes these two packets in the opposite order, `CTOS_HS_READY` may validate against the old deck.

This PR makes the two messages order-independent.

- `CTOS_UPDATE_DECK` now performs full deck validation directly, instead of splitting validation into two steps.
- If `CTOS_UPDATE_DECK` is received first, the deck is marked as confirmed, and the player is marked ready when `CTOS_HS_READY` is later received.
- If `CTOS_HS_READY` is received first, the ready request is recorded as pending, and the player is marked ready when `CTOS_UPDATE_DECK` is later received.
- The client can continue sending both messages back to back.

Known drawback:

- `CTOS_UPDATE_DECK` still sends no response when deck validation succeeds.
