### PR TITLE
update network headers

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -4,12 +4,12 @@
 #define IRR_COMPILE_WITH_DX9_DEV_PACK
 
 #include <cerrno>
+#include <cstdio>
+#include <string>
+#include "bufferio.h"
+#include "../ocgcore/ocgapi.h"
 
 #ifdef _WIN32
-
-#include <WinSock2.h>
-#include <windows.h>
-#include <ws2tcpip.h>
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #define mywcsncasecmp _wcsnicmp
@@ -19,34 +19,12 @@
 #define mystrncasecmp strncasecmp
 #endif
 
-#define socklen_t int
-
 #else //_WIN32
-
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/ioctl.h>
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <unistd.h>
-
-#define SD_BOTH 2
-#define SOCKET int
-#define closesocket close
-#define INVALID_SOCKET -1
-#define SOCKET_ERROR -1
-#define SOCKADDR_IN sockaddr_in
-#define SOCKADDR sockaddr
-#define SOCKET_ERRNO() (errno)
 
 #define mywcsncasecmp wcsncasecmp
 #define mystrncasecmp strncasecmp
-#endif
 
-#include <cstdio>
-#include <string>
-#include "bufferio.h"
-#include "../ocgcore/ocgapi.h"
+#endif // _WIN32
 
 template<size_t N, typename... TR>
 inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {
@@ -65,4 +43,4 @@ inline T myclamp(T v, T lo, T hi) {
 
 constexpr uint16_t PRO_VERSION = 0x1362;
 
-#endif
+#endif // YGOPRO_CONFIG_H

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -13,6 +13,10 @@
 #include "game.h"
 #include "deck_manager.h"
 #include "replay.h"
+#include "mysocket.h"
+#include <event2/event.h>
+#include <event2/bufferevent.h>
+#include <event2/buffer.h>
 
 namespace ygo {
 
@@ -62,6 +66,10 @@ unsigned char DuelClient::duel_client_write[SIZE_NETWORK_BUFFER]{};
 unsigned char DuelClient::selftype = 0;
 std::vector<HostPacket> DuelClient::hosts;
 
+int DuelClient::WriteBufferEvent(bufferevent* bufev, const void* data, size_t size) {
+	return bufferevent_write(bufev, data, size);
+}
+
 bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_game) {
 	if(connect_state != CONNECT_STATE_NONE)
 		return false;
@@ -93,7 +101,7 @@ bool DuelClient::StartClient(unsigned int ip, unsigned short port, bool create_g
 	std::thread(ClientThread).detach();
 	return true;
 }
-void DuelClient::ConnectTimeout(evutil_socket_t fd, short events, void* arg) {
+void DuelClient::ConnectTimeout(EventSocket fd, short events, void* arg) {
 	if(connect_state & CONNECT_STATE_JOINED)
 		return;
 	if(close_reason == CLIENT_CLOSE_REASON_NONE) {
@@ -4121,7 +4129,7 @@ void DuelClient::BeginRefreshHost() {
 	hosts.clear();
 	std::vector<unsigned int> local_addresses;
 	char hname[256]{};
-	if(gethostname(hname, sizeof(hname) - 1) != SOCKET_ERROR) {
+	if(gethostname(hname, sizeof(hname) - 1) != SOCKET_RESULT_ERROR) {
 		evutil_addrinfo hints{};
 		hints.ai_family = AF_INET;
 		hints.ai_socktype = SOCK_DGRAM;
@@ -4147,8 +4155,8 @@ void DuelClient::BeginRefreshHost() {
 		EndRefreshHost();
 		return;
 	}
-	SOCKET reply = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	if(reply == INVALID_SOCKET) {
+	Socket reply = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if(reply == INVALID_SOCKET_HANDLE) {
 		event_base_free(broadev);
 		EndRefreshHost();
 		return;
@@ -4158,8 +4166,8 @@ void DuelClient::BeginRefreshHost() {
 	reply_addr.sin_family = AF_INET;
 	reply_addr.sin_port = htons(7921);
 	reply_addr.sin_addr.s_addr = 0;
-	if(bind(reply, (sockaddr*)&reply_addr, sizeof(reply_addr)) == SOCKET_ERROR) {
-		closesocket(reply);
+	if(bind(reply, (sockaddr*)&reply_addr, sizeof(reply_addr)) == SOCKET_RESULT_ERROR) {
+		CloseSocket(reply);
 		event_base_free(broadev);
 		EndRefreshHost();
 		return;
@@ -4171,17 +4179,17 @@ void DuelClient::BeginRefreshHost() {
 			event_free(resp_event);
 			resp_event = nullptr;
 		}
-		closesocket(reply);
+		CloseSocket(reply);
 		event_base_free(broadev);
 		EndRefreshHost();
 		return;
 	}
 	std::thread(RefreshThread, broadev).detach();
 	//send request
-	SOCKADDR_IN local;
+	sockaddr_in local;
 	local.sin_family = AF_INET;
 	local.sin_port = htons(7922);
-	SOCKADDR_IN sockTo;
+	sockaddr_in sockTo;
 	sockTo.sin_addr.s_addr = htonl(INADDR_BROADCAST);
 	sockTo.sin_family = AF_INET;
 	sockTo.sin_port = htons(7920);
@@ -4189,22 +4197,22 @@ void DuelClient::BeginRefreshHost() {
 	hReq.identifier = NETWORK_CLIENT_ID;
 	for(auto local_addr : local_addresses) {
 		local.sin_addr.s_addr = local_addr;
-		SOCKET sSend = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-		if(sSend == INVALID_SOCKET)
+		Socket sSend = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+		if(sSend == INVALID_SOCKET_HANDLE)
 			continue;
 		int opt = TRUE;
 		setsockopt(sSend, SOL_SOCKET, SO_BROADCAST, (const char*)&opt, sizeof opt);
-		if(bind(sSend, (sockaddr*)&local, sizeof(sockaddr)) == SOCKET_ERROR) {
-			closesocket(sSend);
+		if(bind(sSend, (sockaddr*)&local, sizeof(sockaddr)) == SOCKET_RESULT_ERROR) {
+			CloseSocket(sSend);
 			continue;
 		}
 		sendto(sSend, (const char*)&hReq, sizeof(HostRequest), 0, (sockaddr*)&sockTo, sizeof(sockaddr));
-		closesocket(sSend);
+		CloseSocket(sSend);
 	}
 }
 int DuelClient::RefreshThread(event_base* broadev) {
 	event_base_dispatch(broadev);
-	evutil_socket_t fd;
+	EventSocket fd;
 	event_get_assignment(resp_event, 0, &fd, 0, 0, 0);
 	evutil_closesocket(fd);
 	event_free(resp_event);
@@ -4213,7 +4221,7 @@ int DuelClient::RefreshThread(event_base* broadev) {
 	EndRefreshHost();
 	return 0;
 }
-void DuelClient::BroadcastReply(evutil_socket_t fd, short events, void * arg) {
+void DuelClient::BroadcastReply(EventSocket fd, short events, void * arg) {
 	if(events & EV_TIMEOUT) {
 		event_base_loopbreak((event_base*)arg);
 	} else if(events & EV_READ) {

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -4200,7 +4200,7 @@ void DuelClient::BeginRefreshHost() {
 		Socket sSend = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 		if(sSend == INVALID_SOCKET_HANDLE)
 			continue;
-		int opt = TRUE;
+		int opt = 1;
 		setsockopt(sSend, SOL_SOCKET, SO_BROADCAST, (const char*)&opt, sizeof opt);
 		if(bind(sSend, (sockaddr*)&local, sizeof(sockaddr)) == SOCKET_RESULT_ERROR) {
 			CloseSocket(sSend);

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -21,11 +21,12 @@ class DuelClient {
 private:
 	static bufferevent* client_bev;
 	static unsigned char duel_client_write[SIZE_NETWORK_BUFFER];
+	static int WriteBufferEvent(bufferevent* bufev, const void* data, size_t size);
 
 public:
 	static unsigned char selftype;
 	static bool StartClient(unsigned int ip, unsigned short port, bool create_game = true);
-	static void ConnectTimeout(evutil_socket_t fd, short events, void* arg);
+	static void ConnectTimeout(EventSocket fd, short events, void* arg);
 	static void StopClient(unsigned reason = CLIENT_CLOSE_REASON_STOP);
 	static void ClientRead(bufferevent* bev, void* ctx);
 	static void ClientEvent(bufferevent* bev, short events, void* ctx);
@@ -41,7 +42,7 @@ public:
 		auto p = duel_client_write;
 		BufferIO::Write<uint16_t>(p, 1);
 		BufferIO::Write<uint8_t>(p, proto);
-		bufferevent_write(client_bev, duel_client_write, 3);
+		WriteBufferEvent(client_bev, duel_client_write, 3);
 	}
 	template<typename ST>
 	static void SendPacketToServer(unsigned char proto, const ST& st) {
@@ -50,7 +51,7 @@ public:
 		BufferIO::Write<uint16_t>(p, (uint16_t)(1 + sizeof(ST)));
 		BufferIO::Write<uint8_t>(p, proto);
 		std::memcpy(p, &st, sizeof(ST));
-		bufferevent_write(client_bev, duel_client_write, sizeof(ST) + 3);
+		WriteBufferEvent(client_bev, duel_client_write, sizeof(ST) + 3);
 	}
 	static void SendBufferToServer(unsigned char proto, void* buffer, size_t len) {
 		auto p = duel_client_write;
@@ -59,13 +60,13 @@ public:
 		BufferIO::Write<uint16_t>(p, (uint16_t)(1 + len));
 		BufferIO::Write<uint8_t>(p, proto);
 		std::memcpy(p, buffer, len);
-		bufferevent_write(client_bev, duel_client_write, len + 3);
+		WriteBufferEvent(client_bev, duel_client_write, len + 3);
 	}
 
 	static std::vector<HostPacket> hosts;
 	static void BeginRefreshHost();
 	static int RefreshThread(event_base* broadev);
-	static void BroadcastReply(evutil_socket_t fd, short events, void* arg);
+	static void BroadcastReply(EventSocket fd, short events, void* arg);
 
 	static unsigned int ResolveHostName(const char* hostname, const char* port);
 };

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -13,6 +13,7 @@
 #include <thread>
 #include <chrono>
 #ifdef _WIN32
+#include <windows.h>
 #include <timeapi.h>
 #else
 #include <spawn.h>

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -14,6 +14,11 @@
 #include <mutex>
 #include <functional>
 
+#ifdef _WIN32
+struct HWND__;
+using HWND = HWND__*;
+#endif
+
 namespace ygo {
 
 constexpr int DEFAULT_DUEL_RULE = CURRENT_RULE;

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -5,6 +5,8 @@
 #include <clocale>
 #include <memory>
 #ifdef _WIN32
+#include <WinSock2.h>
+#include <windows.h>
 #include <shellapi.h>
 #else
 #include <signal.h>

--- a/gframe/mysocket.h
+++ b/gframe/mysocket.h
@@ -1,0 +1,45 @@
+#ifndef YGOPRO_SOCKET_H
+#define YGOPRO_SOCKET_H
+
+#ifdef _WIN32
+
+#include <WinSock2.h>
+#include <ws2tcpip.h>
+
+#else
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+
+#endif // _WIN32
+
+namespace ygo {
+
+#ifdef _WIN32
+
+using Socket = SOCKET;
+constexpr Socket INVALID_SOCKET_HANDLE = INVALID_SOCKET;
+constexpr int SOCKET_RESULT_ERROR = SOCKET_ERROR;
+
+inline int CloseSocket(Socket socket) {
+	return closesocket(socket);
+}
+
+#else
+
+using Socket = int;
+constexpr Socket INVALID_SOCKET_HANDLE = -1;
+constexpr int SOCKET_RESULT_ERROR = -1;
+
+inline int CloseSocket(Socket socket) {
+	return close(socket);
+}
+
+#endif // _WIN32
+
+}
+
+#endif // YGOPRO_SOCKET_H

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -77,7 +77,7 @@ bool NetServer::StartBroadcast() {
 	if(!net_evbase || !broadcast_enabled)
 		return false;
 	Socket udp = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	int opt = TRUE;
+	int opt = 1;
 	setsockopt(udp, SOL_SOCKET, SO_BROADCAST, (const char*)&opt, sizeof opt);
 	setsockopt(udp, SOL_SOCKET, SO_REUSEADDR, (const char*)&opt, sizeof opt);
 	sockaddr_in addr;

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -2,8 +2,14 @@
 #include "netserver.h"
 #include "single_duel.h"
 #include "tag_duel.h"
+#include "deck_manager.h"
+#include "mysocket.h"
 #include <thread>
 #include <unordered_map>
+#include <event2/event.h>
+#include <event2/listener.h>
+#include <event2/bufferevent.h>
+#include <event2/buffer.h>
 
 namespace ygo {
 
@@ -18,7 +24,7 @@ namespace{
 	bool broadcast_enabled{};
 	unsigned char net_server_read[SIZE_NETWORK_BUFFER]{};
 
-	void DuelTimer(evutil_socket_t, short, void* arg) {
+	void DuelTimer(EventSocket, short, void* arg) {
 		static_cast<DuelMode*>(arg)->TimerTick();
 	}
 }
@@ -26,6 +32,10 @@ namespace{
 unsigned char NetServer::net_server_write[SIZE_NETWORK_BUFFER]{};
 size_t NetServer::last_sent{};
 bufferevent* NetServer::disconnecting_bev = nullptr;
+
+int NetServer::WriteBufferEvent(bufferevent* bufev, const void* data, size_t size) {
+	return bufferevent_write(bufev, data, size);
+}
 
 bool NetServer::StartServer(unsigned short port, unsigned int ip, unsigned short* out_actual_port, bool enable_broadcast) {
 	if(net_evbase)
@@ -48,7 +58,7 @@ bool NetServer::StartServer(unsigned short port, unsigned int ip, unsigned short
 	sockaddr_in bound_addr;
 	std::memset(&bound_addr, 0, sizeof bound_addr);
 	socklen_t bound_addr_len = sizeof bound_addr;
-	if(getsockname(evconnlistener_get_fd(listener), (sockaddr*)&bound_addr, &bound_addr_len) == SOCKET_ERROR) {
+	if(getsockname(evconnlistener_get_fd(listener), (sockaddr*)&bound_addr, &bound_addr_len) == SOCKET_RESULT_ERROR) {
 		evconnlistener_free(listener);
 		listener = nullptr;
 		event_base_free(net_evbase);
@@ -66,7 +76,7 @@ bool NetServer::StartServer(unsigned short port, unsigned int ip, unsigned short
 bool NetServer::StartBroadcast() {
 	if(!net_evbase || !broadcast_enabled)
 		return false;
-	SOCKET udp = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	Socket udp = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	int opt = TRUE;
 	setsockopt(udp, SOL_SOCKET, SO_BROADCAST, (const char*)&opt, sizeof opt);
 	setsockopt(udp, SOL_SOCKET, SO_REUSEADDR, (const char*)&opt, sizeof opt);
@@ -75,8 +85,8 @@ bool NetServer::StartBroadcast() {
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(7920);
 	addr.sin_addr.s_addr = 0;
-	if(bind(udp, (sockaddr*)&addr, sizeof(addr)) == SOCKET_ERROR) {
-		closesocket(udp);
+	if(bind(udp, (sockaddr*)&addr, sizeof(addr)) == SOCKET_RESULT_ERROR) {
+		CloseSocket(udp);
 		return false;
 	}
 	broadcast_ev = event_new(net_evbase, udp, EV_READ | EV_PERSIST, BroadcastEvent, nullptr);
@@ -94,7 +104,7 @@ void NetServer::StopBroadcast() {
 	if(!net_evbase || !broadcast_ev)
 		return;
 	event_del(broadcast_ev);
-	evutil_socket_t fd;
+	EventSocket fd;
 	event_get_assignment(broadcast_ev, 0, &fd, 0, 0, 0);
 	evutil_closesocket(fd);
 	event_free(broadcast_ev);
@@ -114,7 +124,7 @@ void NetServer::StopDuelTimer() {
 	if(duel_etimer)
 		event_del(duel_etimer);
 }
-void NetServer::BroadcastEvent(evutil_socket_t fd, short events, void* arg) {
+void NetServer::BroadcastEvent(EventSocket fd, short events, void* arg) {
 	sockaddr_in bc_addr;
 	socklen_t sz = sizeof(sockaddr_in);
 	char buf[256];
@@ -125,7 +135,7 @@ void NetServer::BroadcastEvent(evutil_socket_t fd, short events, void* arg) {
 	std::memcpy(&packet, buf, sizeof packet);
 	const HostRequest* pHR = &packet;
 	if(pHR->identifier == NETWORK_CLIENT_ID) {
-		SOCKADDR_IN sockTo;
+		sockaddr_in sockTo;
 		sockTo.sin_addr.s_addr = bc_addr.sin_addr.s_addr;
 		sockTo.sin_family = AF_INET;
 		sockTo.sin_port = htons(7921);
@@ -138,7 +148,7 @@ void NetServer::BroadcastEvent(evutil_socket_t fd, short events, void* arg) {
 		sendto(fd, (const char*)&hp, sizeof(HostPacket), 0, (sockaddr*)&sockTo, sizeof(sockTo));
 	}
 }
-void NetServer::ServerAccept(evconnlistener* listener, evutil_socket_t fd, sockaddr* address, int socklen, void* ctx) {
+void NetServer::ServerAccept(evconnlistener* listener, EventSocket fd, sockaddr* address, int socklen, void* ctx) {
 	bufferevent* bev = bufferevent_socket_new(net_evbase, fd, BEV_OPT_CLOSE_ON_FREE);
 	DuelPlayer dp;
 	dp.name[0] = 0;
@@ -195,7 +205,7 @@ void NetServer::ServerThread() {
 	evconnlistener_free(listener);
 	listener = nullptr;
 	if(broadcast_ev) {
-		evutil_socket_t fd;
+		EventSocket fd;
 		event_get_assignment(broadcast_ev, 0, &fd, 0, 0, 0);
 		evutil_closesocket(fd);
 		event_free(broadcast_ev);

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -3,6 +3,7 @@
 
 #include "bufferio.h"
 #include "network.h"
+#include "../ocgcore/ocgapi.h"
 
 namespace ygo {
 
@@ -11,6 +12,7 @@ private:
 	static unsigned char net_server_write[SIZE_NETWORK_BUFFER];
 	static size_t last_sent;
 	static bufferevent* disconnecting_bev;
+	static int WriteBufferEvent(bufferevent* bufev, const void* data, size_t size);
 
 	static bool CanWriteToPlayer(DuelPlayer* dp) {
 		return dp && dp->bev && dp->bev != disconnecting_bev;
@@ -24,8 +26,8 @@ public:
 	static void StopListen();
 	static void StartDuelTimer();
 	static void StopDuelTimer();
-	static void BroadcastEvent(evutil_socket_t fd, short events, void* arg);
-	static void ServerAccept(evconnlistener* listener, evutil_socket_t fd, sockaddr* address, int socklen, void* ctx);
+	static void BroadcastEvent(EventSocket fd, short events, void* arg);
+	static void ServerAccept(evconnlistener* listener, EventSocket fd, sockaddr* address, int socklen, void* ctx);
 	static void ServerAcceptError(evconnlistener *listener, void* ctx);
 	static void ServerEchoRead(bufferevent* bev, void* ctx);
 	static void ServerEchoEvent(bufferevent* bev, short events, void* ctx);
@@ -50,7 +52,7 @@ public:
 		BufferIO::Write<uint8_t>(p, proto);
 		last_sent = 3;
 		if (CanWriteToPlayer(dp))
-			bufferevent_write(dp->bev, net_server_write, 3);
+			WriteBufferEvent(dp->bev, net_server_write, 3);
 	}
 	template<typename ST>
 	static void SendPacketToPlayer(DuelPlayer* dp, unsigned char proto, const ST& st) {
@@ -61,7 +63,7 @@ public:
 		std::memcpy(p, &st, sizeof(ST));
 		last_sent = sizeof(ST) + 3;
 		if (CanWriteToPlayer(dp))
-			bufferevent_write(dp->bev, net_server_write, sizeof(ST) + 3);
+			WriteBufferEvent(dp->bev, net_server_write, sizeof(ST) + 3);
 	}
 	static void SendBufferToPlayer(DuelPlayer* dp, unsigned char proto, void* buffer, size_t len) {
 		auto p = net_server_write;
@@ -72,11 +74,11 @@ public:
 		std::memcpy(p, buffer, len);
 		last_sent = len + 3;
 		if (CanWriteToPlayer(dp))
-			bufferevent_write(dp->bev, net_server_write, len + 3);
+			WriteBufferEvent(dp->bev, net_server_write, len + 3);
 	}
 	static void ReSendToPlayer(DuelPlayer* dp) {
 		if (CanWriteToPlayer(dp))
-			bufferevent_write(dp->bev, net_server_write, last_sent);
+			WriteBufferEvent(dp->bev, net_server_write, last_sent);
 	}
 };
 

--- a/gframe/network.h
+++ b/gframe/network.h
@@ -3,17 +3,23 @@
 
 #include <cstdint>
 #include <cstring>
-#include <event2/event.h>
-#include <event2/listener.h>
-#include <event2/bufferevent.h>
-#include <event2/buffer.h>
-#include <event2/thread.h>
 #include <type_traits>
-#include "deck_manager.h"
+
+struct bufferevent;
+struct event;
+struct event_base;
+struct evconnlistener;
+struct sockaddr;
 
 #define check_trivially_copyable(T) static_assert(std::is_trivially_copyable<T>::value == true && std::is_standard_layout<T>::value == true, "not trivially copyable")
 
 namespace ygo {
+
+#ifdef _WIN32
+using EventSocket = intptr_t; // evutil_socket_t
+#else
+using EventSocket = int;
+#endif
 
 constexpr int SIZE_NETWORK_BUFFER = 0x20000;
 constexpr int MAX_DATA_SIZE = UINT16_MAX - 1;

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -5,6 +5,7 @@
 #include "netserver.h"
 #include "game.h"
 #include "data_manager.h"
+#include "deck_manager.h"
 #include "../ocgcore/mtrandom.h"
 
 namespace ygo {

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -5,6 +5,7 @@
 #include "netserver.h"
 #include "game.h"
 #include "data_manager.h"
+#include "deck_manager.h"
 #include "../ocgcore/mtrandom.h"
 
 namespace ygo {


### PR DESCRIPTION
Currently, the project includes headers such as `<WinSock2.h>`, `<Windows.h>`, and `<sys/socket.h>` almost globally through `config.h`, which is unnecessary. In addition, `network.h`, which is widely included, also pulls in relatively heavy headers such as `<event2/*.h>`. Under the current configuration, `<event2/event.h>` even indirectly includes `<Windows.h>`.

This PR partially refactors the project's header dependencies:

* Restrict libevent headers to implementation files only.
  * Introduce `DuelClient::WriteBufferEvent` and `NetServer::WriteBufferEvent` so that header-defined template functions no longer call `bufferevent_write` directly.
* Move socket-related headers into a new `mysocket.h`, which is included only by source files that directly operate on sockets.
* Replace Windows- and POSIX-specific incompatible socket symbols with project-defined abstractions.
* Remove `deck_manager.h` from `network.h`, as it is not used directly.
* Add `ocgapi.h` to `netserver.h`, which uses `POS_FACEDOWN` and related constants, instead of relying on `config.h` being included first by the implementation file.
* Since `<Windows.h>` is no longer included indirectly, add the required headers and forward declarations where needed.

Future plans:

* Remove `<irrlicht.h>` from `config.h`.
* Remove `CGUITTFont.h` from `game.h`.
* #3145
