### PR TITLE
update & fix duel timer

### DIFF
--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -11,11 +11,16 @@ namespace{
 	std::unordered_map<bufferevent*, DuelPlayer> users{};
 	unsigned short server_port{};
 	event_base* net_evbase{};
-	event* broadcast_ev {};
+	event* broadcast_ev{};
+	event* duel_etimer{};
 	evconnlistener* listener{};
 	DuelMode* duel_mode{};
 	bool broadcast_enabled{};
 	unsigned char net_server_read[SIZE_NETWORK_BUFFER]{};
+
+	void DuelTimer(evutil_socket_t, short, void* arg) {
+		static_cast<DuelMode*>(arg)->TimerTick();
+	}
 }
 
 unsigned char NetServer::net_server_write[SIZE_NETWORK_BUFFER]{};
@@ -98,6 +103,16 @@ void NetServer::StopBroadcast() {
 void NetServer::StopListen() {
 	evconnlistener_disable(listener);
 	StopBroadcast();
+}
+void NetServer::StartDuelTimer() {
+	if(!duel_etimer)
+		return;
+	timeval timeout = { 1, 0 };
+	event_add(duel_etimer, &timeout);
+}
+void NetServer::StopDuelTimer() {
+	if(duel_etimer)
+		event_del(duel_etimer);
 }
 void NetServer::BroadcastEvent(evutil_socket_t fd, short events, void* arg) {
 	sockaddr_in bc_addr;
@@ -186,10 +201,11 @@ void NetServer::ServerThread() {
 		event_free(broadcast_ev);
 		broadcast_ev = nullptr;
 	}
-	if(duel_mode) {
-		event_free(duel_mode->etimer);
+	if(duel_etimer)
+		event_free(duel_etimer);
+	duel_etimer = nullptr;
+	if(duel_mode)
 		delete duel_mode;
-	}
 	duel_mode = nullptr;
 	event_base_free(net_evbase);
 	net_evbase = nullptr;
@@ -316,18 +332,16 @@ void NetServer::HandleCTOSPacket(DuelPlayer* dp, unsigned char* data, size_t len
 		}
 		if (pkt->info.mode == MODE_SINGLE) {
 			duel_mode = new SingleDuel(false);
-			duel_mode->etimer = event_new(net_evbase, 0, EV_TIMEOUT | EV_PERSIST, SingleDuel::SingleTimer, duel_mode);
 		}
 		else if (pkt->info.mode == MODE_MATCH) {
 			duel_mode = new SingleDuel(true);
-			duel_mode->etimer = event_new(net_evbase, 0, EV_TIMEOUT | EV_PERSIST, SingleDuel::SingleTimer, duel_mode);
 		}
 		else if (pkt->info.mode == MODE_TAG) {
 			duel_mode = new TagDuel();
-			duel_mode->etimer = event_new(net_evbase, 0, EV_TIMEOUT | EV_PERSIST, TagDuel::TagTimer, duel_mode);
 		}
 		else
 			return;
+		duel_etimer = event_new(net_evbase, -1, EV_PERSIST, DuelTimer, duel_mode);
 		duel_mode->host_info = pkt->info;
 		BufferIO::NullTerminate(pkt->name);
 		BufferIO::NullTerminate(pkt->pass);

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -22,6 +22,8 @@ public:
 	static void StopServer();
 	static void StopBroadcast();
 	static void StopListen();
+	static void StartDuelTimer();
+	static void StopDuelTimer();
 	static void BroadcastEvent(evutil_socket_t fd, short events, void* arg);
 	static void ServerAccept(evconnlistener* listener, evutil_socket_t fd, sockaddr* address, int socklen, void* ctx);
 	static void ServerAcceptError(evconnlistener *listener, void* ctx);

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -223,11 +223,11 @@ public:
 	virtual void Surrender(DuelPlayer* dp) = 0;
 	virtual void GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len) = 0;
 	virtual void TimeConfirm(DuelPlayer* dp) = 0;
+	virtual void TimerTick() = 0;
 	virtual void EndDuel() = 0;
 	virtual void OnPlayerDisconnected(DuelPlayer* dp) = 0;
 
 public:
-	event* etimer { nullptr };
 	DuelPlayer* host_player{ nullptr };
 	HostInfo host_info;
 	int duel_stage{};

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -481,8 +481,7 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	start_duel(pduel, opt);
 	if(host_info.time_limit) {
 		time_elapsed = 0;
-		timeval timeout = { 1, 0 };
-		event_add(etimer, &timeout);
+		NetServer::StartDuelTimer();
 	}
 	Process();
 }
@@ -571,7 +570,6 @@ void SingleDuel::Surrender(DuelPlayer* dp) {
 	}
 	EndDuel();
 	DuelEndProc();
-	event_del(etimer);
 }
 // Analyze ocgcore message
 int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
@@ -1452,7 +1450,7 @@ void SingleDuel::EndDuel() {
 	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 		NetServer::ReSendToPlayer(*oit);
 	end_duel(pduel);
-	event_del(etimer);
+	NetServer::StopDuelTimer();
 	pduel = 0;
 }
 void SingleDuel::OnPlayerDisconnected(DuelPlayer* dp) {
@@ -1621,33 +1619,28 @@ uint32_t SingleDuel::MessageHandler(intptr_t fduel, uint32_t type) {
 	mainGame->AddDebugMsg(msgbuf);
 	return 0;
 }
-void SingleDuel::SingleTimer(evutil_socket_t fd, short events, void* arg) {
-	SingleDuel* sd = static_cast<SingleDuel*>(arg);
-	sd->time_elapsed++;
-	if(sd->time_elapsed >= sd->time_limit[sd->last_response] || sd->time_limit[sd->last_response] <= 0) {
+void SingleDuel::TimerTick() {
+	time_elapsed++;
+	if(time_elapsed >= time_limit[last_response] || time_limit[last_response] <= 0) {
 		unsigned char wbuf[3];
-		uint32_t player = sd->last_response;
+		uint32_t player = last_response;
 		wbuf[0] = MSG_WIN;
 		wbuf[1] = 1 - player;
 		wbuf[2] = 0x3;
-		NetServer::SendBufferToPlayer(sd->players[0], STOC_GAME_MSG, wbuf, 3);
-		NetServer::ReSendToPlayer(sd->players[1]);
-		for(auto oit = sd->observers.begin(); oit != sd->observers.end(); ++oit)
+		NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, wbuf, 3);
+		NetServer::ReSendToPlayer(players[1]);
+		for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 			NetServer::ReSendToPlayer(*oit);
-		if(sd->players[player] == sd->pplayer[player]) {
-			sd->match_result[sd->duel_count++] = 1 - player;
-			sd->tp_player = player;
+		if(players[player] == pplayer[player]) {
+			match_result[duel_count++] = 1 - player;
+			tp_player = player;
 		} else {
-			sd->match_result[sd->duel_count++] = player;
-			sd->tp_player = 1 - player;
+			match_result[duel_count++] = player;
+			tp_player = 1 - player;
 		}
-		sd->EndDuel();
-		sd->DuelEndProc();
-		event_del(sd->etimer);
-		return;
+		EndDuel();
+		DuelEndProc();
 	}
-	timeval timeout = { 1, 0 };
-	event_add(sd->etimer, &timeout);
 }
 
 }

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -430,6 +430,7 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	}
 	time_limit[0] = host_info.time_limit;
 	time_limit[1] = host_info.time_limit;
+	time_elapsed = 0;
 	set_script_reader(DataManager::ScriptReaderEx);
 	set_card_reader(DataManager::CardReader);
 	set_message_handler(SingleDuel::MessageHandler);
@@ -479,10 +480,8 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	RefreshExtra(0);
 	RefreshExtra(1);
 	start_duel(pduel, opt);
-	if(host_info.time_limit) {
-		time_elapsed = 0;
+	if(host_info.time_limit)
 		NetServer::StartDuelTimer();
-	}
 	Process();
 }
 void SingleDuel::Process() {
@@ -1621,7 +1620,7 @@ uint32_t SingleDuel::MessageHandler(intptr_t fduel, uint32_t type) {
 }
 void SingleDuel::TimerTick() {
 	time_elapsed++;
-	if(time_elapsed >= time_limit[last_response] || time_limit[last_response] <= 0) {
+	if(time_elapsed >= time_limit[last_response]) {
 		unsigned char wbuf[3];
 		uint32_t player = last_response;
 		wbuf[0] = MSG_WIN;

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -28,6 +28,7 @@ public:
 	int Analyze(unsigned char* msgbuffer, unsigned int len) override;
 	void GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len) override;
 	void TimeConfirm(DuelPlayer* dp) override;
+	void TimerTick() override;
 	void EndDuel() override;
 	void OnPlayerDisconnected(DuelPlayer* dp) override;
 	
@@ -41,8 +42,6 @@ public:
 	void RefreshSingle(int player, int location, int sequence, int flag = 0xf81fff);
 
 	static uint32_t MessageHandler(intptr_t fduel, uint32_t type);
-	static void SingleTimer(evutil_socket_t fd, short events, void* arg);
-
 private:
 	int WriteUpdateData(int player, int location, unsigned int flag, unsigned char*& qbuf, int use_cache);
 	

--- a/gframe/single_duel.h
+++ b/gframe/single_duel.h
@@ -61,8 +61,8 @@ protected:
 	unsigned char duel_count{ 0 };
 	unsigned char tp_player{ 0 };
 	unsigned char match_result[3]{};
-	short time_limit[2]{};
-	short time_elapsed{ 0 };
+	uint16_t time_limit[2]{};
+	uint16_t time_elapsed{ 0 };
 };
 
 }

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -402,6 +402,7 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	}
 	time_limit[0] = host_info.time_limit;
 	time_limit[1] = host_info.time_limit;
+	time_elapsed = 0;
 	set_script_reader(DataManager::ScriptReaderEx);
 	set_card_reader(DataManager::CardReader);
 	set_message_handler(TagDuel::MessageHandler);
@@ -464,10 +465,8 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	RefreshExtra(0);
 	RefreshExtra(1);
 	start_duel(pduel, opt);
-	if(host_info.time_limit) {
-		time_elapsed = 0;
+	if(host_info.time_limit)
 		NetServer::StartDuelTimer();
-	}
 	Process();
 }
 void TagDuel::Process() {
@@ -1749,7 +1748,7 @@ uint32_t TagDuel::MessageHandler(intptr_t fduel, uint32_t type) {
 }
 void TagDuel::TimerTick() {
 	time_elapsed++;
-	if(time_elapsed >= time_limit[last_response] || time_limit[last_response] <= 0) {
+	if(time_elapsed >= time_limit[last_response]) {
 		unsigned char wbuf[3];
 		uint32_t player = last_response;
 		wbuf[0] = MSG_WIN;

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -466,8 +466,7 @@ void TagDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	start_duel(pduel, opt);
 	if(host_info.time_limit) {
 		time_elapsed = 0;
-		timeval timeout = { 1, 0 };
-		event_add(etimer, &timeout);
+		NetServer::StartDuelTimer();
 	}
 	Process();
 }
@@ -529,7 +528,6 @@ void TagDuel::Surrender(DuelPlayer* dp) {
 		NetServer::ReSendToPlayer(*oit);
 	EndDuel();
 	DuelEndProc();
-	event_del(etimer);
 }
 int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 	unsigned char* offset, *pbufw, *pbuf = msgbuffer;
@@ -1554,7 +1552,7 @@ void TagDuel::EndDuel() {
 	for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 		NetServer::ReSendToPlayer(*oit);
 	end_duel(pduel);
-	event_del(etimer);
+	NetServer::StopDuelTimer();
 	pduel = 0;
 }
 void TagDuel::OnPlayerDisconnected(DuelPlayer* dp) {
@@ -1749,26 +1747,21 @@ uint32_t TagDuel::MessageHandler(intptr_t fduel, uint32_t type) {
 	mainGame->AddDebugMsg(msgbuf);
 	return 0;
 }
-void TagDuel::TagTimer(evutil_socket_t fd, short events, void* arg) {
-	TagDuel* sd = static_cast<TagDuel*>(arg);
-	sd->time_elapsed++;
-	if(sd->time_elapsed >= sd->time_limit[sd->last_response] || sd->time_limit[sd->last_response] <= 0) {
+void TagDuel::TimerTick() {
+	time_elapsed++;
+	if(time_elapsed >= time_limit[last_response] || time_limit[last_response] <= 0) {
 		unsigned char wbuf[3];
-		uint32_t player = sd->last_response;
+		uint32_t player = last_response;
 		wbuf[0] = MSG_WIN;
 		wbuf[1] = 1 - player;
 		wbuf[2] = 0x3;
-		NetServer::SendBufferToPlayer(sd->players[0], STOC_GAME_MSG, wbuf, 3);
-		NetServer::ReSendToPlayer(sd->players[1]);
-		NetServer::ReSendToPlayer(sd->players[2]);
-		NetServer::ReSendToPlayer(sd->players[3]);
-		sd->EndDuel();
-		sd->DuelEndProc();
-		event_del(sd->etimer);
-		return;
+		NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, wbuf, 3);
+		NetServer::ReSendToPlayer(players[1]);
+		NetServer::ReSendToPlayer(players[2]);
+		NetServer::ReSendToPlayer(players[3]);
+		EndDuel();
+		DuelEndProc();
 	}
-	timeval timeout = { 1, 0 };
-	event_add(sd->etimer, &timeout);
 }
 
 }

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -28,6 +28,7 @@ public:
 	int Analyze(unsigned char* msgbuffer, unsigned int len) override;
 	void GetResponse(DuelPlayer* dp, unsigned char* pdata, unsigned int len) override;
 	void TimeConfirm(DuelPlayer* dp) override;
+	void TimerTick() override;
 	void EndDuel() override;
 	void OnPlayerDisconnected(DuelPlayer* dp) override;
 	
@@ -41,8 +42,6 @@ public:
 	void RefreshSingle(int player, int location, int sequence, int flag = 0xf81fff);
 
 	static uint32_t MessageHandler(intptr_t fduel, uint32_t type);
-	static void TagTimer(evutil_socket_t fd, short events, void* arg);
-
 private:
 	int WriteUpdateData(int player, int location, unsigned int flag, unsigned char*& qbuf, int use_cache);
 	

--- a/gframe/tag_duel.h
+++ b/gframe/tag_duel.h
@@ -59,8 +59,8 @@ protected:
 	Replay last_replay;
 	size_t last_replay_response_size{ 0 };
 	unsigned char turn_count{ 0 };
-	short time_limit[2]{};
-	short time_elapsed{ 0 };
+	uint16_t time_limit[2]{};
+	uint16_t time_elapsed{ 0 };
 };
 
 }


### PR DESCRIPTION
- Move ownership of the duel timer from `DuelMode` to `NetServer`.
  - Ready for removing the libevent dependency from `single_duel.cpp` and `tag_duel.cpp` in the [future](https://github.com/mercury233/ygopro/pull/61).
  - The current architecture is already designed to support only one `DuelMode` instance.
- Fix the incorrect file descriptor passed to `event_new` and remove the redundant `EV_TIMEOUT` flag.
- Remove redundant `event_add` and `event_del` calls.
- Change `time_limit` and `time_elapsed` from `short` to `uint16_t`, allowing them to represent the full range of `HostInfo::time_limit`.