### PR TITLE
header updates

### DIFF
--- a/gframe/config.h
+++ b/gframe/config.h
@@ -1,28 +1,17 @@
 #ifndef YGOPRO_CONFIG_H
 #define YGOPRO_CONFIG_H
 
-#include <cerrno>
 #include <cstdio>
-#include <string>
 #include "bufferio.h"
-#include "../ocgcore/ocgapi.h"
+#include "../ocgcore/common.h"
 
 #ifdef _WIN32
-
-#if defined(_MSC_VER) || defined(__MINGW32__)
 #define mywcsncasecmp _wcsnicmp
 #define mystrncasecmp _strnicmp
 #else
 #define mywcsncasecmp wcsncasecmp
 #define mystrncasecmp strncasecmp
 #endif
-
-#else //_WIN32
-
-#define mywcsncasecmp wcsncasecmp
-#define mystrncasecmp strncasecmp
-
-#endif // _WIN32
 
 template<size_t N, typename... TR>
 inline int myswprintf(wchar_t(&buf)[N], const wchar_t* fmt, TR... args) {

--- a/gframe/deck_con.h
+++ b/gframe/deck_con.h
@@ -2,7 +2,6 @@
 #define DECK_CON_H
 
 #include <string>
-#include <unordered_map>
 #include <vector>
 #include <random>
 #include <IEventReceiver.h>

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cerrno>
 #include "deck_manager.h"
 #include "data_manager.h"
 #include "game.h"

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -7,7 +7,6 @@
 #include "data_manager.h"
 #include "client_card.h"
 #include "materials.h"
-#include "image_manager.h"
 #include "sound_manager.h"
 #include "single_mode.h"
 #include "game.h"

--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -1,5 +1,5 @@
 #include <algorithm>
-#include "event_handler.h"
+#include "client_card.h"
 #include "client_field.h"
 #include "network.h"
 #include "game.h"

--- a/gframe/event_handler.h
+++ b/gframe/event_handler.h
@@ -1,8 +1,0 @@
-#ifndef EVENT_HANDLER_H
-#define EVENT_HANDLER_H
-
-#include "config.h"
-#include "game.h"
-#include "client_card.h"
-
-#endif //EVENT_HANDLER_H

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -6,7 +6,6 @@
 #include "data_manager.h"
 #include "deck_manager.h"
 #include "sound_manager.h"
-#include "replay.h"
 #include "materials.h"
 #include "duelclient.h"
 #include "netserver.h"

--- a/gframe/image_manager.h
+++ b/gframe/image_manager.h
@@ -1,7 +1,6 @@
 #ifndef IMAGEMANAGER_H
 #define IMAGEMANAGER_H
 
-#include "config.h"
 #include <unordered_map>
 #include <queue>
 #include <mutex>

--- a/gframe/irrUString.h
+++ b/gframe/irrUString.h
@@ -32,11 +32,7 @@
 #ifndef __IRR_USTRING_H_INCLUDED__
 #define __IRR_USTRING_H_INCLUDED__
 
-#include <cstring>
-#include <cstdlib>
 #include <cstdint>
-
-#include <utility>
 #include <iterator>
 #include <string>
 

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -7,7 +7,6 @@
 #include "deck_manager.h"
 #include "replay_mode.h"
 #include "single_mode.h"
-#include "image_manager.h"
 #include "sound_manager.h"
 #include "game.h"
 

--- a/gframe/netserver.h
+++ b/gframe/netserver.h
@@ -1,9 +1,8 @@
 #ifndef NETSERVER_H
 #define NETSERVER_H
 
-#include "bufferio.h"
+#include "config.h"
 #include "network.h"
-#include "../ocgcore/ocgapi.h"
 
 namespace ygo {
 

--- a/gframe/replay.h
+++ b/gframe/replay.h
@@ -4,8 +4,8 @@
 #include <cstdio>
 #include <vector>
 #include <string>
-#include "../ocgcore/ocgapi.h"
 #include "deck.h"
+#include "../ocgcore/common.h"
 
 namespace ygo {
 

--- a/gframe/replay_mode.cpp
+++ b/gframe/replay_mode.cpp
@@ -4,6 +4,7 @@
 #include "duelclient.h"
 #include "game.h"
 #include "data_manager.h"
+#include "../ocgcore/ocgapi.h"
 
 namespace ygo {
 

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -7,6 +7,7 @@
 #include "data_manager.h"
 #include "deck_manager.h"
 #include "../ocgcore/mtrandom.h"
+#include "../ocgcore/ocgapi.h"
 
 namespace ygo {
 

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -4,6 +4,7 @@
 #include "duelclient.h"
 #include "game.h"
 #include "data_manager.h"
+#include "../ocgcore/ocgapi.h"
 
 namespace ygo {
 

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -7,6 +7,7 @@
 #include "data_manager.h"
 #include "deck_manager.h"
 #include "../ocgcore/mtrandom.h"
+#include "../ocgcore/ocgapi.h"
 
 namespace ygo {
 


### PR DESCRIPTION
> ocgcore: 855

- Remove unused includes.
- Include `ocgapi.h` only in source files that directly use the OCGCore API.
- Replace unnecessary `ocgapi.h` dependencies with `common.h`.
  - Require https://github.com/Fluorohydride/ygopro-core/pull/855 .
- Move `<cerrno>` to its actual consumer.
- Remove the declaration-free `event_handler.h`.
- Simplify `mywcsncasecmp` and `mystrncasecmp` helpers for the supported Windows toolchains.
