### PR TITLE
define `NOMINMAX` and `WIN32_LEAN_AND_MEAN` globally on Windows

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -7,7 +7,6 @@
 
 #ifdef _WIN32
 
-#define NOMINMAX
 #include <WinSock2.h>
 #include <windows.h>
 #include <ws2tcpip.h>

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -4,7 +4,9 @@
 #include <event2/thread.h>
 #include <clocale>
 #include <memory>
-#ifndef _WIN32
+#ifdef _WIN32
+#include <shellapi.h>
+#else
 #include <signal.h>
 #endif
 

--- a/gframe/myfilesystem.h
+++ b/gframe/myfilesystem.h
@@ -16,7 +16,6 @@
 
 #ifdef _WIN32
 
-#define NOMINMAX
 #include <Windows.h>
 #include <shellapi.h>
 

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -5,6 +5,7 @@ project "YGOPro"
         openmp "On"
     end
 
+    defines { "_IRR_STATIC_LIB_" }
     files { "*.cpp", "*.h" }
     includedirs { "../ocgcore", EVENT_INCLUDE_DIR, IRRLICHT_INCLUDE_DIR, JPEG_INCLUDE_DIR, ZLIB_INCLUDE_DIR, LZMA_INCLUDE_DIR, SQLITE_INCLUDE_DIR }
     links { "ocgcore", "lzma", "sqlite3", "irrlicht", "png", "freetype", "event" }
@@ -83,7 +84,7 @@ project "YGOPro"
         entrypoint "mainCRTStartup"
         files "ygopro.rc"
         links { "ws2_32", "iphlpapi", "winmm" }
-        defines { "_IRR_STATIC_LIB_", "NOMINMAX=1", "WIN32_LEAN_AND_MEAN" }
+        defines { "NOMINMAX=1", "WIN32_LEAN_AND_MEAN" }
 
     filter "not action:vs*"
         cppdialect "C++14"

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -5,7 +5,6 @@ project "YGOPro"
         openmp "On"
     end
 
-    defines { "_IRR_STATIC_LIB_" }
     files { "*.cpp", "*.h" }
     includedirs { "../ocgcore", EVENT_INCLUDE_DIR, IRRLICHT_INCLUDE_DIR, JPEG_INCLUDE_DIR, ZLIB_INCLUDE_DIR, LZMA_INCLUDE_DIR, SQLITE_INCLUDE_DIR }
     links { "ocgcore", "lzma", "sqlite3", "irrlicht", "png", "freetype", "event" }
@@ -84,6 +83,7 @@ project "YGOPro"
         entrypoint "mainCRTStartup"
         files "ygopro.rc"
         links { "ws2_32", "iphlpapi", "winmm" }
+        defines { "_IRR_STATIC_LIB_", "NOMINMAX=1", "WIN32_LEAN_AND_MEAN" }
 
     filter "not action:vs*"
         cppdialect "C++14"


### PR DESCRIPTION
`NOMINMAX` prevents `Windows.h` from defining the `min` and `max` macros, which can conflict with functions such as `std::min` and `std::max`.

`WIN32_LEAN_AND_MEAN` reduces the number of headers indirectly included by `Windows.h`.

`NOMINMAX` is currently defined in individual source headers. However, `Windows.h` is not only included explicitly: it can also be pulled in indirectly by headers such as `WinSock2.h`, and even through libevent headers. Defining the macros for the entire YGOPro Windows target therefore provides more reliable behavior regardless of include order.

This may only be a temporary solution. Moving the definitions back into the source code could be reconsidered after separate future changes address the widespread inclusion of `event2/event.h` through `network.h` and the nearly global inclusion of `WinSock2.h`.

One concrete example occurs in #3145 : without this change, placing `#include "myfilesystem.h"` before `#include "game.h"` causes the Winsock-related files to fail to compile.

`irrlicht` and `libevent` have already defined `WIN32_LEAN_AND_MEAN` internally.

With `WIN32_LEAN_AND_MEAN` defined, `Windows.h` no longer includes the Shell API declarations. Therefore, `CommandLineToArgvW` now requires an explicit `#include <shellapi.h>`.