### PR TITLE
cleanup warnings

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -491,19 +491,22 @@ workspace "YGOPro"
     filter { "configurations:Release", "action:vs*" }
         linktimeoptimization "On"
         staticruntime "On"
-        disablewarnings { "4244", "4267", "4838", "4996", "6011", "6031", "6054", "6262" }
+        disablewarnings {
+            "4996", -- Currently only some dependencies use deprecated functions.
+        }
 
     filter { "configurations:Release", "not action:vs*" }
         defines "NDEBUG"
-
-    filter { "configurations:Debug", "action:vs*" }
-        disablewarnings { "6011", "6031", "6054", "6262" }
 
     filter "action:vs*"
         cdialect "C11"
         conformancemode "On"
         buildoptions { "/utf-8" }
         defines { "_CRT_SECURE_NO_WARNINGS" }
+        disablewarnings {
+            "4244", -- Intentional narrowing conversions are pervasive in the program and dependencies.
+            "4267", -- The 32-bit APIs frequently consume container sizes represented by size_t on 64-bit builds.
+        }
 
     filter "action:gmake"
         buildoptions { "-fno-strict-aliasing" }


### PR DESCRIPTION
- Globally suppress **C4244 (possible data loss from numeric conversion)** and **C4267 (possible data loss from size conversion)** to avoid being overwhelmed by unimportant information.
- Remove the suppression for **C4838 (narrowing conversion warning)**, which no longer appears.
- Remove the suppression for **C6xxx**, which only appear during static code analysis, to avoid hiding actual issues.
  - There are indeed many false positives, but the total number is limited and acceptable.
- Add comments.
