### PR TITLE
fix ClientField::Clear

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -52,6 +52,8 @@ void ClientField::Clear() {
 	reposable_cards.clear();
 	attackable_cards.clear();
 	disabled_field = 0;
+	selectable_field = 0;
+	selected_field = 0;
 	panel = 0;
 	hovered_card = 0;
 	clicked_card = 0;


### PR DESCRIPTION
Reproduce: Summon a monster in the puzzle mode, surrender when selecting place, enter the normal duel. The field selection will remain before the duel start.

<img width="583" height="319" alt="image" src="https://github.com/user-attachments/assets/954be47f-9b3c-4cd9-9c99-61a7b5f75388" />
 