### PR TITLE
fix HINT_ZONE and fix MSG_HINT in puzzle mode

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1224,15 +1224,16 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 			break;
 		}
 		case HINT_ZONE: {
+			uint32_t zones = static_cast<uint32_t>(data);
 			if(mainGame->LocalPlayer(player) == 1)
-				data = (data >> 16) | (data << 16);
-			for(unsigned filter = 0x1; filter != 0; filter <<= 1) {
+				zones = (zones >> 16) | (zones << 16);
+			// Shared Extra Monster Zones use opposite sequences (5 <-> 6) on the two sides.
+			// Prefer the local player's side when both sides represent the same zone.
+			zones &= ~(((zones & 0x20) << 17) | ((zones & 0x40) << 15));
+			for(uint32_t filter = 0x1; filter != 0; filter <<= 1) {
 				std::wstring str;
-				if(unsigned s = filter & data) {
-					if(s & 0x60) {
-						str += dataManager.GetSysString(1081);
-						data &= ~0x600000;
-					} else if(s & 0xffff)
+				if(uint32_t s = filter & zones) {
+					if(s & 0xffff)
 						str += dataManager.GetSysString(102);
 					else if(s & 0xffff0000) {
 						str += dataManager.GetSysString(103);
@@ -1240,6 +1241,8 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 					}
 					if(s & 0x1f)
 						str += dataManager.GetSysString(1002);
+					else if(s & 0x60)
+						str += dataManager.GetSysString(1081);
 					else if(s & 0xff00) {
 						s >>= 8;
 						if(s & 0x1f)
@@ -1250,7 +1253,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 							str += dataManager.GetSysString(1009);
 					}
 					int seq = 1;
-					for(int i = 0x1; i < 0x100; i <<= 1) {
+					for(uint32_t i = 0x1; i < 0x100; i <<= 1) {
 						if(s & i)
 							break;
 						++seq;
@@ -1260,7 +1263,7 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, size_t len) {
 					mainGame->AddLog(textBuffer);
 				}
 			}
-			mainGame->dField.selectable_field = data;
+			mainGame->dField.selectable_field = zones;
 			mainGame->WaitFrameSignal(40);
 			mainGame->dField.selectable_field = 0;
 			break;

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -605,14 +605,14 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			case HINT_RACE:
 			case HINT_ATTRIB:
 			case HINT_CODE:
-			case HINT_NUMBER:
-			case HINT_ZONE: {
+			case HINT_NUMBER: {
 				NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, offset, pbuf - offset);
 				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 					NetServer::ReSendToPlayer(*oit);
 				break;
 			}
-			case HINT_CARD: {
+			case HINT_CARD:
+			case HINT_ZONE: {
 				NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 				NetServer::SendBufferToPlayer(players[1], STOC_GAME_MSG, offset, pbuf - offset);
 				for(auto oit = observers.begin(); oit != observers.end(); ++oit)

--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -594,25 +594,25 @@ int SingleDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			player = BufferIO::Read<uint8_t>(pbuf);
 			BufferIO::Read<int32_t>(pbuf);
 			switch (type) {
-			case 1:
-			case 2:
-			case 3:
-			case 5: {
+			case HINT_EVENT:
+			case HINT_MESSAGE:
+			case HINT_SELECTMSG:
+			case HINT_EFFECT: {
 				NetServer::SendBufferToPlayer(players[player], STOC_GAME_MSG, offset, pbuf - offset);
 				break;
 			}
-			case 4:
-			case 6:
-			case 7:
-			case 8:
-			case 9:
-			case 11: {
+			case HINT_OPSELECTED:
+			case HINT_RACE:
+			case HINT_ATTRIB:
+			case HINT_CODE:
+			case HINT_NUMBER:
+			case HINT_ZONE: {
 				NetServer::SendBufferToPlayer(players[1 - player], STOC_GAME_MSG, offset, pbuf - offset);
 				for(auto oit = observers.begin(); oit != observers.end(); ++oit)
 					NetServer::ReSendToPlayer(*oit);
 				break;
 			}
-			case 10: {
+			case HINT_CARD: {
 				NetServer::SendBufferToPlayer(players[0], STOC_GAME_MSG, offset, pbuf - offset);
 				NetServer::SendBufferToPlayer(players[1], STOC_GAME_MSG, offset, pbuf - offset);
 				for(auto oit = observers.begin(); oit != observers.end(); ++oit)

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -203,11 +203,33 @@ bool SingleMode::SinglePlayAnalyze(unsigned char* msg, unsigned int len) {
 			break;
 		}
 		case MSG_HINT: {
-			/*int type = */BufferIO::Read<uint8_t>(pbuf);
+			int type = BufferIO::Read<uint8_t>(pbuf);
 			player = BufferIO::Read<uint8_t>(pbuf);
 			/*int data = */BufferIO::Read<int32_t>(pbuf);
-			if(player == 0)
+			switch (type) {
+			case HINT_EVENT:
+			case HINT_MESSAGE:
+			case HINT_SELECTMSG:
+			case HINT_EFFECT: {
+				if(player == 0)
+					DuelClient::ClientAnalyze(offset, pbuf - offset);
+				break;
+			}
+			case HINT_OPSELECTED:
+			case HINT_NUMBER:
+			case HINT_RACE:
+			case HINT_ATTRIB:
+			case HINT_CODE: {
+				if(player == 1)
+					DuelClient::ClientAnalyze(offset, pbuf - offset);
+				break;
+			}
+			case HINT_CARD:
+			case HINT_ZONE: {
 				DuelClient::ClientAnalyze(offset, pbuf - offset);
+				break;
+			}
+			}
 			break;
 		}
 		case MSG_WIN: {

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -551,19 +551,19 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			player = BufferIO::Read<uint8_t>(pbuf);
 			BufferIO::Read<int32_t>(pbuf);
 			switch (type) {
-			case 1:
-			case 2:
-			case 3:
-			case 5: {
+			case HINT_EVENT:
+			case HINT_MESSAGE:
+			case HINT_SELECTMSG:
+			case HINT_EFFECT: {
 				NetServer::SendBufferToPlayer(cur_player[player], STOC_GAME_MSG, offset, pbuf - offset);
 				break;
 			}
-			case 4:
-			case 6:
-			case 7:
-			case 8:
-			case 9:
-			case 11: {
+			case HINT_OPSELECTED:
+			case HINT_RACE:
+			case HINT_ATTRIB:
+			case HINT_CODE:
+			case HINT_NUMBER:
+			case HINT_ZONE: {
 				for(int i = 0; i < 4; ++i)
 					if(players[i] != cur_player[player])
 						NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
@@ -571,7 +571,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 					NetServer::ReSendToPlayer(*oit);
 				break;
 			}
-			case 10: {
+			case HINT_CARD: {
 				for(int i = 0; i < 4; ++i)
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
 				for(auto oit = observers.begin(); oit != observers.end(); ++oit)

--- a/gframe/tag_duel.cpp
+++ b/gframe/tag_duel.cpp
@@ -562,8 +562,7 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 			case HINT_RACE:
 			case HINT_ATTRIB:
 			case HINT_CODE:
-			case HINT_NUMBER:
-			case HINT_ZONE: {
+			case HINT_NUMBER: {
 				for(int i = 0; i < 4; ++i)
 					if(players[i] != cur_player[player])
 						NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
@@ -571,7 +570,8 @@ int TagDuel::Analyze(unsigned char* msgbuffer, unsigned int len) {
 					NetServer::ReSendToPlayer(*oit);
 				break;
 			}
-			case HINT_CARD: {
+			case HINT_CARD:
+			case HINT_ZONE: {
 				for(int i = 0; i < 4; ++i)
 					NetServer::SendBufferToPlayer(players[i], STOC_GAME_MSG, offset, pbuf - offset);
 				for(auto oit = observers.begin(); oit != observers.end(); ++oit)


### PR DESCRIPTION
- Replace numeric `MSG_HINT` types with named constants.
- Send `HINT_ZONE` to both players on the server, including the player who selected the zones, consistent with `MSG_BECOME_TARGET`.
- Fix client-side zone handling, including support for displaying the opponent's Extra Monster Zones.
- Apply the same hint routing rules in puzzle mode as on the server, displaying hints according to their type and intended recipient.
  - Known issue: The simple AI does not support declarations, so the player makes declarations on behalf of the puzzle opponent. This fix recover the hidden "The player selected..." hint after the declaration.