### PR TITLE
Simplify ClientField::Clear by resetting to a new instance

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -17,7 +17,6 @@ ClientField::ClientField() {
 		szone[p].resize(8, 0);
 	}
 }
-ClientField::~ClientField() = default;
 void ClientField::Clear() {
 	for(int i = 0; i < 2; ++i) {
 		deck[i].clear();
@@ -37,7 +36,6 @@ void ClientField::Clear() {
 		extra_act[i] = false;
 		pzone_act[i] = false;
 	}
-	cards_.clear();
 	overlay_cards.clear();
 	extra_p_count[0] = 0;
 	extra_p_count[1] = 0;
@@ -65,6 +63,7 @@ void ClientField::Clear() {
 	cant_check_grave = false;
 	tag_surrender = false;
 	tag_teammate_surrender = false;
+	cards_.clear();
 }
 void ClientField::Initial(int player, int deckc, int extrac, int sidec) {
 	auto load_location = [&](std::vector<ClientCard*>& container, int count, uint8_t location) {

--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -18,52 +18,7 @@ ClientField::ClientField() {
 	}
 }
 void ClientField::Clear() {
-	for(int i = 0; i < 2; ++i) {
-		deck[i].clear();
-		hand[i].clear();
-		for (auto& card : mzone[i]) {
-			card = nullptr;
-		}
-		for (auto& card : szone[i]) {
-			card = nullptr;
-		}
-		grave[i].clear();
-		remove[i].clear();
-		extra[i].clear();
-		deck_act[i] = false;
-		grave_act[i] = false;
-		remove_act[i] = false;
-		extra_act[i] = false;
-		pzone_act[i] = false;
-	}
-	overlay_cards.clear();
-	extra_p_count[0] = 0;
-	extra_p_count[1] = 0;
-	player_desc_hints[0].clear();
-	player_desc_hints[1].clear();
-	chains.clear();
-	activatable_cards.clear();
-	summonable_cards.clear();
-	spsummonable_cards.clear();
-	msetable_cards.clear();
-	ssetable_cards.clear();
-	reposable_cards.clear();
-	attackable_cards.clear();
-	disabled_field = 0;
-	panel = 0;
-	hovered_card = 0;
-	clicked_card = 0;
-	highlighting_card = 0;
-	menu_card = 0;
-	hovered_controler = 0;
-	hovered_location = 0;
-	hovered_sequence = 0;
-	conti_act = false;
-	deck_reversed = false;
-	cant_check_grave = false;
-	tag_surrender = false;
-	tag_teammate_surrender = false;
-	cards_.clear();
+	*this = ClientField();
 }
 void ClientField::Initial(int player, int deckc, int extrac, int sidec) {
 	auto load_location = [&](std::vector<ClientCard*>& container, int count, uint8_t location) {

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -100,7 +100,6 @@ public:
 	bool tag_teammate_surrender{ false };
 
 	ClientField();
-	~ClientField() override;
 	void Clear();
 	void Initial(int player, int deckc, int extrac, int sidec = 0);
 	ClientCard* CreateCard();

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <IEventReceiver.h>
 #include <vector3d.h>
+#include "client_card.h"
 
 namespace irr {
 	namespace gui {
@@ -16,8 +17,6 @@ namespace irr {
 }
 
 namespace ygo {
-
-class ClientCard;
 
 struct ChainInfo {
 	irr::core::vector3df chain_pos;


### PR DESCRIPTION
- The class does not need a user-defined destructor.
- Cleanning by move assignment is much easier. 