### PR TITLE
use default entry point on Windows

### DIFF
--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -25,19 +25,12 @@ void ClickButton(irr::gui::IGUIElement* btn) {
 	ygo::mainGame->device->postEventFromUser(event);
 }
 
-int main(int argc, char* argv[]) {
-#if defined(_WIN32)
-	std::setlocale(LC_CTYPE, ".UTF-8");
-#elif defined(__APPLE__)
-	std::setlocale(LC_CTYPE, "UTF-8");
-#else
-	std::setlocale(LC_CTYPE, "");
-#endif
+int mymain(int wargc, const wchar_t* const wargv[]) {
 #ifdef __APPLE__
 	ygo::Game::FixMacOSBundleWorkingDirectory();
 #endif //__APPLE__
 #ifdef _WIN32
-	if (argc == 2 && (ygo::IsExtension(argv[1], ".ydk") || ygo::IsExtension(argv[1], ".yrp"))) { // open file from explorer
+	if (wargc == 2 && (ygo::IsExtension(wargv[1], L".ydk") || ygo::IsExtension(wargv[1], L".yrp"))) { // open file from explorer
 		wchar_t exepath[MAX_PATH];
 		GetModuleFileNameW(nullptr, exepath, MAX_PATH);
 		wchar_t* p = std::wcsrchr(exepath, L'\\');
@@ -61,19 +54,6 @@ int main(int argc, char* argv[]) {
 	ygo::mainGame = &_game;
 	if(!ygo::mainGame->Initialize())
 		return EXIT_FAILURE;
-
-#ifdef _WIN32
-	int wargc = 0;
-	std::unique_ptr<wchar_t*[], void(*)(wchar_t**)> wargv(CommandLineToArgvW(GetCommandLineW(), &wargc), [](wchar_t** wargv) {
-		LocalFree(wargv);
-	});
-#else
-	int wargc = argc;
-	auto wargv = std::make_unique<wchar_t[][256]>(wargc);
-	for(int i = 0; i < argc; ++i) {
-		BufferIO::DecodeUTF8(argv[i], wargv[i]);
-	}
-#endif //_WIN32
 
 	bool keep_on_return = false;
 	bool deckCategorySpecified = false;
@@ -204,3 +184,37 @@ int main(int argc, char* argv[]) {
 #endif //_WIN32
 	return EXIT_SUCCESS;
 }
+
+#ifdef _WIN32
+
+int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
+	std::setlocale(LC_CTYPE, ".UTF-8");
+	int wargc = 0;
+	std::unique_ptr<wchar_t*[], void(*)(wchar_t**)> wargv(CommandLineToArgvW(GetCommandLineW(), &wargc), [](wchar_t** wargv) {
+		LocalFree(wargv);
+	});
+	if(!wargv)
+		return EXIT_FAILURE;
+	return mymain(wargc, wargv.get());
+}
+
+#else
+
+int main(int argc, char* argv[]) {
+#ifdef __APPLE__
+	std::setlocale(LC_CTYPE, "UTF-8");
+#else
+	std::setlocale(LC_CTYPE, "");
+#endif
+	std::vector<std::wstring> wide_arguments;
+	wide_arguments.reserve(argc);
+	for(int i = 0; i < argc; ++i)
+		wide_arguments.emplace_back(BufferIO::DecodeUTF8String(argv[i]));
+	std::vector<const wchar_t*> wargv;
+	wargv.reserve(argc);
+	for(const auto& argument : wide_arguments)
+		wargv.emplace_back(argument.c_str());
+	return mymain(argc, wargv.data());
+}
+
+#endif //_WIN32

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -25,7 +25,7 @@ void ClickButton(irr::gui::IGUIElement* btn) {
 	ygo::mainGame->device->postEventFromUser(event);
 }
 
-int mymain(int wargc, const wchar_t* const wargv[]) {
+static int mymain(int wargc, const wchar_t* const wargv[]) {
 #ifdef __APPLE__
 	ygo::Game::FixMacOSBundleWorkingDirectory();
 #endif //__APPLE__

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -55,7 +55,6 @@ project "YGOPro"
     end
 
     filter "system:windows"
-        entrypoint "mainCRTStartup"
         files "ygopro.rc"
         links { "ws2_32", "iphlpapi", "winmm" }
         defines { "NOMINMAX=1", "WIN32_LEAN_AND_MEAN" }


### PR DESCRIPTION
Currently, the project uses `main` as its entry point on all platforms. On Windows, `mainCRTStartup` is forcefuly specified as the actual entry point so that it can invoke `main`.

After this change, Windows will use the default `wWinMainCRTStartup` entry point, which invokes `wWinMain`.

Previously, each command-line argument on non-Windows platforms had a fixed maximum length. After this change, a vector of `wstring` objects manages the arguments’ lifetimes, while another vector stores pointers to them.