### PR TITLE
move `sqlite3.h` to `data_manager.cpp`

### DIFF
--- a/gframe/data_manager.cpp
+++ b/gframe/data_manager.cpp
@@ -1,6 +1,7 @@
 #include "data_manager.h"
 #include "game.h"
 #include "client_card.h"
+#include <sqlite3.h>
 
 namespace ygo {
 

--- a/gframe/data_manager.h
+++ b/gframe/data_manager.h
@@ -4,7 +4,6 @@
 #include <unordered_map>
 #include <vector>
 #include <string>
-#include <sqlite3.h>
 #include "../ocgcore/card_data.h"
 
 namespace irr {
@@ -13,6 +12,9 @@ namespace irr {
 		class IFileSystem;
 	}
 }
+
+struct sqlite3;
+struct sqlite3_stmt;
 
 namespace ygo {
 


### PR DESCRIPTION
Use forward declarations. Avoid having a large number of translation units include `sqlite3.h`.
